### PR TITLE
Tablet-friendly app shell + local tenant subdomain fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -249,7 +249,10 @@
       "Bash(sed -n '/public function index/,/^    }/p' app/Http/Controllers/Purchases/PurchasesController.php)",
       "Bash(echo \"tests exit: $?\")",
       "Bash(echo \"exit: $?\")",
-      "Bash(echo \"exit=$?  \\(inspector should be absent; horizon line present\\)\")"
+      "Bash(echo \"exit=$?  \\(inspector should be absent; horizon line present\\)\")",
+      "Bash(php -d memory_limit=-1 vendor/bin/pest tests/Feature/ActiveTenantMiddlewareTest.php)",
+      "Bash(echo \"EXIT=$?\")",
+      "Bash(npx eslint *)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/skills/laravel-best-practices/SKILL.md
+++ b/.claude/skills/laravel-best-practices/SKILL.md
@@ -94,7 +94,7 @@ Check sibling files, related controllers, models, or tests for established patte
 ### 9. Queue & Job Patterns → `rules/queue-jobs.md`
 
 - `retry_after` must exceed job `timeout`; use exponential backoff `[1, 5, 10]`
-- `ShouldBeUnique` to prevent duplicates; `WithoutOverlapping::untilProcessing()` for concurrency
+- `ShouldBeUnique` to prevent duplicates; `ShouldBeUniqueUntilProcessing` for early lock release
 - Always implement `failed()`; with `retryUntil()`, set `$tries = 0`
 - `RateLimited` middleware for external API calls; `Bus::batch()` for related jobs
 - Horizon for complex multi-queue scenarios

--- a/.claude/skills/laravel-best-practices/rules/architecture.md
+++ b/.claude/skills/laravel-best-practices/rules/architecture.md
@@ -82,7 +82,7 @@ $this->app->bind(PaymentGateway::class, StripeGateway::class);
 
 ## Default Sort by Descending
 
-When no explicit order is specified, sort by `id` or `created_at` descending. Explicit ordering prevents cross-database inconsistencies between MySQL and Postgres.
+When no explicit order is specified, sort by `id` or `created_at` descending. Without an explicit `ORDER BY`, row order is undefined.
 
 Incorrect:
 ```php

--- a/.claude/skills/laravel-best-practices/rules/caching.md
+++ b/.claude/skills/laravel-best-practices/rules/caching.md
@@ -2,7 +2,7 @@
 
 ## Use `Cache::remember()` Instead of Manual Get/Put
 
-Atomic pattern prevents race conditions and removes boilerplate.
+Cleaner cache-aside pattern that removes boilerplate. use `Cache::lock()` for race conditions.
 
 Incorrect:
 ```php

--- a/.claude/skills/laravel-best-practices/rules/config.md
+++ b/.claude/skills/laravel-best-practices/rules/config.md
@@ -2,7 +2,7 @@
 
 ## `env()` Only in Config Files
 
-Direct `env()` calls return `null` when config is cached.
+Direct `env()` calls may return `null` when config is cached.
 
 Incorrect:
 ```php

--- a/.claude/skills/laravel-best-practices/rules/events-notifications.md
+++ b/.claude/skills/laravel-best-practices/rules/events-notifications.md
@@ -29,7 +29,11 @@ class InvoicePaid extends Notification implements ShouldQueue
 
 ## Use `afterCommit()` on Notifications in Transactions
 
-Same race condition as events — the queued notification job may run before the transaction commits.
+Same race condition as events — call `afterCommit()` to delay dispatch until the transaction commits.
+
+```php
+$user->notify((new InvoicePaid($invoice))->afterCommit());
+```
 
 ## Route Notification Channels to Dedicated Queues
 

--- a/.claude/skills/laravel-best-practices/rules/http-client.md
+++ b/.claude/skills/laravel-best-practices/rules/http-client.md
@@ -52,7 +52,7 @@ $response = Http::retry([100, 500, 1000])
 Only retry on specific errors:
 
 ```php
-$response = Http::retry(3, 100, function (Exception $exception, PendingRequest $request) {
+$response = Http::retry(3, 100, function (Throwable $exception, PendingRequest $request) {
     return $exception instanceof ConnectionException
         || ($exception instanceof RequestException && $exception->response->serverError());
 })->post('https://api.example.com/data');

--- a/.claude/skills/laravel-best-practices/rules/mail.md
+++ b/.claude/skills/laravel-best-practices/rules/mail.md
@@ -10,7 +10,7 @@ A queued mailable dispatched inside a transaction may process before the commit.
 
 ## Use `assertQueued()` Not `assertSent()` for Queued Mailables
 
-`Mail::assertSent()` only catches synchronous mail. Queued mailables silently pass `assertSent`, giving false confidence.
+`Mail::assertSent()` only catches synchronous mail. Queued mailables fail `assertSent` with a "Did you mean to use assertQueued()?" hint.
 
 Incorrect: `Mail::assertSent(OrderShipped::class);` when mailable implements `ShouldQueue`.
 

--- a/.claude/skills/laravel-best-practices/rules/queue-jobs.md
+++ b/.claude/skills/laravel-best-practices/rules/queue-jobs.md
@@ -112,18 +112,16 @@ public function retryUntil(): \DateTimeInterface
 }
 ```
 
-## Use `WithoutOverlapping::untilProcessing()`
+## Use `ShouldBeUniqueUntilProcessing` for Early Lock Release
 
-Prevents concurrent execution while allowing new instances to queue.
+`ShouldBeUnique` holds the lock until the job completes. `ShouldBeUniqueUntilProcessing` releases it when processing starts, allowing new instances to queue.
 
 ```php
-public function middleware(): array
+class UpdateSearchIndex implements ShouldQueue, ShouldBeUniqueUntilProcessing
 {
-    return [new WithoutOverlapping($this->product->id)->untilProcessing()];
+    // Lock releases when processing begins, not when it finishes
 }
 ```
-
-Without `untilProcessing()`, the lock extends through queue wait time. With it, the lock releases when processing starts.
 
 ## Use Horizon for Complex Queue Scenarios
 

--- a/.claude/skills/laravel-best-practices/rules/routing.md
+++ b/.claude/skills/laravel-best-practices/rules/routing.md
@@ -36,7 +36,8 @@ Use `Route::resource()` or `apiResource()` for RESTful endpoints.
 
 ```php
 Route::resource('posts', PostController::class);
-Route::apiResource('api/posts', Api\PostController::class);
+// In routes/api.php — the /api prefix is applied automatically
+Route::apiResource('posts', Api\PostController::class);
 ```
 
 ## Keep Controllers Thin

--- a/.claude/skills/laravel-best-practices/rules/security.md
+++ b/.claude/skills/laravel-best-practices/rules/security.md
@@ -32,7 +32,7 @@ Use policies or gates in controllers. Never skip authorization.
 
 Incorrect:
 ```php
-public function update(Request $request, Post $post)
+public function update(UpdatePostRequest $request, Post $post)
 {
     $post->update($request->validated());
 }
@@ -90,7 +90,7 @@ Correct:
 
 ## CSRF Protection
 
-Include `@csrf` in all POST/PUT/DELETE Blade forms. Not needed in Inertia.
+Include `@csrf` in all POST/PUT/DELETE Blade forms. In Inertia apps, the `@csrf` directive is automatically applied.
 
 Incorrect:
 ```blade
@@ -121,7 +121,7 @@ Route::post('/login', LoginController::class)->middleware('throttle:login');
 
 ## Validate File Uploads
 
-Validate MIME type, extension, and size. Never trust client-provided filenames.
+Validate extension, MIME type, and size. The `mimes` rule checks extensions; use `mimetypes` for actual MIME type validation. Never trust client-provided filenames.
 
 ```php
 public function rules(): array

--- a/.claude/skills/laravel-best-practices/rules/testing.md
+++ b/.claude/skills/laravel-best-practices/rules/testing.md
@@ -2,7 +2,7 @@
 
 ## Use `LazilyRefreshDatabase` Over `RefreshDatabase`
 
-`RefreshDatabase` runs all migrations every test run even when the schema hasn't changed. `LazilyRefreshDatabase` only migrates when needed, significantly speeding up large suites.
+`RefreshDatabase` migrates once per process and wraps each test in a rolled-back transaction. `LazilyRefreshDatabase` skips even that first migration if the schema is already up to date.
 
 ## Use Model Assertions Over Raw Database Assertions
 

--- a/.claude/skills/pest-testing/SKILL.md
+++ b/.claude/skills/pest-testing/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: pest-testing
-description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit) or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 3 features. Do not use for editing factories, seeders, migrations, controllers, models, or non-test PHP code."
+description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
 license: MIT
 metadata:
   author: laravel
 ---
 
-# Pest Testing 3
+# Pest Testing 4
 
 ## Documentation
 
-Use `search-docs` for detailed Pest 3 patterns and documentation.
+Use `search-docs` for detailed Pest 4 patterns and documentation.
 
 ## Basic Usage
 
@@ -18,11 +18,17 @@ Use `search-docs` for detailed Pest 3 patterns and documentation.
 
 All tests must be written using Pest. Use `php artisan make:test --pest {name}`.
 
+The `{name}` argument should include only the path and test name, but should not include the test suite.
+- Incorrect: `php artisan make:test --pest Feature/SomeFeatureTest` will generate `tests/Feature/Feature/SomeFeatureTest.php`
+- Correct: `php artisan make:test --pest SomeControllerTest` will generate `tests/Feature/SomeControllerTest.php`
+- Incorrect: `php artisan make:test --pest --unit Unit/SomeServiceTest` will generate `tests/Unit/Unit/SomeServiceTest.php`
+- Correct: `php artisan make:test --pest --unit SomeServiceTest` will generate `tests/Unit/SomeServiceTest.php`
+
 ### Test Organization
 
-- Tests live in the `tests/Feature` and `tests/Unit` directories.
+- Unit/Feature tests: `tests/Feature` and `tests/Unit` directories.
+- Browser tests: `tests/Browser/` directory.
 - Do NOT remove tests without approval - these are core application code.
-- Test happy paths, failure paths, and edge cases.
 
 ### Basic Test Structure
 
@@ -76,11 +82,71 @@ it('has emails', function (string $email) {
 ]);
 ```
 
-## Pest 3 Features
+## Pest 4 Features
+
+| Feature | Purpose |
+|---------|---------|
+| Browser Testing | Full integration tests in real browsers |
+| Smoke Testing | Validate multiple pages quickly |
+| Visual Regression | Compare screenshots for visual changes |
+| Test Sharding | Parallel CI runs |
+| Architecture Testing | Enforce code conventions |
+
+### Browser Test Example
+
+Browser tests run in real browsers for full integration testing:
+
+- Browser tests live in `tests/Browser/`.
+- Use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories.
+- Use `RefreshDatabase` for clean state per test.
+- Interact with page: click, type, scroll, select, submit, drag-and-drop, touch gestures.
+- Test on multiple browsers (Chrome, Firefox, Safari) if requested.
+- Test on different devices/viewports (iPhone 14 Pro, tablets) if requested.
+- Switch color schemes (light/dark mode) when appropriate.
+- Take screenshots or pause tests for debugging.
+
+<!-- Pest Browser Test Example -->
+```php
+it('may reset the password', function () {
+    Notification::fake();
+
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/sign-in');
+
+    $page->assertSee('Sign In')
+        ->assertNoJavaScriptErrors()
+        ->click('Forgot Password?')
+        ->fill('email', 'nuno@laravel.com')
+        ->click('Send Reset Link')
+        ->assertSee('We have emailed your password reset link!');
+
+    Notification::assertSent(ResetPassword::class);
+});
+```
+
+### Smoke Testing
+
+Quickly validate multiple pages have no JavaScript errors:
+
+<!-- Pest Smoke Testing Example -->
+```php
+$pages = visit(['/', '/about', '/contact']);
+
+$pages->assertNoJavaScriptErrors()->assertNoConsoleLogs();
+```
+
+### Visual Regression Testing
+
+Capture and compare screenshots to detect visual changes.
+
+### Test Sharding
+
+Split tests across parallel processes for faster CI runs.
 
 ### Architecture Testing
 
-Pest 3 includes architecture testing to enforce code conventions:
+Pest 4 includes architecture testing (from Pest 3):
 
 <!-- Architecture Test Example -->
 ```php
@@ -88,19 +154,7 @@ arch('controllers')
     ->expect('App\Http\Controllers')
     ->toExtendNothing()
     ->toHaveSuffix('Controller');
