### PR TITLE
Fix Cypress E2E suite (259/277 → 277/277) + faster DB reset

### DIFF
--- a/app/Queries/DashboardStatsQuery.php
+++ b/app/Queries/DashboardStatsQuery.php
@@ -224,7 +224,9 @@ class DashboardStatsQuery
 
     private function cacheTtl(string $duration): DateTimeInterface|int
     {
-        if (app()->environment('testing')) {
+        // Only cache in production; outside it (incl. the 'local'-based Cypress
+        // env) stats must stay fresh right after data is seeded.
+        if (! app()->environment('production')) {
             return 0;
         }
 

--- a/app/Queries/Reports/InventoryValuationQuery.php
+++ b/app/Queries/Reports/InventoryValuationQuery.php
@@ -91,7 +91,9 @@ class InventoryValuationQuery
 
     private function longCacheTtl(): \DateTimeInterface|int
     {
-        if (app()->environment('testing')) {
+        // Only cache in production; outside it (incl. the 'local'-based Cypress
+        // env) results must stay fresh right after data is seeded.
+        if (! app()->environment('production')) {
             return 0;
         }
 

--- a/app/Queries/Reports/ResolvesReportDates.php
+++ b/app/Queries/Reports/ResolvesReportDates.php
@@ -16,7 +16,10 @@ trait ResolvesReportDates
 
     private function cacheTtl(): DateTimeInterface|int
     {
-        if (app()->environment('testing')) {
+        // Only cache report results in production. Outside it (local, testing,
+        // and the Cypress E2E env which runs as 'local') results must stay fresh
+        // so a query right after seeding data isn't served a stale empty result.
+        if (! app()->environment('production')) {
             return 0;
         }
 

--- a/resources/js/Components/Products/ProductForm.vue
+++ b/resources/js/Components/Products/ProductForm.vue
@@ -354,6 +354,15 @@
                                                 {{ __("Add Unit") }}
                                             </button>
                                         </div>
+
+                                        <button
+                                            v-if="product.units.length === 0"
+                                            type="button"
+                                            class="px-4 py-2.5 bg-gray-100 rounded-lg w-full text-sm font-semibold"
+                                            @click="addUnit"
+                                        >
+                                            {{ __("Add Unit") }}
+                                        </button>
                                     </div>
                                 </div>
 

--- a/tests/cypress/integration/admin.cy.js
+++ b/tests/cypress/integration/admin.cy.js
@@ -152,8 +152,7 @@ describe('Tenant Detail & User Management', () => {
         // Create a tenant with an owner
         cy.php(`
             $tenant = App\\Models\\Tenant::factory()->create();
-            (new Database\\Seeders\\PermissionSeeder)->run();
-            (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+            (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
 
             $owner = App\\Models\\User::factory()->create(['current_tenant_id' => $tenant->id]);
             $role = App\\Models\\Role::withoutGlobalScopes()
@@ -181,8 +180,7 @@ describe('Tenant Detail & User Management', () => {
     it('opens the add user modal', () => {
         cy.php(`
             $tenant = App\\Models\\Tenant::factory()->create();
-            (new Database\\Seeders\\PermissionSeeder)->run();
-            (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+            (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
 
             $owner = App\\Models\\User::factory()->create(['current_tenant_id' => $tenant->id]);
             $role = App\\Models\\Role::withoutGlobalScopes()
@@ -207,8 +205,7 @@ describe('Impersonation', () => {
 
         cy.php(`
             $tenant = App\\Models\\Tenant::factory()->create(['name' => 'Impersonate Me']);
-            (new Database\\Seeders\\PermissionSeeder)->run();
-            (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+            (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
 
             $owner = App\\Models\\User::factory()->create(['current_tenant_id' => $tenant->id]);
             $role = App\\Models\\Role::withoutGlobalScopes()
@@ -233,8 +230,7 @@ describe('Impersonation', () => {
 
         cy.php(`
             $tenant = App\\Models\\Tenant::factory()->create(['name' => 'Impersonate Target', 'slug' => 'imp-target']);
-            (new Database\\Seeders\\PermissionSeeder)->run();
-            (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+            (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
 
             $owner = App\\Models\\User::factory()->create(['current_tenant_id' => $tenant->id]);
             $role = App\\Models\\Role::withoutGlobalScopes()

--- a/tests/cypress/integration/entities.cy.js
+++ b/tests/cypress/integration/entities.cy.js
@@ -32,7 +32,8 @@ describe('Products', () => {
             cy.get('.flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)').contains('15').click();
         });
 
-        // Fill unit fields inside the modal
+        // Add a unit row, then fill its fields inside the modal
+        cy.contains('button', 'Add Unit').click();
         cy.get('input[placeholder="Unit eg: box"]').clear().type('Box');
         cy.get('input[placeholder="Unit Conversion Factor"]').clear().type('1');
 

--- a/tests/cypress/integration/product-cards.cy.js
+++ b/tests/cypress/integration/product-cards.cy.js
@@ -251,7 +251,8 @@ describe('Optional Expire Date and Units', () => {
         cy.get('#name').clear().type('No Expiry Product');
         cy.get('#cost').clear().type('100');
 
-        // Fill unit fields
+        // Add a unit row, then fill its fields
+        cy.contains('button', 'Add Unit').click();
         cy.get('input[placeholder="Unit eg: box"]').clear().type('Pack');
         cy.get('input[placeholder="Unit Conversion Factor"]').clear().type('1');
 

--- a/tests/cypress/integration/subdomain-login.cy.js
+++ b/tests/cypress/integration/subdomain-login.cy.js
@@ -44,8 +44,7 @@ describe('Subdomain Login', () => {
             app()->instance('currentTenant', $tenant);
 
             if (!App\\Models\\Role::withoutGlobalScopes()->where('tenant_id', $tenant->id)->exists()) {
-                (new Database\\Seeders\\PermissionSeeder)->run();
-                (new App\\Services\\DefaultRolesService)->seedForTenant($tenant);
+                (new App\\Services\\OnBoarding\\DefaultRolesService)->seedForTenant($tenant);
             }
 
             $user = App\\Models\\User::factory()->create([
@@ -69,7 +68,7 @@ describe('Subdomain Login', () => {
                 ['key' => 'language', 'tenant_id' => $tenant->id],
                 ['value' => 'en']
             );
-            App\\Services\\TenantCache::forget('preferences');
+            App\\Facades\\Cache::forget('preferences');
 
             return $user->email;
         `).then((email) => {

--- a/tests/cypress/integration/treasury-impacts.cy.js
+++ b/tests/cypress/integration/treasury-impacts.cy.js
@@ -97,6 +97,7 @@ describe('Sale Invoice impacts treasury', () => {
                 'total' => 50,
                 'discount' => 0,
                 'payment_method' => 'cash',
+                'initial_payment_amount' => 50,
                 'treasury_account_id' => ${cashAccountId},
             ]));
 
@@ -138,6 +139,7 @@ describe('Purchase Invoice impacts treasury', () => {
                 'total' => 15,
                 'discount' => 0,
                 'payment_method' => 'cash',
+                'initial_payment_amount' => 15,
                 'treasury_account_id' => ${cashAccountId},
             ]));
 

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -23,9 +23,8 @@ import './tenant-commands';
 before(() => {
     cy.task('activateCypressEnvFile', {}, { log: false });
     cy.artisan('config:clear', {}, { log: false });
-    cy.refreshRoutes();
 
-    // SAFETY GUARD: the suite runs destructive migrate:fresh. Refuse to run
+    // SAFETY GUARD: the suite runs a destructive database reset. Refuse to run
     // unless the live app is actually connected to an isolated test database.
     // If the .env swap didn't take effect (e.g. a warm php-fpm worker still
     // holding the dev env), this aborts the run instead of wiping real data.

--- a/tests/cypress/support/laravel-commands.js
+++ b/tests/cypress/support/laravel-commands.js
@@ -206,13 +206,47 @@ Cypress.Commands.add('create', (model, count = 1, attributes = {}, load = [], st
 /**
  * Refresh the database state.
  *
- * @param {Object} options
+ * Fast reset: TRUNCATE every table instead of running `migrate:fresh` (which
+ * drops and replays every migration on each spec). The database itself is kept,
+ * so Herd's persistent php-fpm connections stay valid. The schema is migrated
+ * once on first use, then each reset just truncates + re-seeds the permission
+ * catalog (the seeding migration only runs once, so it must be re-applied).
  *
  * @example cy.refreshDatabase();
- *          cy.refreshDatabase({ '--drop-views': true });
  */
-Cypress.Commands.add('refreshDatabase', (options = {}) => {
-    return cy.artisan('migrate:fresh', options);
+Cypress.Commands.add('refreshDatabase', () => {
+    // Fast reset: TRUNCATE every table instead of migrate:fresh (which drops and
+    // replays every migration). The schema persists across specs — TRUNCATE keeps
+    // the tables — so we only need to migrate on a fresh database. Every other
+    // reset is a single round-trip that truncates and re-seeds the permission
+    // catalog (its seeding migration only runs once, so it must be re-applied).
+    const reset = `
+        if (! Illuminate\\Support\\Facades\\Schema::hasTable('permissions')) {
+            return 'needs-migrate';
+        }
+
+        $tables = collect(Illuminate\\Support\\Facades\\DB::select(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+        ))->pluck('tablename')
+          ->reject(fn ($t) => $t === 'migrations')
+          ->map(fn ($t) => '"' . $t . '"')
+          ->implode(', ');
+
+        Illuminate\\Support\\Facades\\DB::statement(
+            "TRUNCATE TABLE {$tables} RESTART IDENTITY CASCADE"
+        );
+
+        (new Database\\Seeders\\PermissionSeeder)->run();
+
+        return 'reset';
+    `;
+
+    return cy.php(reset).then((result) => {
+        if (result === 'needs-migrate') {
+            cy.artisan('migrate', { '--force': true });
+            cy.php(reset);
+        }
+    });
 });
 
 /**


### PR DESCRIPTION
Follow-up to #38. Gets the Cypress E2E suite fully green and speeds up its database reset.

## App fixes
- **Reports/dashboard caching served stale data outside production.** `ResolvesReportDates`, `InventoryValuationQuery`, and `DashboardStatsQuery` cached query results with a 5–15 min TTL everywhere except the `testing` env. The Cypress env runs as `local`, so a report viewed right after seeding returned an empty cached result. Caching is now gated to **production only**.
- **ProductForm: no way to add a unit on the create form.** With units made optional, the "Add Unit" button was trapped inside an empty `v-for`, so a new product had neither a unit row nor a reachable button. Added a button that shows when the unit list is empty.

## Test corrections
- **admin / subdomain-login:** updated stale inline `cy.php` to the renamed `OnBoarding\DefaultRolesService` / `App\Facades\Cache` (the old classes were deleted, causing 500s).
- **treasury-impacts:** seed `initial_payment_amount` so a payment — and its treasury movement — is actually recorded.
- **entities / product-cards:** click "Add Unit" before filling the unit fields.

## Test infra
- `refreshDatabase` now **TRUNCATEs** all tables and re-seeds the permission catalog instead of `migrate:fresh` per spec; the schema persists across specs, so it only migrates on a fresh database.
- Dropped the dead per-spec `cy.refreshRoutes()` (no spec uses route-based `cy.visit`).

## Verification
Full suite: **277/277 passing.**

> Note: the suite relies on two local `.env.cypress` settings — `APP_LOCALE=en` and `SESSION_DOMAIN=.namain.test` — which are environment-specific (untracked).