### PR TITLE
fix(pos): close-session modal silently no-op'd on empty closing float

### DIFF
--- a/resources/js/Components/Pos/PosCloseSessionModal.vue
+++ b/resources/js/Components/Pos/PosCloseSessionModal.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useForm } from "@inertiajs/vue3";
 import Modal from "@/Components/Modal.vue";
 import InputLabel from "@/Components/InputLabel.vue";
+import InputError from "@/Components/InputError.vue";
 import TextInput from "@/Components/TextInput.vue";
 import PrimaryButton from "@/Components/PrimaryButton.vue";
 
@@ -19,7 +20,9 @@ const fmt = (val) => `${Number(val).toLocaleString('en-US', { minimumFractionDig
 
 const form = useForm({
     session_id: props.sessionId,
-    closing_float: '',
+    // Pre-fill with the expected float so closing works on a single click; the
+    // cashier can overwrite it with the actual counted cash.
+    closing_float: props.sessionStats?.expected_closing_float ?? '',
 });
 
 const liveVariance = computed(() => {
@@ -70,6 +73,7 @@ const closeSession = () => form.post(route('pos.close'));
                 <div>
                     <InputLabel for="closing_float" :value="__('Actual Cash in Hand')" />
                     <TextInput v-model="form.closing_float" id="closing_float" type="number" step="0.01" min="0" class="mt-1 block w-full rounded-xl" :placeholder="sessionStats ? String(sessionStats.expected_closing_float) : '0.00'" />
+                    <InputError :message="form.errors.closing_float" class="mt-1" />
                 </div>
                 <div v-if="liveVariance !== null" class="flex items-center justify-between rounded-xl px-4 py-3 transition-colors" :class="liveVariance < 0 ? 'bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800' : 'bg-emerald-50 dark:bg-emerald-900/10 border border-emerald-200 dark:border-emerald-800'">
                     <span class="text-sm font-medium" :class="liveVariance < 0 ? 'text-red-700 dark:text-red-400' : 'text-emerald-700 dark:text-emerald-400'">{{ __('Variance') }}</span>

--- a/tests/cypress/integration/pos.cy.js
+++ b/tests/cypress/integration/pos.cy.js
@@ -127,3 +127,24 @@ describe('POS Sale Point Picker', () => {
         });
     });
 });
+
+describe('POS Close Session', () => {
+    it('closes the open session from the modal in one click', () => {
+        cy.visit('/pos');
+
+        ensureSessionOpen();
+
+        // Open the close modal and confirm. The closing-float field is pre-filled with
+        // the expected amount, so a single click must actually close the session.
+        // (force: a success-flash overlay can sit above the cart header in headless.)
+        cy.contains('button', 'Close Session').click({ force: true });
+        cy.contains('button', 'Confirm & Close').click({ force: true });
+
+        // Session closed → the sale point returns to its Open screen.
+        cy.get('#opening_float', { timeout: 10000 }).should('exist');
+
+        // And it stays closed on reload (it was not silently left open).
+        cy.visit('/pos');
+        cy.get('#opening_float', { timeout: 10000 }).should('exist');
+    });
+});


### PR DESCRIPTION
## Problem

Clicking **Confirm & Close** in the POS close-session modal did nothing — the session stayed open and the modal just stayed up.

`PosCloseSessionModal.vue` posted `closing_float: ''` (empty), but `PosSessionController@destroy` validates it as `required|numeric|min:0`. The POST failed validation (422) and the field had **no error display**, so the failure was silent and the close action was never reached.

## Fix

- Pre-fill the *Actual Cash in Hand* field with the **expected closing float**, so a single click on Confirm & Close actually closes the session (the cashier can still overwrite it with the real counted amount).
- Add an `InputError` under the field so any validation failure is visible instead of silent.

## Test

New Cypress regression test in `pos.cy.js`: opens a session, clicks Confirm & Close once, asserts the sale point returns to its Open screen and **stays** closed on reload. POS spec is green (5/5).

Pre-existing bug, separate from the merchant-feedback work (#40).