-
-arch('models')
-    ->expect('App\Models')
-    ->toExtend('Illuminate\Database\Eloquent\Model');
-
-arch('no debugging')
-    ->expect(['dd', 'dump', 'ray'])
-    ->not->toBeUsed();
 ```
-
-### Type Coverage
-
-Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag.
 
 ## Common Pitfalls
 
@@ -108,3 +162,5 @@ Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag
 - Using `assertStatus(200)` instead of `assertSuccessful()`
 - Forgetting datasets for repetitive validation tests
 - Deleting tests without approval
+- Forgetting `assertNoJavaScriptErrors()` in browser tests
+- Prefixing `Feature/` or `Unit/` in `{name}` when using `make:test`

--- a/.github/skills/laravel-best-practices/SKILL.md
+++ b/.github/skills/laravel-best-practices/SKILL.md
@@ -94,7 +94,7 @@ Check sibling files, related controllers, models, or tests for established patte
 ### 9. Queue & Job Patterns → `rules/queue-jobs.md`
 
 - `retry_after` must exceed job `timeout`; use exponential backoff `[1, 5, 10]`
-- `ShouldBeUnique` to prevent duplicates; `WithoutOverlapping::untilProcessing()` for concurrency
+- `ShouldBeUnique` to prevent duplicates; `ShouldBeUniqueUntilProcessing` for early lock release
 - Always implement `failed()`; with `retryUntil()`, set `$tries = 0`
 - `RateLimited` middleware for external API calls; `Bus::batch()` for related jobs
 - Horizon for complex multi-queue scenarios

--- a/.github/skills/laravel-best-practices/rules/architecture.md
+++ b/.github/skills/laravel-best-practices/rules/architecture.md
@@ -82,7 +82,7 @@ $this->app->bind(PaymentGateway::class, StripeGateway::class);
 
 ## Default Sort by Descending
 
-When no explicit order is specified, sort by `id` or `created_at` descending. Explicit ordering prevents cross-database inconsistencies between MySQL and Postgres.
+When no explicit order is specified, sort by `id` or `created_at` descending. Without an explicit `ORDER BY`, row order is undefined.
 
 Incorrect:
 ```php

--- a/.github/skills/laravel-best-practices/rules/caching.md
+++ b/.github/skills/laravel-best-practices/rules/caching.md
@@ -2,7 +2,7 @@
 
 ## Use `Cache::remember()` Instead of Manual Get/Put
 
-Atomic pattern prevents race conditions and removes boilerplate.
+Cleaner cache-aside pattern that removes boilerplate. use `Cache::lock()` for race conditions.
 
 Incorrect:
 ```php

--- a/.github/skills/laravel-best-practices/rules/config.md
+++ b/.github/skills/laravel-best-practices/rules/config.md
@@ -2,7 +2,7 @@
 
 ## `env()` Only in Config Files
 
-Direct `env()` calls return `null` when config is cached.
+Direct `env()` calls may return `null` when config is cached.
 
 Incorrect:
 ```php

--- a/.github/skills/laravel-best-practices/rules/events-notifications.md
+++ b/.github/skills/laravel-best-practices/rules/events-notifications.md
@@ -29,7 +29,11 @@ class InvoicePaid extends Notification implements ShouldQueue
 
 ## Use `afterCommit()` on Notifications in Transactions
 
-Same race condition as events — the queued notification job may run before the transaction commits.
+Same race condition as events — call `afterCommit()` to delay dispatch until the transaction commits.
+
+```php
+$user->notify((new InvoicePaid($invoice))->afterCommit());
+```
 
 ## Route Notification Channels to Dedicated Queues
 

--- a/.github/skills/laravel-best-practices/rules/http-client.md
+++ b/.github/skills/laravel-best-practices/rules/http-client.md
@@ -52,7 +52,7 @@ $response = Http::retry([100, 500, 1000])
 Only retry on specific errors:
 
 ```php
-$response = Http::retry(3, 100, function (Exception $exception, PendingRequest $request) {
+$response = Http::retry(3, 100, function (Throwable $exception, PendingRequest $request) {
     return $exception instanceof ConnectionException
         || ($exception instanceof RequestException && $exception->response->serverError());
 })->post('https://api.example.com/data');

--- a/.github/skills/laravel-best-practices/rules/mail.md
+++ b/.github/skills/laravel-best-practices/rules/mail.md
@@ -10,7 +10,7 @@ A queued mailable dispatched inside a transaction may process before the commit.
 
 ## Use `assertQueued()` Not `assertSent()` for Queued Mailables
 
-`Mail::assertSent()` only catches synchronous mail. Queued mailables silently pass `assertSent`, giving false confidence.
+`Mail::assertSent()` only catches synchronous mail. Queued mailables fail `assertSent` with a "Did you mean to use assertQueued()?" hint.
 
 Incorrect: `Mail::assertSent(OrderShipped::class);` when mailable implements `ShouldQueue`.
 

--- a/.github/skills/laravel-best-practices/rules/queue-jobs.md
+++ b/.github/skills/laravel-best-practices/rules/queue-jobs.md
@@ -112,18 +112,16 @@ public function retryUntil(): \DateTimeInterface
 }
 ```
 
-## Use `WithoutOverlapping::untilProcessing()`
+## Use `ShouldBeUniqueUntilProcessing` for Early Lock Release
 
-Prevents concurrent execution while allowing new instances to queue.
+`ShouldBeUnique` holds the lock until the job completes. `ShouldBeUniqueUntilProcessing` releases it when processing starts, allowing new instances to queue.
 
 ```php
-public function middleware(): array
+class UpdateSearchIndex implements ShouldQueue, ShouldBeUniqueUntilProcessing
 {
-    return [new WithoutOverlapping($this->product->id)->untilProcessing()];
+    // Lock releases when processing begins, not when it finishes
 }
 ```
-
-Without `untilProcessing()`, the lock extends through queue wait time. With it, the lock releases when processing starts.
 
 ## Use Horizon for Complex Queue Scenarios
 

--- a/.github/skills/laravel-best-practices/rules/routing.md
+++ b/.github/skills/laravel-best-practices/rules/routing.md
@@ -36,7 +36,8 @@ Use `Route::resource()` or `apiResource()` for RESTful endpoints.
 
 ```php
 Route::resource('posts', PostController::class);
-Route::apiResource('api/posts', Api\PostController::class);
+// In routes/api.php — the /api prefix is applied automatically
+Route::apiResource('posts', Api\PostController::class);
 ```
 
 ## Keep Controllers Thin

--- a/.github/skills/laravel-best-practices/rules/security.md
+++ b/.github/skills/laravel-best-practices/rules/security.md
@@ -32,7 +32,7 @@ Use policies or gates in controllers. Never skip authorization.
 
 Incorrect:
 ```php
-public function update(Request $request, Post $post)
+public function update(UpdatePostRequest $request, Post $post)
 {
     $post->update($request->validated());
 }
@@ -90,7 +90,7 @@ Correct:
 
 ## CSRF Protection
 
-Include `@csrf` in all POST/PUT/DELETE Blade forms. Not needed in Inertia.
+Include `@csrf` in all POST/PUT/DELETE Blade forms. In Inertia apps, the `@csrf` directive is automatically applied.
 
 Incorrect:
 ```blade
@@ -121,7 +121,7 @@ Route::post('/login', LoginController::class)->middleware('throttle:login');
 
 ## Validate File Uploads
 
-Validate MIME type, extension, and size. Never trust client-provided filenames.
+Validate extension, MIME type, and size. The `mimes` rule checks extensions; use `mimetypes` for actual MIME type validation. Never trust client-provided filenames.
 
 ```php
 public function rules(): array

--- a/.github/skills/laravel-best-practices/rules/testing.md
+++ b/.github/skills/laravel-best-practices/rules/testing.md
@@ -2,7 +2,7 @@
 
 ## Use `LazilyRefreshDatabase` Over `RefreshDatabase`
 
-`RefreshDatabase` runs all migrations every test run even when the schema hasn't changed. `LazilyRefreshDatabase` only migrates when needed, significantly speeding up large suites.
+`RefreshDatabase` migrates once per process and wraps each test in a rolled-back transaction. `LazilyRefreshDatabase` skips even that first migration if the schema is already up to date.
 
 ## Use Model Assertions Over Raw Database Assertions
 

--- a/.github/skills/pest-testing/SKILL.md
+++ b/.github/skills/pest-testing/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: pest-testing
-description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit) or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 3 features. Do not use for editing factories, seeders, migrations, controllers, models, or non-test PHP code."
+description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
 license: MIT
 metadata:
   author: laravel
 ---
 
-# Pest Testing 3
+# Pest Testing 4
 
 ## Documentation
 
-Use `search-docs` for detailed Pest 3 patterns and documentation.
+Use `search-docs` for detailed Pest 4 patterns and documentation.
 
 ## Basic Usage
 
@@ -18,11 +18,17 @@ Use `search-docs` for detailed Pest 3 patterns and documentation.
 
 All tests must be written using Pest. Use `php artisan make:test --pest {name}`.
 
+The `{name}` argument should include only the path and test name, but should not include the test suite.
+- Incorrect: `php artisan make:test --pest Feature/SomeFeatureTest` will generate `tests/Feature/Feature/SomeFeatureTest.php`
+- Correct: `php artisan make:test --pest SomeControllerTest` will generate `tests/Feature/SomeControllerTest.php`
+- Incorrect: `php artisan make:test --pest --unit Unit/SomeServiceTest` will generate `tests/Unit/Unit/SomeServiceTest.php`
+- Correct: `php artisan make:test --pest --unit SomeServiceTest` will generate `tests/Unit/SomeServiceTest.php`
+
 ### Test Organization
 
-- Tests live in the `tests/Feature` and `tests/Unit` directories.
+- Unit/Feature tests: `tests/Feature` and `tests/Unit` directories.
+- Browser tests: `tests/Browser/` directory.
 - Do NOT remove tests without approval - these are core application code.
-- Test happy paths, failure paths, and edge cases.
 
 ### Basic Test Structure
 
@@ -76,11 +82,71 @@ it('has emails', function (string $email) {
 ]);
 ```
 
-## Pest 3 Features
+## Pest 4 Features
+
+| Feature | Purpose |
+|---------|---------|
+| Browser Testing | Full integration tests in real browsers |
+| Smoke Testing | Validate multiple pages quickly |
+| Visual Regression | Compare screenshots for visual changes |
+| Test Sharding | Parallel CI runs |
+| Architecture Testing | Enforce code conventions |
+
+### Browser Test Example
+
+Browser tests run in real browsers for full integration testing:
+
+- Browser tests live in `tests/Browser/`.
+- Use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories.
+- Use `RefreshDatabase` for clean state per test.
+- Interact with page: click, type, scroll, select, submit, drag-and-drop, touch gestures.
+- Test on multiple browsers (Chrome, Firefox, Safari) if requested.
+- Test on different devices/viewports (iPhone 14 Pro, tablets) if requested.
+- Switch color schemes (light/dark mode) when appropriate.
+- Take screenshots or pause tests for debugging.
+
+<!-- Pest Browser Test Example -->
+```php
+it('may reset the password', function () {
+    Notification::fake();
+
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/sign-in');
+
+    $page->assertSee('Sign In')
+        ->assertNoJavaScriptErrors()
+        ->click('Forgot Password?')
+        ->fill('email', 'nuno@laravel.com')
+        ->click('Send Reset Link')
+        ->assertSee('We have emailed your password reset link!');
+
+    Notification::assertSent(ResetPassword::class);
+});
+```
+
+### Smoke Testing
+
+Quickly validate multiple pages have no JavaScript errors:
+
+<!-- Pest Smoke Testing Example -->
+```php
+$pages = visit(['/', '/about', '/contact']);
+
+$pages->assertNoJavaScriptErrors()->assertNoConsoleLogs();
+```
+
+### Visual Regression Testing
+
+Capture and compare screenshots to detect visual changes.
+
+### Test Sharding
+
+Split tests across parallel processes for faster CI runs.
 
 ### Architecture Testing
 
-Pest 3 includes architecture testing to enforce code conventions:
+Pest 4 includes architecture testing (from Pest 3):
 
 <!-- Architecture Test Example -->
 ```php
@@ -88,19 +154,7 @@ arch('controllers')
     ->expect('App\Http\Controllers')
     ->toExtendNothing()
     ->toHaveSuffix('Controller');
-
-arch('models')
-    ->expect('App\Models')
-    ->toExtend('Illuminate\Database\Eloquent\Model');
-
-arch('no debugging')
-    ->expect(['dd', 'dump', 'ray'])
-    ->not->toBeUsed();
 ```
-
-### Type Coverage
-
-Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag.
 
 ## Common Pitfalls
 
@@ -108,3 +162,5 @@ Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag
 - Using `assertStatus(200)` instead of `assertSuccessful()`
 - Forgetting datasets for repetitive validation tests
 - Deleting tests without approval
+- Forgetting `assertNoJavaScriptErrors()` in browser tests
+- Prefixing `Feature/` or `Unit/` in `{name}` when using `make:test`

--- a/.junie/skills/laravel-best-practices/SKILL.md
+++ b/.junie/skills/laravel-best-practices/SKILL.md
@@ -94,7 +94,7 @@ Check sibling files, related controllers, models, or tests for established patte
 ### 9. Queue & Job Patterns → `rules/queue-jobs.md`
 
 - `retry_after` must exceed job `timeout`; use exponential backoff `[1, 5, 10]`
-- `ShouldBeUnique` to prevent duplicates; `WithoutOverlapping::untilProcessing()` for concurrency
+- `ShouldBeUnique` to prevent duplicates; `ShouldBeUniqueUntilProcessing` for early lock release
 - Always implement `failed()`; with `retryUntil()`, set `$tries = 0`
 - `RateLimited` middleware for external API calls; `Bus::batch()` for related jobs
 - Horizon for complex multi-queue scenarios

--- a/.junie/skills/laravel-best-practices/rules/architecture.md
+++ b/.junie/skills/laravel-best-practices/rules/architecture.md
@@ -82,7 +82,7 @@ $this->app->bind(PaymentGateway::class, StripeGateway::class);
 
 ## Default Sort by Descending
 
-When no explicit order is specified, sort by `id` or `created_at` descending. Explicit ordering prevents cross-database inconsistencies between MySQL and Postgres.
+When no explicit order is specified, sort by `id` or `created_at` descending. Without an explicit `ORDER BY`, row order is undefined.
 
 Incorrect:
 ```php

--- a/.junie/skills/laravel-best-practices/rules/caching.md
+++ b/.junie/skills/laravel-best-practices/rules/caching.md
@@ -2,7 +2,7 @@
 
 ## Use `Cache::remember()` Instead of Manual Get/Put
 
-Atomic pattern prevents race conditions and removes boilerplate.
+Cleaner cache-aside pattern that removes boilerplate. use `Cache::lock()` for race conditions.
 
 Incorrect:
 ```php

--- a/.junie/skills/laravel-best-practices/rules/config.md
+++ b/.junie/skills/laravel-best-practices/rules/config.md
@@ -2,7 +2,7 @@
 
 ## `env()` Only in Config Files
 
-Direct `env()` calls return `null` when config is cached.
+Direct `env()` calls may return `null` when config is cached.
 
 Incorrect:
 ```php

--- a/.junie/skills/laravel-best-practices/rules/events-notifications.md
+++ b/.junie/skills/laravel-best-practices/rules/events-notifications.md
@@ -29,7 +29,11 @@ class InvoicePaid extends Notification implements ShouldQueue
 
 ## Use `afterCommit()` on Notifications in Transactions
 
-Same race condition as events — the queued notification job may run before the transaction commits.
+Same race condition as events — call `afterCommit()` to delay dispatch until the transaction commits.
+
+```php
+$user->notify((new InvoicePaid($invoice))->afterCommit());
+```
 
 ## Route Notification Channels to Dedicated Queues
 

--- a/.junie/skills/laravel-best-practices/rules/http-client.md
+++ b/.junie/skills/laravel-best-practices/rules/http-client.md
@@ -52,7 +52,7 @@ $response = Http::retry([100, 500, 1000])
 Only retry on specific errors:
 
 ```php
-$response = Http::retry(3, 100, function (Exception $exception, PendingRequest $request) {
+$response = Http::retry(3, 100, function (Throwable $exception, PendingRequest $request) {
     return $exception instanceof ConnectionException
         || ($exception instanceof RequestException && $exception->response->serverError());
 })->post('https://api.example.com/data');

--- a/.junie/skills/laravel-best-practices/rules/mail.md
+++ b/.junie/skills/laravel-best-practices/rules/mail.md
@@ -10,7 +10,7 @@ A queued mailable dispatched inside a transaction may process before the commit.
 
 ## Use `assertQueued()` Not `assertSent()` for Queued Mailables
 
-`Mail::assertSent()` only catches synchronous mail. Queued mailables silently pass `assertSent`, giving false confidence.
+`Mail::assertSent()` only catches synchronous mail. Queued mailables fail `assertSent` with a "Did you mean to use assertQueued()?" hint.
 
 Incorrect: `Mail::assertSent(OrderShipped::class);` when mailable implements `ShouldQueue`.
 

--- a/.junie/skills/laravel-best-practices/rules/queue-jobs.md
+++ b/.junie/skills/laravel-best-practices/rules/queue-jobs.md
@@ -112,18 +112,16 @@ public function retryUntil(): \DateTimeInterface
 }
 ```
 
-## Use `WithoutOverlapping::untilProcessing()`
+## Use `ShouldBeUniqueUntilProcessing` for Early Lock Release
 
-Prevents concurrent execution while allowing new instances to queue.
+`ShouldBeUnique` holds the lock until the job completes. `ShouldBeUniqueUntilProcessing` releases it when processing starts, allowing new instances to queue.
 
 ```php
-public function middleware(): array
+class UpdateSearchIndex implements ShouldQueue, ShouldBeUniqueUntilProcessing
 {
-    return [new WithoutOverlapping($this->product->id)->untilProcessing()];
+    // Lock releases when processing begins, not when it finishes
 }
 ```
-
-Without `untilProcessing()`, the lock extends through queue wait time. With it, the lock releases when processing starts.
 
 ## Use Horizon for Complex Queue Scenarios
 

--- a/.junie/skills/laravel-best-practices/rules/routing.md
+++ b/.junie/skills/laravel-best-practices/rules/routing.md
@@ -36,7 +36,8 @@ Use `Route::resource()` or `apiResource()` for RESTful endpoints.
 
 ```php
 Route::resource('posts', PostController::class);
-Route::apiResource('api/posts', Api\PostController::class);
+// In routes/api.php — the /api prefix is applied automatically
+Route::apiResource('posts', Api\PostController::class);
 ```
 
 ## Keep Controllers Thin

--- a/.junie/skills/laravel-best-practices/rules/security.md
+++ b/.junie/skills/laravel-best-practices/rules/security.md
@@ -32,7 +32,7 @@ Use policies or gates in controllers. Never skip authorization.
 
 Incorrect:
 ```php
-public function update(Request $request, Post $post)
+public function update(UpdatePostRequest $request, Post $post)
 {
     $post->update($request->validated());
 }
@@ -90,7 +90,7 @@ Correct:
 
 ## CSRF Protection
 
-Include `@csrf` in all POST/PUT/DELETE Blade forms. Not needed in Inertia.
+Include `@csrf` in all POST/PUT/DELETE Blade forms. In Inertia apps, the `@csrf` directive is automatically applied.
 
 Incorrect:
 ```blade
@@ -121,7 +121,7 @@ Route::post('/login', LoginController::class)->middleware('throttle:login');
 
 ## Validate File Uploads
 
-Validate MIME type, extension, and size. Never trust client-provided filenames.
+Validate extension, MIME type, and size. The `mimes` rule checks extensions; use `mimetypes` for actual MIME type validation. Never trust client-provided filenames.
 
 ```php
 public function rules(): array

--- a/.junie/skills/laravel-best-practices/rules/testing.md
+++ b/.junie/skills/laravel-best-practices/rules/testing.md
@@ -2,7 +2,7 @@
 
 ## Use `LazilyRefreshDatabase` Over `RefreshDatabase`
 
-`RefreshDatabase` runs all migrations every test run even when the schema hasn't changed. `LazilyRefreshDatabase` only migrates when needed, significantly speeding up large suites.
+`RefreshDatabase` migrates once per process and wraps each test in a rolled-back transaction. `LazilyRefreshDatabase` skips even that first migration if the schema is already up to date.
 
 ## Use Model Assertions Over Raw Database Assertions
 

--- a/.junie/skills/pest-testing/SKILL.md
+++ b/.junie/skills/pest-testing/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: pest-testing
-description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit) or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 3 features. Do not use for editing factories, seeders, migrations, controllers, models, or non-test PHP code."
+description: "Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit, tests/Browser), or needs browser testing, smoke testing multiple pages for JS errors, or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing (visit/click/fill), smoke testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 4 features. Do not use for factories, seeders, migrations, controllers, models, or non-test PHP code."
 license: MIT
 metadata:
   author: laravel
 ---
 
-# Pest Testing 3
+# Pest Testing 4
 
 ## Documentation
 
-Use `search-docs` for detailed Pest 3 patterns and documentation.
+Use `search-docs` for detailed Pest 4 patterns and documentation.
 
 ## Basic Usage
 
@@ -18,11 +18,17 @@ Use `search-docs` for detailed Pest 3 patterns and documentation.
 
 All tests must be written using Pest. Use `php artisan make:test --pest {name}`.
 
+The `{name}` argument should include only the path and test name, but should not include the test suite.
+- Incorrect: `php artisan make:test --pest Feature/SomeFeatureTest` will generate `tests/Feature/Feature/SomeFeatureTest.php`
+- Correct: `php artisan make:test --pest SomeControllerTest` will generate `tests/Feature/SomeControllerTest.php`
+- Incorrect: `php artisan make:test --pest --unit Unit/SomeServiceTest` will generate `tests/Unit/Unit/SomeServiceTest.php`
+- Correct: `php artisan make:test --pest --unit SomeServiceTest` will generate `tests/Unit/SomeServiceTest.php`
+
 ### Test Organization
 
-- Tests live in the `tests/Feature` and `tests/Unit` directories.
+- Unit/Feature tests: `tests/Feature` and `tests/Unit` directories.
+- Browser tests: `tests/Browser/` directory.
 - Do NOT remove tests without approval - these are core application code.
-- Test happy paths, failure paths, and edge cases.
 
 ### Basic Test Structure
 
@@ -76,11 +82,71 @@ it('has emails', function (string $email) {
 ]);
 ```
 
-## Pest 3 Features
+## Pest 4 Features
+
+| Feature | Purpose |
+|---------|---------|
+| Browser Testing | Full integration tests in real browsers |
+| Smoke Testing | Validate multiple pages quickly |
+| Visual Regression | Compare screenshots for visual changes |
+| Test Sharding | Parallel CI runs |
+| Architecture Testing | Enforce code conventions |
+
+### Browser Test Example
+
+Browser tests run in real browsers for full integration testing:
+
+- Browser tests live in `tests/Browser/`.
+- Use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories.
+- Use `RefreshDatabase` for clean state per test.
+- Interact with page: click, type, scroll, select, submit, drag-and-drop, touch gestures.
+- Test on multiple browsers (Chrome, Firefox, Safari) if requested.
+- Test on different devices/viewports (iPhone 14 Pro, tablets) if requested.
+- Switch color schemes (light/dark mode) when appropriate.
+- Take screenshots or pause tests for debugging.
+
+<!-- Pest Browser Test Example -->
+```php
+it('may reset the password', function () {
+    Notification::fake();
+
+    $this->actingAs(User::factory()->create());
+
+    $page = visit('/sign-in');
+
+    $page->assertSee('Sign In')
+        ->assertNoJavaScriptErrors()
+        ->click('Forgot Password?')
+        ->fill('email', 'nuno@laravel.com')
+        ->click('Send Reset Link')
+        ->assertSee('We have emailed your password reset link!');
+
+    Notification::assertSent(ResetPassword::class);
+});
+```
+
+### Smoke Testing
+
+Quickly validate multiple pages have no JavaScript errors:
+
+<!-- Pest Smoke Testing Example -->
+```php
+$pages = visit(['/', '/about', '/contact']);
+
+$pages->assertNoJavaScriptErrors()->assertNoConsoleLogs();
+```
+
+### Visual Regression Testing
+
+Capture and compare screenshots to detect visual changes.
+
+### Test Sharding
+
+Split tests across parallel processes for faster CI runs.
 
 ### Architecture Testing
 
-Pest 3 includes architecture testing to enforce code conventions:
+Pest 4 includes architecture testing (from Pest 3):
 
 <!-- Architecture Test Example -->
 ```php
@@ -88,19 +154,7 @@ arch('controllers')
     ->expect('App\Http\Controllers')
     ->toExtendNothing()
     ->toHaveSuffix('Controller');
-
-arch('models')
-    ->expect('App\Models')
-    ->toExtend('Illuminate\Database\Eloquent\Model');
-
-arch('no debugging')
-    ->expect(['dd', 'dump', 'ray'])
-    ->not->toBeUsed();
 ```
-
-### Type Coverage
-
-Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag.
 
 ## Common Pitfalls
 
@@ -108,3 +162,5 @@ Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag
 - Using `assertStatus(200)` instead of `assertSuccessful()`
 - Forgetting datasets for repetitive validation tests
 - Deleting tests without approval
+- Forgetting `assertNoJavaScriptErrors()` in browser tests
+- Prefixing `Feature/` or `Unit/` in `{name}` when using `make:test`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -924,7 +924,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - inertiajs/inertia-laravel (INERTIA_LARAVEL) - v2
 - laravel/boost (BOOST) - v2
 - laravel/fortify (FORTIFY) - v1
-- laravel/framework (LARAVEL) - v12
+- laravel/framework (LARAVEL) - v13
 - laravel/horizon (HORIZON) - v5
 - laravel/mcp (MCP) - v0
 - laravel/prompts (PROMPTS) - v0
@@ -936,8 +936,8 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/dusk (DUSK) - v8
 - laravel/pint (PINT) - v1
 - laravel/sail (SAIL) - v1
-- pestphp/pest (PEST) - v3
-- phpunit/phpunit (PHPUNIT) - v11
+- pestphp/pest (PEST) - v4
+- phpunit/phpunit (PHPUNIT) - v12
 - @inertiajs/vue3 (INERTIA_VUE) - v1
 - laravel-echo (ECHO) - v2
 - eslint (ESLINT) - v8
@@ -946,15 +946,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 ## Skills Activation
 
-This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
-
-- `fortify-development` — ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.
-- `laravel-best-practices` — Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying controllers, models, migrations, form requests, policies, jobs, scheduled commands, service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, validation, error handling, queue and job configuration, route definitions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns.
-- `configuring-horizon` — Use this skill whenever the user mentions Horizon by name in a Laravel context. Covers the full Horizon lifecycle: installing Horizon (horizon:install, Sail setup), configuring config/horizon.php (supervisor blocks, queue assignments, balancing strategies, minProcesses/maxProcesses), fixing the dashboard (authorization via Gate::define viewHorizon, blank metrics, horizon:snapshot scheduling), and troubleshooting production issues (worker crashes, timeout chain ordering, LongWaitDetected notifications, waits config). Also covers job tagging and silencing. Do not use for generic Laravel queues without Horizon, SQS or database drivers, standalone Redis setup, Linux supervisord, Telescope, or job batching.
-- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit) or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 3 features. Do not use for editing factories, seeders, migrations, controllers, models, or non-test PHP code.
-- `inertia-vue-development` — Develops Inertia.js v1 Vue client-side applications. Activates when creating Vue pages, forms, or navigation; using Link or router; or when user mentions Vue with Inertia, Vue pages, Vue forms, or Vue navigation.
-- `echo-development` — Develops real-time broadcasting with Laravel Echo. Activates when setting up broadcasting (Reverb, Pusher, Ably); creating ShouldBroadcast events; defining broadcast channels (public, private, presence, encrypted); authorizing channels; configuring Echo; listening for events; implementing client events (whisper); setting up model broadcasting; broadcasting notifications; or when the user mentions broadcasting, Echo, WebSockets, real-time events, Reverb, or presence channels.
-- `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
+This project has domain-specific skills available in `**/skills/**`. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
 ## Conventions
 
@@ -1033,6 +1025,12 @@ This project has domain-specific skills available. You MUST activate the relevan
 - Prefer PHPDoc blocks over inline comments. Only add inline comments for exceptionally complex logic.
 - Use array shape type definitions in PHPDoc blocks.
 
+=== deployments rules ===
+
+# Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
+
 === herd rules ===
 
 # Laravel Herd
@@ -1092,35 +1090,6 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
 
-## Deployment
-
-- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
-
-=== laravel/v12 rules ===
-
-# Laravel 12
-
-- CRITICAL: ALWAYS use `search-docs` tool for version-specific Laravel documentation and updated code examples.
-- Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
-
-## Laravel 12 Structure
-
-- In Laravel 12, middleware are no longer registered in `app\Http/Kernel.php`.
-- Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
-- `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
-- `bootstrap/providers.php` contains application specific service providers.
-- The `app\Console/Kernel.php` file no longer exists; use `bootstrap/app.php` or `routes/console.php` for console configuration.
-- Console commands in `app\Console/Commands/` are automatically available and do not require manual registration.
-
-## Database
-
-- When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
-- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
-
-### Models
-
-- Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
-
 === pint/core rules ===
 
 # Laravel Pint Code Formatter
@@ -1133,6 +1102,7 @@ This project has domain-specific skills available. You MUST activate the relevan
 ## Pest
 
 - This project uses Pest for testing. Create tests: `php artisan make:test --pest {name}`.
+- The `{name}` argument should not include the test suite directory. Use `php artisan make:test --pest SomeFeatureTest` instead of `php artisan make:test --pest Feature/SomeFeatureTest`.
 - Run tests: `php artisan test --compact` or filter: `php artisan test --compact --filter=testName`.
 - Do NOT delete tests without approval.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -924,7 +924,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - inertiajs/inertia-laravel (INERTIA_LARAVEL) - v2
 - laravel/boost (BOOST) - v2
 - laravel/fortify (FORTIFY) - v1
-- laravel/framework (LARAVEL) - v12
+- laravel/framework (LARAVEL) - v13
 - laravel/horizon (HORIZON) - v5
 - laravel/mcp (MCP) - v0
 - laravel/prompts (PROMPTS) - v0
@@ -936,8 +936,8 @@ This application is a Laravel application and its main Laravel ecosystems packag
 - laravel/dusk (DUSK) - v8
 - laravel/pint (PINT) - v1
 - laravel/sail (SAIL) - v1
-- pestphp/pest (PEST) - v3
-- phpunit/phpunit (PHPUNIT) - v11
+- pestphp/pest (PEST) - v4
+- phpunit/phpunit (PHPUNIT) - v12
 - @inertiajs/vue3 (INERTIA_VUE) - v1
 - laravel-echo (ECHO) - v2
 - eslint (ESLINT) - v8
@@ -946,15 +946,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 ## Skills Activation
 
-This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
-
-- `fortify-development` — ACTIVATE when the user works on authentication in Laravel. This includes login, registration, password reset, email verification, two-factor authentication (2FA/TOTP/QR codes/recovery codes), profile updates, password confirmation, or any auth-related routes and controllers. Activate when the user mentions Fortify, auth, authentication, login, register, signup, forgot password, verify email, 2FA, or references app/Actions/Fortify/, CreateNewUser, UpdateUserProfileInformation, FortifyServiceProvider, config/fortify.php, or auth guards. Fortify is the frontend-agnostic authentication backend for Laravel that registers all auth routes and controllers. Also activate when building SPA or headless authentication, customizing login redirects, overriding response contracts like LoginResponse, or configuring login throttling. Do NOT activate for Laravel Passport (OAuth2 API tokens), Socialite (OAuth social login), or non-auth Laravel features.
-- `laravel-best-practices` — Apply this skill whenever writing, reviewing, or refactoring Laravel PHP code. This includes creating or modifying controllers, models, migrations, form requests, policies, jobs, scheduled commands, service classes, and Eloquent queries. Triggers for N+1 and query performance issues, caching strategies, authorization and security patterns, validation, error handling, queue and job configuration, route definitions, and architectural decisions. Also use for Laravel code reviews and refactoring existing Laravel code to follow best practices. Covers any task involving Laravel backend PHP code patterns.
-- `configuring-horizon` — Use this skill whenever the user mentions Horizon by name in a Laravel context. Covers the full Horizon lifecycle: installing Horizon (horizon:install, Sail setup), configuring config/horizon.php (supervisor blocks, queue assignments, balancing strategies, minProcesses/maxProcesses), fixing the dashboard (authorization via Gate::define viewHorizon, blank metrics, horizon:snapshot scheduling), and troubleshooting production issues (worker crashes, timeout chain ordering, LongWaitDetected notifications, waits config). Also covers job tagging and silencing. Do not use for generic Laravel queues without Horizon, SQS or database drivers, standalone Redis setup, Linux supervisord, Telescope, or job batching.
-- `pest-testing` — Use this skill for Pest PHP testing in Laravel projects only. Trigger whenever any test is being written, edited, fixed, or refactored — including fixing tests that broke after a code change, adding assertions, converting PHPUnit to Pest, adding datasets, and TDD workflows. Always activate when the user asks how to write something in Pest, mentions test files or directories (tests/Feature, tests/Unit) or architecture tests. Covers: test()/it()/expect() syntax, datasets, mocking, browser testing, arch(), Livewire component tests, RefreshDatabase, and all Pest 3 features. Do not use for editing factories, seeders, migrations, controllers, models, or non-test PHP code.
-- `inertia-vue-development` — Develops Inertia.js v1 Vue client-side applications. Activates when creating Vue pages, forms, or navigation; using Link or router; or when user mentions Vue with Inertia, Vue pages, Vue forms, or Vue navigation.
-- `echo-development` — Develops real-time broadcasting with Laravel Echo. Activates when setting up broadcasting (Reverb, Pusher, Ably); creating ShouldBroadcast events; defining broadcast channels (public, private, presence, encrypted); authorizing channels; configuring Echo; listening for events; implementing client events (whisper); setting up model broadcasting; broadcasting notifications; or when the user mentions broadcasting, Echo, WebSockets, real-time events, Reverb, or presence channels.
-- `tailwindcss-development` — Always invoke when the user's message includes 'tailwind' in any form. Also invoke for: building responsive grid layouts (multi-column card grids, product grids), flex/grid page structures (dashboards with sidebars, fixed topbars, mobile-toggle navs), styling UI components (cards, tables, navbars, pricing sections, forms, inputs, badges), adding dark mode variants, fixing spacing or typography, and Tailwind v3/v4 work. The core use case: writing or fixing Tailwind utility classes in HTML templates (Blade, JSX, Vue). Skip for backend PHP logic, database queries, API routes, JavaScript with no HTML/CSS component, CSS file audits, build tool configuration, and vanilla CSS.
+This project has domain-specific skills available in `**/skills/**`. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 
 ## Conventions
 
@@ -1033,6 +1025,12 @@ This project has domain-specific skills available. You MUST activate the relevan
 - Prefer PHPDoc blocks over inline comments. Only add inline comments for exceptionally complex logic.
 - Use array shape type definitions in PHPDoc blocks.
 
+=== deployments rules ===
+
+# Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
+
 === herd rules ===
 
 # Laravel Herd
@@ -1092,35 +1090,6 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
 
-## Deployment
-
-- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
-
-=== laravel/v12 rules ===
-
-# Laravel 12
-
-- CRITICAL: ALWAYS use `search-docs` tool for version-specific Laravel documentation and updated code examples.
-- Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
-
-## Laravel 12 Structure
-
-- In Laravel 12, middleware are no longer registered in `app\Http/Kernel.php`.
-- Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
-- `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
-- `bootstrap/providers.php` contains application specific service providers.
-- The `app\Console/Kernel.php` file no longer exists; use `bootstrap/app.php` or `routes/console.php` for console configuration.
-- Console commands in `app\Console/Commands/` are automatically available and do not require manual registration.
-
-## Database
-
-- When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
-- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
-
-### Models
-
-- Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
-
 === pint/core rules ===
 
 # Laravel Pint Code Formatter
@@ -1133,6 +1102,7 @@ This project has domain-specific skills available. You MUST activate the relevan
 ## Pest
 
 - This project uses Pest for testing. Create tests: `php artisan make:test --pest {name}`.
+- The `{name}` argument should not include the test suite directory. Use `php artisan make:test --pest SomeFeatureTest` instead of `php artisan make:test --pest Feature/SomeFeatureTest`.
 - Run tests: `php artisan test --compact` or filter: `php artisan test --compact --filter=testName`.
 - Do NOT delete tests without approval.
 

--- a/app/Http/Requests/StoreTenantRequest.php
+++ b/app/Http/Requests/StoreTenantRequest.php
@@ -21,7 +21,7 @@ class StoreTenantRequest extends FormRequest
             'slug' => [
                 'required', 'string', 'max:63', 'alpha_dash:ascii',
                 Rule::unique('tenants', 'slug'),
-                Rule::notIn(Tenant::RESERVED_SLUGS),
+                Rule::notIn(Tenant::reservedSlugs()),
             ],
             'owner_email' => ['required', 'email', 'exists:users,email'],
         ];

--- a/app/Http/Requests/UpdateTenantRequest.php
+++ b/app/Http/Requests/UpdateTenantRequest.php
@@ -21,7 +21,7 @@ class UpdateTenantRequest extends FormRequest
             'slug' => [
                 'required', 'string', 'max:63', 'alpha_dash:ascii',
                 Rule::unique('tenants', 'slug')->ignore($this->route('tenant')),
-                Rule::notIn(Tenant::RESERVED_SLUGS),
+                Rule::notIn(Tenant::reservedSlugs()),
             ],
         ];
     }

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -24,6 +24,18 @@ class Tenant extends Model
         'dashboard', 'auth', 'sso', 'oauth', 'cloud',
     ];
 
+    /**
+     * Slugs that may not be used as a tenant subdomain.
+     *
+     * The reservation is lifted on local so any subdomain works while developing.
+     *
+     * @return string[]
+     */
+    public static function reservedSlugs(): array
+    {
+        return app()->isLocal() ? [] : self::RESERVED_SLUGS;
+    }
+
     protected static function booted(): void
     {
         static::unguard();

--- a/boost.json
+++ b/boost.json
@@ -4,6 +4,7 @@
         "junie",
         "copilot"
     ],
+    "cloud": false,
     "guidelines": true,
     "mcp": true,
     "nightwatch_mcp": false,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -24,12 +24,15 @@ return Application::configure(basePath: dirname(__DIR__))
                 ->domain(config('app.domain'))
                 ->group(base_path('routes/web.php'));
 
-            $excluded = implode('|', Tenant::RESERVED_SLUGS);
+            $tenantRoutes = Route::middleware('web')
+                ->domain('{tenant}.'.config('app.domain'));
 
-            Route::middleware('web')
-                ->domain('{tenant}.'.config('app.domain'))
-                ->where(['tenant' => "^(?!(?:{$excluded})$).+$"])
-                ->group(base_path('routes/tenant.php'));
+            if ($reserved = Tenant::reservedSlugs()) {
+                $excluded = implode('|', $reserved);
+                $tenantRoutes->where(['tenant' => "^(?!(?:{$excluded})$).+$"]);
+            }
+
+            $tenantRoutes->group(base_path('routes/tenant.php'));
         },
     )
     ->withBroadcasting(

--- a/database/factories/BankFactory.php
+++ b/database/factories/BankFactory.php
@@ -31,7 +31,7 @@ class BankFactory extends Factory
         ];
 
         return [
-            'name' => $this->faker->randomElement($banks),
+            'name' => $this->faker->unique()->randomElement($banks),
             'code' => $this->faker->unique()->numerify('###'),
         ];
     }

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import { computed, ref } from "vue";
+    import { computed, ref, onMounted, onUnmounted } from "vue";
     import { router, Head, Link, usePage } from "@inertiajs/vue3";
     import ApplicationLogo from "@/Components/ApplicationLogo.vue";
     import Banner from "@/Components/Banner.vue";
@@ -23,8 +23,6 @@
         return usePage().props.locale === "ar" ? "rtl" : "ltr";
     });
 
-    const page = usePage();
-
     const logout = () => {
         router.post(route("tenant.logout"));
     };
@@ -40,6 +38,19 @@
             onFinish: () => { switchingToTenant.value = null; },
         });
     };
+
+    // Auto-close the navigation drawer after navigating (tablet/mobile).
+    let stopNavigationListener = null;
+    onMounted(() => {
+        stopNavigationListener = router.on("navigate", () => {
+            showingSidebar.value = false;
+        });
+    });
+    onUnmounted(() => {
+        if (stopNavigationListener) {
+            stopNavigationListener();
+        }
+    });
 </script>
 
 <template>
@@ -50,46 +61,56 @@
         <Banner />
 
         <!-- App shell -->
-        <div class="xl:flex xl:h-screen xl:overflow-hidden">
+        <div class="lg:flex lg:h-screen lg:overflow-hidden">
 
             <!-- ─────────────────────────────────────────
                  SIDEBAR
-                 DOM order: first → top on mobile, end-side on desktop via xl:order-last
+                 Slide-over drawer below lg (1024px); static side pane at lg+.
+                 Anchored to the inline-start edge, direction-aware via :dir.
             ───────────────────────────────────────── -->
-            <aside class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 xl:flex xl:w-72 xl:shrink-0 xl:flex-col xl:border-b-0 xl:border-s xl:border-s-gray-200 dark:xl:border-s-gray-700 text-right ltr:text-left">
+            <!-- Drawer backdrop (below lg) -->
+            <Transition
+                enter-active-class="transition-opacity ease-out duration-300"
+                enter-from-class="opacity-0"
+                enter-to-class="opacity-100"
+                leave-active-class="transition-opacity ease-in duration-200"
+                leave-from-class="opacity-100"
+                leave-to-class="opacity-0"
+            >
+                <div
+                    v-if="showingSidebar"
+                    class="fixed inset-0 z-40 bg-gray-900/50 backdrop-blur-sm lg:hidden"
+                    @click="showingSidebar = false"
+                />
+            </Transition>
 
-                <!-- Mobile header: logo + hamburger toggle -->
-                <div class="flex h-14 shrink-0 items-center justify-between px-4 xl:hidden">
-                    <Link :href="route('dashboard')" class="inline-flex items-center gap-x-2">
-                        <ApplicationLogo class="h-8 w-auto" />
-                        <span class="text-lg font-bold tracking-tight text-gray-900 dark:text-white">NamaIn</span>
+            <!-- SIDEBAR: slide-over drawer below lg, static pane at lg+ -->
+            <aside
+                class="fixed inset-y-0 start-0 z-50 flex w-72 max-w-[85vw] flex-col bg-white dark:bg-gray-900 shadow-xl transition-transform duration-300 ease-in-out lg:static lg:z-auto lg:w-60 xl:w-72 lg:max-w-none lg:shrink-0 lg:border-e lg:border-gray-200 lg:shadow-none dark:lg:border-gray-700 text-right ltr:text-left"
+                :class="showingSidebar
+                    ? 'translate-x-0'
+                    : (direction === 'rtl' ? 'translate-x-full lg:translate-x-0' : '-translate-x-full lg:translate-x-0')"
+            >
+                <!-- Logo header + drawer close (close shown below lg) -->
+                <div class="flex h-14 lg:h-16 shrink-0 items-center justify-between border-b border-gray-100 px-4 lg:px-5 dark:border-gray-800">
+                    <Link :href="route('dashboard')" class="group inline-flex items-center gap-x-2.5">
+                        <ApplicationLogo class="h-8 w-auto transition-transform duration-200 group-hover:scale-105" />
+                        <span class="text-xl font-bold tracking-tight text-gray-900 dark:text-white">NamaIn</span>
                     </Link>
                     <button
-                        class="inline-flex items-center justify-center rounded-lg p-2 text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none dark:hover:bg-gray-800 dark:hover:text-gray-300"
-                        @click="showingSidebar = !showingSidebar"
+                        type="button"
+                        class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 lg:hidden"
+                        @click="showingSidebar = false"
                     >
-                        <svg v-if="!showingSidebar" class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-                        </svg>
-                        <svg v-else class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <span class="sr-only">{{ __('Close navigation') }}</span>
+                        <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
                         </svg>
                     </button>
                 </div>
 
-                <!-- Desktop logo header (h-16 aligns with desktop search bar) -->
-                <div class="hidden h-16 shrink-0 items-center justify-center border-b border-gray-100 px-5 dark:border-gray-800 xl:flex ">
-                    <Link :href="route('dashboard')" class="group inline-flex items-center gap-x-2.5">
-                        <ApplicationLogo class="h-8 w-auto transition-transform duration-200 group-hover:scale-105" />
-                        <span class="text-xl font-bold tracking-tight text-gray-900 dark:text-white">NamaIn</span>
-                    </Link>
-                </div>
-
-                <!-- Nav body: always visible on xl, toggled on mobile -->
-                <div
-                    :class="showingSidebar ? 'block' : 'hidden'"
-                    class="xl:flex xl:flex-1 xl:flex-col xl:overflow-y-auto px-4 py-5 border-l ltr:border-l border-gray-100 dark:border-gray-800"
-                >
+                <!-- Nav body: scrollable, always mounted (drawer slides via transform) -->
+                <div class="flex flex-1 flex-col overflow-y-auto px-4 py-5">
                     <div class="mb-4">
                         <NavLink :href="route('dashboard')" :active="route().current('dashboard')">
                             <svg class="h-5 w-5 shrink-0 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -284,11 +305,8 @@
                     </nav>
                 </div>
 
-                <!-- User footer: toggled on mobile, always visible on desktop -->
-                <div
-                    :class="showingSidebar ? 'block' : 'hidden'"
-                    class="xl:block shrink-0 border-t border-gray-100 dark:border-gray-800"
-                >
+                <!-- User footer -->
+                <div class="shrink-0 border-t border-gray-100 dark:border-gray-800">
                     <!-- Click-outside overlay -->
                     <div v-if="showingUserMenu" class="fixed inset-0 z-40" @click="showingUserMenu = false" />
 
@@ -457,21 +475,28 @@
             <!-- ─────────────────────────────────────────
                  CONTENT AREA
             ───────────────────────────────────────── -->
-            <div class="flex min-h-0 flex-1 flex-col xl:overflow-hidden">
+            <div class="flex min-h-0 flex-1 flex-col lg:overflow-hidden">
 
-                <!-- Desktop top bar: search only, h-16 aligns with sidebar logo header -->
-                <div class="hidden h-16 shrink-0 items-center border-b border-gray-100 bg-white px-4 dark:border-gray-700 dark:bg-gray-900 sm:px-6 lg:px-8 xl:flex">
-                    <GlobalSearch />
-                </div>
-
-                <!-- Mobile search bar (shown below the aside on mobile) -->
-                <div class=" border-b border-gray-100 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-900 xl:hidden">
-                    <GlobalSearch />
+                <!-- Top bar: hamburger (below lg) + global search -->
+                <div class="flex h-14 lg:h-16 shrink-0 items-center gap-x-3 border-b border-gray-100 bg-white px-4 dark:border-gray-700 dark:bg-gray-900 sm:px-6 lg:px-8">
+                    <button
+                        type="button"
+                        class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 lg:hidden"
+                        @click="showingSidebar = true"
+                    >
+                        <span class="sr-only">{{ __('Open navigation') }}</span>
+                        <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                        </svg>
+                    </button>
+                    <div class="min-w-0 flex-1">
+                        <GlobalSearch />
+                    </div>
                 </div>
 
                 <!-- Main content -->
-                <main class="xl:flex-1 dark:bg-gray-900 xl:overflow-y-auto">
-                    <div class="px-4 py-10 sm:px-6 lg:px-8 max-w-[1800px] 2xl:mx-auto min-h-screen xl:min-h-full">
+                <main class="lg:flex-1 dark:bg-gray-900 lg:overflow-y-auto">
+                    <div class="px-4 py-10 sm:px-6 lg:px-8 max-w-[1800px] 2xl:mx-auto min-h-screen lg:min-h-full">
                         <Flash />
                         <ErrorToast />
                         <OperationsCenter />

--- a/tests/Feature/TenantModelTest.php
+++ b/tests/Feature/TenantModelTest.php
@@ -43,3 +43,15 @@ test('tenant has users relationship', function () {
     expect($tenant->users)->toHaveCount(1);
     expect($tenant->owner()->id)->toBe($user->id);
 });
+
+test('reserved slugs are enforced outside the local environment', function () {
+    app()->detectEnvironment(fn () => 'production');
+
+    expect(Tenant::reservedSlugs())->toBe(Tenant::RESERVED_SLUGS);
+});
+
+test('no slugs are reserved on local so any subdomain is allowed', function () {
+    app()->detectEnvironment(fn () => 'local');
+
+    expect(Tenant::reservedSlugs())->toBe([]);
+});

--- a/tests/cypress/integration/rbac/action-buttons.cy.js
+++ b/tests/cypress/integration/rbac/action-buttons.cy.js
@@ -216,14 +216,8 @@ describe('Storages page', () => {
         });
     });
 
-    describe('as cashier (inventory.view only)', () => {
-        beforeEach(() => cy.tenantLoginAs('cashier'));
-
-        it('hides create storage button (no inventory.manage)', () => {
-            cy.visit('/storages');
-            cy.contains('button', 'Add New').should('not.exist');
-        });
-    });
+    // Cashier has no inventory.view, so /storages is backend-blocked (403)
+    // and is covered by the page-access spec instead.
 });
 
 /*

--- a/tests/cypress/integration/rbac/page-access.cy.js
+++ b/tests/cypress/integration/rbac/page-access.cy.js
@@ -104,9 +104,8 @@ describe('as staff', () => {
 |--------------------------------------------------------------------------
 | Cashier
 |--------------------------------------------------------------------------
-| products.view, customers.view, suppliers.view, sales.view,
-| sales.create, pos.view, pos.operate, pos.manage-sessions,
-| payments.view, payments.create, inventory.view
+| customers.view, sales.view, sales.create, pos.operate,
+| pos.manage-sessions, payments.view, payments.create
 */
 describe('as cashier', () => {
     beforeEach(() => cy.tenantLoginAs('cashier'));
@@ -116,11 +115,6 @@ describe('as cashier', () => {
     it('can access /dashboard', () => {
         cy.visit('/dashboard');
         cy.url().should('include', '/dashboard');
-    });
-
-    it('can access /products', () => {
-        cy.visit('/products');
-        cy.url().should('include', '/products');
     });
 
     it('can access /customers', () => {
@@ -142,6 +136,16 @@ describe('as cashier', () => {
     });
 
     // ── Blocked pages (backend-protected) ──
+
+    it('cannot access /products (no products.view)', () => {
+        cy.visit('/products', { failOnStatusCode: false });
+        cy.get('body').should('contain', '403');
+    });
+
+    it('cannot access /suppliers (no suppliers.view)', () => {
+        cy.visit('/suppliers', { failOnStatusCode: false });
+        cy.get('body').should('contain', '403');
+    });
 
     it('cannot access /users (no users.view)', () => {
         cy.visit('/users', { failOnStatusCode: false });

--- a/tests/cypress/integration/rbac/sidebar-visibility.cy.js
+++ b/tests/cypress/integration/rbac/sidebar-visibility.cy.js
@@ -117,9 +117,8 @@ describe('Sidebar visibility', () => {
     });
 
     // ── Cashier ──────────────────────────────────────────────
-    // products.view, customers.view, suppliers.view, sales.view,
-    // sales.create, pos.view, pos.operate, pos.manage-sessions,
-    // payments.view, payments.create, inventory.view
+    // customers.view, sales.view, sales.create, pos.operate,
+    // pos.manage-sessions, payments.view, payments.create
     describe('as cashier', () => {
         beforeEach(() => cy.tenantLoginAs('cashier'));
 
@@ -127,14 +126,10 @@ describe('Sidebar visibility', () => {
             cy.visit('/dashboard');
 
             cy.get('aside').within(() => {
-                cy.contains('POS').should('exist');
-                cy.contains('POS History').should('exist');
-                cy.contains('Products').should('exist');
-                cy.contains('Storages').should('exist');
-                cy.contains('Customers').should('exist');
-                cy.contains('Suppliers').should('exist');
-                cy.contains('Sales').should('exist');
-                cy.contains('Payments').should('exist');
+                cy.contains('POS').should('exist');       // pos.operate
+                cy.contains('Customers').should('exist'); // customers.view
+                cy.contains('Sales').should('exist');     // sales.view
+                cy.contains('Payments').should('exist');  // payments.view
             });
         });
 
@@ -142,8 +137,20 @@ describe('Sidebar visibility', () => {
             cy.visit('/dashboard');
 
             cy.get('aside').within(() => {
+                // No pos.view
+                cy.contains('POS History').should('not.exist');
+
                 // No inventory.transfer
                 cy.contains('Stock Transfers').should('not.exist');
+
+                // No products.view
+                cy.contains('Products').should('not.exist');
+
+                // No inventory.view
+                cy.contains('Storages').should('not.exist');
+
+                // No suppliers.view
+                cy.contains('Suppliers').should('not.exist');
 
                 // No purchases.view
                 cy.contains('Purchases').should('not.exist');

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -24,6 +24,17 @@ before(() => {
     cy.task('activateCypressEnvFile', {}, { log: false });
     cy.artisan('config:clear', {}, { log: false });
     cy.refreshRoutes();
+
+    // SAFETY GUARD: the suite runs destructive migrate:fresh. Refuse to run
+    // unless the live app is actually connected to an isolated test database.
+    // If the .env swap didn't take effect (e.g. a warm php-fpm worker still
+    // holding the dev env), this aborts the run instead of wiping real data.
+    cy.php('return config("database.connections.".config("database.default").".database");').then((db) => {
+        expect(
+            String(db),
+            `Refusing to run: connected DB "${db}" is not an isolated test database (expected a name containing "cypress" or "_test"). Restart php-fpm after the env swap.`
+        ).to.match(/cypress|_test/i);
+    });
 });
 
 after(() => {

--- a/tests/cypress/support/routes.json
+++ b/tests/cypress/support/routes.json
@@ -1,4 +1,220 @@
 {
+  "horizon.stats.index": {
+    "name": "horizon.stats.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\DashboardStatsController@index",
+    "uri": "api/stats",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.workload.index": {
+    "name": "horizon.workload.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\WorkloadController@index",
+    "uri": "api/workload",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.masters.index": {
+    "name": "horizon.masters.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\MasterSupervisorController@index",
+    "uri": "api/masters",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.monitoring.index": {
+    "name": "horizon.monitoring.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@index",
+    "uri": "api/monitoring",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.monitoring.store": {
+    "name": "horizon.monitoring.store",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@store",
+    "uri": "api/monitoring",
+    "method": [
+      "POST"
+    ]
+  },
+  "horizon.monitoring-tag.paginate": {
+    "name": "horizon.monitoring-tag.paginate",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@paginate",
+    "uri": "api/monitoring/{tag}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.monitoring-tag.destroy": {
+    "name": "horizon.monitoring-tag.destroy",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@destroy",
+    "uri": "api/monitoring/{tag}",
+    "method": [
+      "DELETE"
+    ]
+  },
+  "horizon.jobs-metrics.index": {
+    "name": "horizon.jobs-metrics.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\JobMetricsController@index",
+    "uri": "api/metrics/jobs",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.jobs-metrics.show": {
+    "name": "horizon.jobs-metrics.show",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\JobMetricsController@show",
+    "uri": "api/metrics/jobs/{id}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.queues-metrics.index": {
+    "name": "horizon.queues-metrics.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\QueueMetricsController@index",
+    "uri": "api/metrics/queues",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.queues-metrics.show": {
+    "name": "horizon.queues-metrics.show",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\QueueMetricsController@show",
+    "uri": "api/metrics/queues/{id}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.jobs-batches.index": {
+    "name": "horizon.jobs-batches.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\BatchesController@index",
+    "uri": "api/batches",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.jobs-batches.show": {
+    "name": "horizon.jobs-batches.show",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\BatchesController@show",
+    "uri": "api/batches/{id}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.jobs-batches.retry": {
+    "name": "horizon.jobs-batches.retry",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\BatchesController@retry",
+    "uri": "api/batches/retry/{id}",
+    "method": [
+      "POST"
+    ]
+  },
+  "horizon.pending-jobs.index": {
+    "name": "horizon.pending-jobs.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\PendingJobsController@index",
+    "uri": "api/jobs/pending",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.completed-jobs.index": {
+    "name": "horizon.completed-jobs.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\CompletedJobsController@index",
+    "uri": "api/jobs/completed",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.silenced-jobs.index": {
+    "name": "horizon.silenced-jobs.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\SilencedJobsController@index",
+    "uri": "api/jobs/silenced",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.failed-jobs.index": {
+    "name": "horizon.failed-jobs.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\FailedJobsController@index",
+    "uri": "api/jobs/failed",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.failed-jobs.show": {
+    "name": "horizon.failed-jobs.show",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\FailedJobsController@show",
+    "uri": "api/jobs/failed/{id}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.retry-jobs.show": {
+    "name": "horizon.retry-jobs.show",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\RetryController@store",
+    "uri": "api/jobs/retry/{id}",
+    "method": [
+      "POST"
+    ]
+  },
+  "horizon.jobs.show": {
+    "name": "horizon.jobs.show",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\JobsController@show",
+    "uri": "api/jobs/{id}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "horizon.index": {
+    "name": "horizon.index",
+    "domain": "queue.",
+    "action": "Laravel\\Horizon\\Http\\Controllers\\HomeController@index",
+    "uri": "{view?}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
   "": {
     "name": null,
     "domain": null,
@@ -10,622 +226,11 @@
       "HEAD"
     ]
   },
-  "cypress.factory": {
-    "name": "cypress.factory",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@factory",
-    "uri": "__cypress__/factory",
-    "method": [
-      "POST"
-    ]
-  },
-  "cypress.login": {
-    "name": "cypress.login",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@login",
-    "uri": "__cypress__/login",
-    "method": [
-      "POST"
-    ]
-  },
-  "cypress.logout": {
-    "name": "cypress.logout",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@logout",
-    "uri": "__cypress__/logout",
-    "method": [
-      "POST"
-    ]
-  },
-  "cypress.artisan": {
-    "name": "cypress.artisan",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@artisan",
-    "uri": "__cypress__/artisan",
-    "method": [
-      "POST"
-    ]
-  },
-  "cypress.run-php": {
-    "name": "cypress.run-php",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@runPhp",
-    "uri": "__cypress__/run-php",
-    "method": [
-      "POST"
-    ]
-  },
-  "cypress.csrf-token": {
-    "name": "cypress.csrf-token",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@csrfToken",
-    "uri": "__cypress__/csrf_token",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "cypress.routes": {
-    "name": "cypress.routes",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@routes",
-    "uri": "__cypress__/routes",
-    "method": [
-      "POST"
-    ]
-  },
-  "cypress.current-user": {
-    "name": "cypress.current-user",
-    "domain": null,
-    "action": "Laracasts\\Cypress\\Controllers\\CypressController@currentUser",
-    "uri": "__cypress__/current-user",
-    "method": [
-      "POST"
-    ]
-  },
-  "dusk.login": {
-    "name": "dusk.login",
-    "domain": null,
-    "action": "Laravel\\Dusk\\Http\\Controllers\\UserController@login",
-    "uri": "_dusk/login/{userId}/{guard?}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "dusk.logout": {
-    "name": "dusk.logout",
-    "domain": null,
-    "action": "Laravel\\Dusk\\Http\\Controllers\\UserController@logout",
-    "uri": "_dusk/logout/{guard?}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "dusk.user": {
-    "name": "dusk.user",
-    "domain": null,
-    "action": "Laravel\\Dusk\\Http\\Controllers\\UserController@user",
-    "uri": "_dusk/user/{guard?}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "login": {
-    "name": "login",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\AuthenticatedSessionController@create",
-    "uri": "login",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "login.store": {
-    "name": "login.store",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\AuthenticatedSessionController@store",
-    "uri": "login",
-    "method": [
-      "POST"
-    ]
-  },
-  "logout": {
-    "name": "logout",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\AuthenticatedSessionController@destroy",
-    "uri": "logout",
-    "method": [
-      "POST"
-    ]
-  },
-  "password.request": {
-    "name": "password.request",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\PasswordResetLinkController@create",
-    "uri": "forgot-password",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "password.reset": {
-    "name": "password.reset",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\NewPasswordController@create",
-    "uri": "reset-password/{token}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "password.email": {
-    "name": "password.email",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\PasswordResetLinkController@store",
-    "uri": "forgot-password",
-    "method": [
-      "POST"
-    ]
-  },
-  "password.update": {
-    "name": "password.update",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\NewPasswordController@store",
-    "uri": "reset-password",
-    "method": [
-      "POST"
-    ]
-  },
-  "register": {
-    "name": "register",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\RegisteredUserController@create",
-    "uri": "register",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "register.store": {
-    "name": "register.store",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\RegisteredUserController@store",
-    "uri": "register",
-    "method": [
-      "POST"
-    ]
-  },
-  "user-profile-information.update": {
-    "name": "user-profile-information.update",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\ProfileInformationController@update",
-    "uri": "user/profile-information",
-    "method": [
-      "PUT"
-    ]
-  },
-  "user-password.update": {
-    "name": "user-password.update",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\PasswordController@update",
-    "uri": "user/password",
-    "method": [
-      "PUT"
-    ]
-  },
-  "password.confirm": {
-    "name": "password.confirm",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmablePasswordController@show",
-    "uri": "user/confirm-password",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "password.confirmation": {
-    "name": "password.confirmation",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmedPasswordStatusController@show",
-    "uri": "user/confirmed-password-status",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "password.confirm.store": {
-    "name": "password.confirm.store",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmablePasswordController@store",
-    "uri": "user/confirm-password",
-    "method": [
-      "POST"
-    ]
-  },
-  "two-factor.login": {
-    "name": "two-factor.login",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticatedSessionController@create",
-    "uri": "two-factor-challenge",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "two-factor.login.store": {
-    "name": "two-factor.login.store",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticatedSessionController@store",
-    "uri": "two-factor-challenge",
-    "method": [
-      "POST"
-    ]
-  },
-  "two-factor.enable": {
-    "name": "two-factor.enable",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticationController@store",
-    "uri": "user/two-factor-authentication",
-    "method": [
-      "POST"
-    ]
-  },
-  "two-factor.confirm": {
-    "name": "two-factor.confirm",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmedTwoFactorAuthenticationController@store",
-    "uri": "user/confirmed-two-factor-authentication",
-    "method": [
-      "POST"
-    ]
-  },
-  "two-factor.disable": {
-    "name": "two-factor.disable",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticationController@destroy",
-    "uri": "user/two-factor-authentication",
-    "method": [
-      "DELETE"
-    ]
-  },
-  "two-factor.qr-code": {
-    "name": "two-factor.qr-code",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorQrCodeController@show",
-    "uri": "user/two-factor-qr-code",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "two-factor.secret-key": {
-    "name": "two-factor.secret-key",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorSecretKeyController@show",
-    "uri": "user/two-factor-secret-key",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "two-factor.recovery-codes": {
-    "name": "two-factor.recovery-codes",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\RecoveryCodeController@index",
-    "uri": "user/two-factor-recovery-codes",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "two-factor.regenerate-recovery-codes": {
-    "name": "two-factor.regenerate-recovery-codes",
-    "domain": "namain.test",
-    "action": "Laravel\\Fortify\\Http\\Controllers\\RecoveryCodeController@store",
-    "uri": "user/two-factor-recovery-codes",
-    "method": [
-      "POST"
-    ]
-  },
-  "horizon.stats.index": {
-    "name": "horizon.stats.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\DashboardStatsController@index",
-    "uri": "api/stats",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.workload.index": {
-    "name": "horizon.workload.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\WorkloadController@index",
-    "uri": "api/workload",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.masters.index": {
-    "name": "horizon.masters.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\MasterSupervisorController@index",
-    "uri": "api/masters",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.monitoring.index": {
-    "name": "horizon.monitoring.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@index",
-    "uri": "api/monitoring",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.monitoring.store": {
-    "name": "horizon.monitoring.store",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@store",
-    "uri": "api/monitoring",
-    "method": [
-      "POST"
-    ]
-  },
-  "horizon.monitoring-tag.paginate": {
-    "name": "horizon.monitoring-tag.paginate",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@paginate",
-    "uri": "api/monitoring/{tag}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.monitoring-tag.destroy": {
-    "name": "horizon.monitoring-tag.destroy",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\MonitoringController@destroy",
-    "uri": "api/monitoring/{tag}",
-    "method": [
-      "DELETE"
-    ]
-  },
-  "horizon.jobs-metrics.index": {
-    "name": "horizon.jobs-metrics.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\JobMetricsController@index",
-    "uri": "api/metrics/jobs",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.jobs-metrics.show": {
-    "name": "horizon.jobs-metrics.show",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\JobMetricsController@show",
-    "uri": "api/metrics/jobs/{id}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.queues-metrics.index": {
-    "name": "horizon.queues-metrics.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\QueueMetricsController@index",
-    "uri": "api/metrics/queues",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.queues-metrics.show": {
-    "name": "horizon.queues-metrics.show",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\QueueMetricsController@show",
-    "uri": "api/metrics/queues/{id}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.jobs-batches.index": {
-    "name": "horizon.jobs-batches.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\BatchesController@index",
-    "uri": "api/batches",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.jobs-batches.show": {
-    "name": "horizon.jobs-batches.show",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\BatchesController@show",
-    "uri": "api/batches/{id}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.jobs-batches.retry": {
-    "name": "horizon.jobs-batches.retry",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\BatchesController@retry",
-    "uri": "api/batches/retry/{id}",
-    "method": [
-      "POST"
-    ]
-  },
-  "horizon.pending-jobs.index": {
-    "name": "horizon.pending-jobs.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\PendingJobsController@index",
-    "uri": "api/jobs/pending",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.completed-jobs.index": {
-    "name": "horizon.completed-jobs.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\CompletedJobsController@index",
-    "uri": "api/jobs/completed",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.silenced-jobs.index": {
-    "name": "horizon.silenced-jobs.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\SilencedJobsController@index",
-    "uri": "api/jobs/silenced",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.failed-jobs.index": {
-    "name": "horizon.failed-jobs.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\FailedJobsController@index",
-    "uri": "api/jobs/failed",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.failed-jobs.show": {
-    "name": "horizon.failed-jobs.show",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\FailedJobsController@show",
-    "uri": "api/jobs/failed/{id}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.retry-jobs.show": {
-    "name": "horizon.retry-jobs.show",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\RetryController@store",
-    "uri": "api/jobs/retry/{id}",
-    "method": [
-      "POST"
-    ]
-  },
-  "horizon.jobs.show": {
-    "name": "horizon.jobs.show",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\JobsController@show",
-    "uri": "api/jobs/{id}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "horizon.index": {
-    "name": "horizon.index",
-    "domain": "queue.namain.test",
-    "action": "Laravel\\Horizon\\Http\\Controllers\\HomeController@index",
+  "telescope": {
+    "name": "telescope",
+    "domain": "monitor.",
+    "action": "Laravel\\Telescope\\Http\\Controllers\\HomeController@index",
     "uri": "{view?}",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "profile.show": {
-    "name": "profile.show",
-    "domain": null,
-    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\UserProfileController@show",
-    "uri": "user/profile",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "other-browser-sessions.destroy": {
-    "name": "other-browser-sessions.destroy",
-    "domain": null,
-    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\OtherBrowserSessionsController@destroy",
-    "uri": "user/other-browser-sessions",
-    "method": [
-      "DELETE"
-    ]
-  },
-  "current-user-photo.destroy": {
-    "name": "current-user-photo.destroy",
-    "domain": null,
-    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\ProfilePhotoController@destroy",
-    "uri": "user/profile-photo",
-    "method": [
-      "DELETE"
-    ]
-  },
-  "current-user.destroy": {
-    "name": "current-user.destroy",
-    "domain": null,
-    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\CurrentUserController@destroy",
-    "uri": "user",
-    "method": [
-      "DELETE"
-    ]
-  },
-  "sanctum.csrf-cookie": {
-    "name": "sanctum.csrf-cookie",
-    "domain": null,
-    "action": "Laravel\\Sanctum\\Http\\Controllers\\CsrfCookieController@show",
-    "uri": "sanctum/csrf-cookie",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "ignition.healthCheck": {
-    "name": "ignition.healthCheck",
-    "domain": null,
-    "action": "Spatie\\LaravelIgnition\\Http\\Controllers\\HealthCheckController",
-    "uri": "_ignition/health-check",
-    "method": [
-      "GET",
-      "HEAD"
-    ]
-  },
-  "ignition.executeSolution": {
-    "name": "ignition.executeSolution",
-    "domain": null,
-    "action": "Spatie\\LaravelIgnition\\Http\\Controllers\\ExecuteSolutionController",
-    "uri": "_ignition/execute-solution",
-    "method": [
-      "POST"
-    ]
-  },
-  "ignition.updateConfig": {
-    "name": "ignition.updateConfig",
-    "domain": null,
-    "action": "Spatie\\LaravelIgnition\\Http\\Controllers\\UpdateConfigController",
-    "uri": "_ignition/update-config",
-    "method": [
-      "POST"
-    ]
-  },
-  "api.customers.index": {
-    "name": "api.customers.index",
-    "domain": null,
-    "action": "App\\Http\\Controllers\\Api\\CustomersController",
-    "uri": "api/customers",
     "method": [
       "GET",
       "HEAD"
@@ -1007,6 +612,36 @@
       "PUT"
     ]
   },
+  "api.customers.index": {
+    "name": "api.customers.index",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Api\\CustomersController",
+    "uri": "api/customers",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "api.products.index": {
+    "name": "api.products.index",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Api\\ProductsController",
+    "uri": "api/products",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "api.suppliers.index": {
+    "name": "api.suppliers.index",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Api\\SuppliersController",
+    "uri": "api/suppliers",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
   "customers.export": {
     "name": "customers.export",
     "domain": "{tenant}.namain.test",
@@ -1137,7 +772,7 @@
   "customer-advances.store": {
     "name": "customer-advances.store",
     "domain": "{tenant}.namain.test",
-    "action": "App\\Http\\Controllers\\CustomerAdvancesController@store",
+    "action": "App\\Http\\Controllers\\Contacts\\CustomerAdvancesController@store",
     "uri": "customers/{customer}/advances",
     "method": [
       "POST"
@@ -1146,7 +781,7 @@
   "customer-advances.settle": {
     "name": "customer-advances.settle",
     "domain": "{tenant}.namain.test",
-    "action": "App\\Http\\Controllers\\CustomerAdvancesController@destroy",
+    "action": "App\\Http\\Controllers\\Contacts\\CustomerAdvancesController@destroy",
     "uri": "customer-advances/{customerAdvance}/settle",
     "method": [
       "POST"
@@ -1552,7 +1187,7 @@
     "name": "purchases.show",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Purchases\\PurchasesController@show",
-    "uri": "purchases/{purchase}",
+    "uri": "purchases/{invoice}",
     "method": [
       "GET",
       "HEAD"
@@ -1562,7 +1197,7 @@
     "name": "purchases.edit",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Purchases\\PurchasesController@edit",
-    "uri": "purchases/{purchase}/edit",
+    "uri": "purchases/{invoice}/edit",
     "method": [
       "GET",
       "HEAD"
@@ -1572,7 +1207,7 @@
     "name": "purchases.update",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Purchases\\PurchasesController@update",
-    "uri": "purchases/{purchase}",
+    "uri": "purchases/{invoice}",
     "method": [
       "PUT",
       "PATCH"
@@ -1582,7 +1217,7 @@
     "name": "purchases.destroy",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Purchases\\PurchasesController@destroy",
-    "uri": "purchases/{purchase}",
+    "uri": "purchases/{invoice}",
     "method": [
       "DELETE"
     ]
@@ -1648,7 +1283,7 @@
     "name": "sales.show",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Sales\\SalesController@show",
-    "uri": "sales/{sale}",
+    "uri": "sales/{invoice}",
     "method": [
       "GET",
       "HEAD"
@@ -1658,7 +1293,7 @@
     "name": "sales.edit",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Sales\\SalesController@edit",
-    "uri": "sales/{sale}/edit",
+    "uri": "sales/{invoice}/edit",
     "method": [
       "GET",
       "HEAD"
@@ -1668,7 +1303,7 @@
     "name": "sales.update",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Sales\\SalesController@update",
-    "uri": "sales/{sale}",
+    "uri": "sales/{invoice}",
     "method": [
       "PUT",
       "PATCH"
@@ -1678,7 +1313,7 @@
     "name": "sales.destroy",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Sales\\SalesController@destroy",
-    "uri": "sales/{sale}",
+    "uri": "sales/{invoice}",
     "method": [
       "DELETE"
     ]
@@ -1758,11 +1393,98 @@
       "POST"
     ]
   },
+  "quotes.index": {
+    "name": "quotes.index",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotesController@index",
+    "uri": "quotes",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "quotes.create": {
+    "name": "quotes.create",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotesController@create",
+    "uri": "quotes/create",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "quotes.store": {
+    "name": "quotes.store",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotesController@store",
+    "uri": "quotes",
+    "method": [
+      "POST"
+    ]
+  },
+  "quotes.edit": {
+    "name": "quotes.edit",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotesController@edit",
+    "uri": "quotes/{quote}/edit",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "quotes.update": {
+    "name": "quotes.update",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotesController@update",
+    "uri": "quotes/{quote}",
+    "method": [
+      "PUT"
+    ]
+  },
+  "quotes.destroy": {
+    "name": "quotes.destroy",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotesController@destroy",
+    "uri": "quotes/{quote}",
+    "method": [
+      "DELETE"
+    ]
+  },
+  "quotes.convert": {
+    "name": "quotes.convert",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuoteConvertController@show",
+    "uri": "quotes/{quote}/convert",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "quotes.print": {
+    "name": "quotes.print",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Sales\\QuotePrintController@show",
+    "uri": "quotes/{quote}/print",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
   "invoices.print": {
     "name": "invoices.print",
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Invoicing\\InvoicePrintController@show",
     "uri": "invoice/print/{invoice}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "invoices.receipt": {
+    "name": "invoices.receipt",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Invoicing\\InvoiceReceiptController@show",
+    "uri": "invoice/receipt/{invoice}",
     "method": [
       "GET",
       "HEAD"
@@ -2286,6 +2008,15 @@
       "PUT"
     ]
   },
+  "users.credentials.resend": {
+    "name": "users.credentials.resend",
+    "domain": "{tenant}.namain.test",
+    "action": "App\\Http\\Controllers\\Users\\UserManagementController@resendCredentials",
+    "uri": "users/{user}/resend-credentials",
+    "method": [
+      "POST"
+    ]
+  },
   "users.destroy": {
     "name": "users.destroy",
     "domain": "{tenant}.namain.test",
@@ -2484,6 +2215,439 @@
     "domain": "{tenant}.namain.test",
     "action": "App\\Http\\Controllers\\Core\\TenantSelectionController@switchFrom",
     "uri": "switch-tenant/{target}",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.factory": {
+    "name": "cypress.factory",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@factory",
+    "uri": "__cypress__/factory",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.login": {
+    "name": "cypress.login",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@login",
+    "uri": "__cypress__/login",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.logout": {
+    "name": "cypress.logout",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@logout",
+    "uri": "__cypress__/logout",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.artisan": {
+    "name": "cypress.artisan",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@artisan",
+    "uri": "__cypress__/artisan",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.run-php": {
+    "name": "cypress.run-php",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@runPhp",
+    "uri": "__cypress__/run-php",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.csrf-token": {
+    "name": "cypress.csrf-token",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@csrfToken",
+    "uri": "__cypress__/csrf_token",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "cypress.routes": {
+    "name": "cypress.routes",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@routes",
+    "uri": "__cypress__/routes",
+    "method": [
+      "POST"
+    ]
+  },
+  "cypress.current-user": {
+    "name": "cypress.current-user",
+    "domain": null,
+    "action": "Laracasts\\Cypress\\Controllers\\CypressController@currentUser",
+    "uri": "__cypress__/current-user",
+    "method": [
+      "POST"
+    ]
+  },
+  "boost.browser-logs": {
+    "name": "boost.browser-logs",
+    "domain": null,
+    "action": "Closure",
+    "uri": "_boost/browser-logs",
+    "method": [
+      "POST"
+    ]
+  },
+  "dusk.login": {
+    "name": "dusk.login",
+    "domain": null,
+    "action": "Laravel\\Dusk\\Http\\Controllers\\UserController@login",
+    "uri": "_dusk/login/{userId}/{guard?}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "dusk.logout": {
+    "name": "dusk.logout",
+    "domain": null,
+    "action": "Laravel\\Dusk\\Http\\Controllers\\UserController@logout",
+    "uri": "_dusk/logout/{guard?}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "dusk.user": {
+    "name": "dusk.user",
+    "domain": null,
+    "action": "Laravel\\Dusk\\Http\\Controllers\\UserController@user",
+    "uri": "_dusk/user/{guard?}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "login": {
+    "name": "login",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\AuthenticatedSessionController@create",
+    "uri": "login",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "login.store": {
+    "name": "login.store",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\AuthenticatedSessionController@store",
+    "uri": "login",
+    "method": [
+      "POST"
+    ]
+  },
+  "logout": {
+    "name": "logout",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\AuthenticatedSessionController@destroy",
+    "uri": "logout",
+    "method": [
+      "POST"
+    ]
+  },
+  "password.request": {
+    "name": "password.request",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\PasswordResetLinkController@create",
+    "uri": "forgot-password",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "password.reset": {
+    "name": "password.reset",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\NewPasswordController@create",
+    "uri": "reset-password/{token}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "password.email": {
+    "name": "password.email",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\PasswordResetLinkController@store",
+    "uri": "forgot-password",
+    "method": [
+      "POST"
+    ]
+  },
+  "password.update": {
+    "name": "password.update",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\NewPasswordController@store",
+    "uri": "reset-password",
+    "method": [
+      "POST"
+    ]
+  },
+  "register": {
+    "name": "register",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\RegisteredUserController@create",
+    "uri": "register",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "register.store": {
+    "name": "register.store",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\RegisteredUserController@store",
+    "uri": "register",
+    "method": [
+      "POST"
+    ]
+  },
+  "verification.notice": {
+    "name": "verification.notice",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\EmailVerificationPromptController@__invoke",
+    "uri": "email/verify",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "verification.verify": {
+    "name": "verification.verify",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\VerifyEmailController@__invoke",
+    "uri": "email/verify/{id}/{hash}",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "verification.send": {
+    "name": "verification.send",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\EmailVerificationNotificationController@store",
+    "uri": "email/verification-notification",
+    "method": [
+      "POST"
+    ]
+  },
+  "user-profile-information.update": {
+    "name": "user-profile-information.update",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\ProfileInformationController@update",
+    "uri": "user/profile-information",
+    "method": [
+      "PUT"
+    ]
+  },
+  "user-password.update": {
+    "name": "user-password.update",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\PasswordController@update",
+    "uri": "user/password",
+    "method": [
+      "PUT"
+    ]
+  },
+  "password.confirm": {
+    "name": "password.confirm",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmablePasswordController@show",
+    "uri": "user/confirm-password",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "password.confirmation": {
+    "name": "password.confirmation",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmedPasswordStatusController@show",
+    "uri": "user/confirmed-password-status",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "password.confirm.store": {
+    "name": "password.confirm.store",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmablePasswordController@store",
+    "uri": "user/confirm-password",
+    "method": [
+      "POST"
+    ]
+  },
+  "two-factor.login": {
+    "name": "two-factor.login",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticatedSessionController@create",
+    "uri": "two-factor-challenge",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "two-factor.login.store": {
+    "name": "two-factor.login.store",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticatedSessionController@store",
+    "uri": "two-factor-challenge",
+    "method": [
+      "POST"
+    ]
+  },
+  "two-factor.enable": {
+    "name": "two-factor.enable",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticationController@store",
+    "uri": "user/two-factor-authentication",
+    "method": [
+      "POST"
+    ]
+  },
+  "two-factor.confirm": {
+    "name": "two-factor.confirm",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\ConfirmedTwoFactorAuthenticationController@store",
+    "uri": "user/confirmed-two-factor-authentication",
+    "method": [
+      "POST"
+    ]
+  },
+  "two-factor.disable": {
+    "name": "two-factor.disable",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorAuthenticationController@destroy",
+    "uri": "user/two-factor-authentication",
+    "method": [
+      "DELETE"
+    ]
+  },
+  "two-factor.qr-code": {
+    "name": "two-factor.qr-code",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorQrCodeController@show",
+    "uri": "user/two-factor-qr-code",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "two-factor.secret-key": {
+    "name": "two-factor.secret-key",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\TwoFactorSecretKeyController@show",
+    "uri": "user/two-factor-secret-key",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "two-factor.recovery-codes": {
+    "name": "two-factor.recovery-codes",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\RecoveryCodeController@index",
+    "uri": "user/two-factor-recovery-codes",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "two-factor.regenerate-recovery-codes": {
+    "name": "two-factor.regenerate-recovery-codes",
+    "domain": null,
+    "action": "Laravel\\Fortify\\Http\\Controllers\\RecoveryCodeController@store",
+    "uri": "user/two-factor-recovery-codes",
+    "method": [
+      "POST"
+    ]
+  },
+  "profile.show": {
+    "name": "profile.show",
+    "domain": null,
+    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\UserProfileController@show",
+    "uri": "user/profile",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "other-browser-sessions.destroy": {
+    "name": "other-browser-sessions.destroy",
+    "domain": null,
+    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\OtherBrowserSessionsController@destroy",
+    "uri": "user/other-browser-sessions",
+    "method": [
+      "DELETE"
+    ]
+  },
+  "current-user-photo.destroy": {
+    "name": "current-user-photo.destroy",
+    "domain": null,
+    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\ProfilePhotoController@destroy",
+    "uri": "user/profile-photo",
+    "method": [
+      "DELETE"
+    ]
+  },
+  "current-user.destroy": {
+    "name": "current-user.destroy",
+    "domain": null,
+    "action": "Laravel\\Jetstream\\Http\\Controllers\\Inertia\\CurrentUserController@destroy",
+    "uri": "user",
+    "method": [
+      "DELETE"
+    ]
+  },
+  "sanctum.csrf-cookie": {
+    "name": "sanctum.csrf-cookie",
+    "domain": null,
+    "action": "Laravel\\Sanctum\\Http\\Controllers\\CsrfCookieController@show",
+    "uri": "sanctum/csrf-cookie",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "ignition.healthCheck": {
+    "name": "ignition.healthCheck",
+    "domain": null,
+    "action": "Spatie\\LaravelIgnition\\Http\\Controllers\\HealthCheckController",
+    "uri": "_ignition/health-check",
+    "method": [
+      "GET",
+      "HEAD"
+    ]
+  },
+  "ignition.executeSolution": {
+    "name": "ignition.executeSolution",
+    "domain": null,
+    "action": "Spatie\\LaravelIgnition\\Http\\Controllers\\ExecuteSolutionController",
+    "uri": "_ignition/execute-solution",
+    "method": [
+      "POST"
+    ]
+  },
+  "ignition.updateConfig": {
+    "name": "ignition.updateConfig",
+    "domain": null,
+    "action": "Spatie\\LaravelIgnition\\Http\\Controllers\\UpdateConfigController",
+    "uri": "_ignition/update-config",
     "method": [
       "POST"
     ]

--- a/tests/cypress/support/tenant-commands.js
+++ b/tests/cypress/support/tenant-commands.js
@@ -54,8 +54,9 @@ Cypress.Commands.add('tenantLogin', (slug = 'cypress') => {
             app()->instance('currentTenant', $tenant);
 
             if (!App\\Models\\Role::withoutGlobalScopes()->where('tenant_id', $tenant->id)->exists()) {
-                (new Database\\Seeders\\PermissionSeeder)->run();
-                (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+                // Permissions are seeded by migration; DefaultRolesService reads
+                // Permission::all() and syncs them to the default roles.
+                (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
             }
 
             $user = App\\Models\\User::factory()->create([
@@ -79,7 +80,7 @@ Cypress.Commands.add('tenantLogin', (slug = 'cypress') => {
                 ['key' => 'language', 'tenant_id' => $tenant->id],
                 ['value' => 'en']
             );
-            App\\Services\\TenantCache::forget('preferences');
+            App\\Facades\\Cache::forget('preferences');
 
             return ['slug' => $tenant->slug, 'email' => $user->email]
         `).then((result) => {
@@ -112,8 +113,9 @@ Cypress.Commands.add('tenantLoginAs', (roleSlug, slug = 'cypress') => {
             app()->instance('currentTenant', $tenant);
 
             if (!App\\Models\\Role::withoutGlobalScopes()->where('tenant_id', $tenant->id)->exists()) {
-                (new Database\\Seeders\\PermissionSeeder)->run();
-                (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+                // Permissions are seeded by migration; DefaultRolesService reads
+                // Permission::all() and syncs them to the default roles.
+                (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
             }
 
             $user = App\\Models\\User::factory()->create([
@@ -136,7 +138,7 @@ Cypress.Commands.add('tenantLoginAs', (roleSlug, slug = 'cypress') => {
                 ['key' => 'language', 'tenant_id' => $tenant->id],
                 ['value' => 'en']
             );
-            App\\Services\\TenantCache::forget('preferences');
+            App\\Facades\\Cache::forget('preferences');
 
             return ['slug' => $tenant->slug, 'email' => $user->email]
         `).then((result) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@esbuild/linux-x64@0.17.11":
+"@esbuild/darwin-x64@0.17.11":
   version "0.17.11"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.11.tgz"
-  integrity sha512-rM/v8UlluxpytFSmVdbCe1yyKQd/e+FmIJE2oPJvbBo+D0XVWi1y/NQ4iTNx+436WmDHQBjVLrbnAQLQ6U7wlw==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.11.tgz"
+  integrity sha512-iB0dQkIHXyczK3BZtzw1tqegf0F0Ab5texX2TvMQjiJIWXAfM4FQl7D909YfXWnB92OQz4ivBYQ2RlxBJrMJOw==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.3.0"
@@ -1328,6 +1328,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1, function-bind@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary

This branch contains two functional changes plus a tooling/docs sync.

### 1. Tablet-friendly app shell with slide-over nav drawer (`AppLayout.vue`)
- Lowers the app-shell breakpoint from `xl` (1280px) to `lg` (1024px) so landscape tablets get the persistent two-pane layout instead of the cramped mobile nav.
- Below `lg`, the sidebar becomes a proper slide-over drawer with a dimmed backdrop and a close button, instead of expanding inline and pushing content down.
- Sidebar narrows to `lg:w-60`, widens to `xl:w-72`; slide direction is RTL-aware.
- Unified top bar (hamburger + global search) replaces the separate desktop/mobile search bars.
- Drawer auto-closes after Inertia navigation; nav links stay mounted (transform-based) so RBAC sidebar tests remain valid.

### 2. Lift reserved tenant subdomains on local
- The `{tenant}` route group excluded every `RESERVED_SLUGS` word via a regex constraint that Ziggy enforces client-side. The local demo tenant uses the slug `demo` (a reserved word), so every dashboard URL build threw a Ziggy error.
- Centralized the reservation in `Tenant::reservedSlugs()` — empty on local, full list elsewhere — consumed by the route constraint and the store/update tenant requests.
- On local any subdomain now resolves; production keeps full reserved-subdomain protection.

### 3. Chore
- Sync of skill docs, cypress fixtures, and tooling config.

## Testing
- Added 2 cases to `TenantModelTest` (reserved enforced in production, empty on local).
- `php artisan test` — tenant model/CRUD/registration suites pass; Pint clean.