### PR TITLE
i18n(dashboard): localize the email verification banner (Arabic + English)

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,4 +1,10 @@
 {
+    "Please verify your email address": "يرجى تأكيد عنوان بريدك الإلكتروني",
+    "Your account is active. Verifying your email keeps it secure and makes sure you receive important notifications.": "حسابك مفعّل. تأكيد بريدك الإلكتروني يحافظ على أمان حسابك ويضمن وصول الإشعارات المهمة إليك.",
+    "Resend email": "إعادة إرسال البريد",
+    "Email sent": "تم إرسال البريد",
+    "Verification email sent. Check your inbox.": "تم إرسال بريد التأكيد. يرجى التحقق من صندوق الوارد.",
+    "Dismiss": "إغلاق",
     "Treasury": "الخزينة",
     "Accounts": "الحسابات",
     "Track your cash, bank, and mobile money balances in one place.": "تتبع أرصدة النقد والبنوك والمحافظ الإلكترونية في مكان واحد.",

--- a/tests/Feature/VerifyEmailBannerLocalizationTest.php
+++ b/tests/Feature/VerifyEmailBannerLocalizationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use function PHPUnit\Framework\assertNotSame;
+use function PHPUnit\Framework\assertSame;
+
+/**
+ * The non-blocking email-verification banner strings must be translatable.
+ * English renders via the source key; Arabic must resolve from lang/ar.json.
+ */
+$bannerKeys = [
+    'Please verify your email address',
+    'Your account is active. Verifying your email keeps it secure and makes sure you receive important notifications.',
+    'Resend email',
+    'Email sent',
+    'Verification email sent. Check your inbox.',
+    'Dismiss',
+];
+
+it('renders the verify-email banner strings in english by key', function () use ($bannerKeys) {
+    app()->setLocale('en');
+
+    foreach ($bannerKeys as $key) {
+        assertSame($key, __($key));
+    }
+});
+
+it('localizes the verify-email banner strings in arabic', function () use ($bannerKeys) {
+    app()->setLocale('ar');
+
+    foreach ($bannerKeys as $key) {
+        $translated = __($key);
+        assertNotSame($key, $translated, "Missing Arabic translation for: {$key}");
+        expect($translated)->toMatch('/\p{Arabic}/u');
+    }
+});


### PR DESCRIPTION
## What

The non-blocking email-verification banner on the dashboard (added in #40) wraps its strings in `__()`, but the strings had **no Arabic entries**, so under the Arabic locale they fell back to English.

## Change

- Add Arabic translations to `lang/ar.json` for all six banner strings: the title, the body copy, `Resend email`, `Email sent`, `Verification email sent. Check your inbox.`, and the `Dismiss` aria-label.
- English continues to render via the source key (no `en.json` needed).
- Add a Pest test asserting both locales resolve (English by key, Arabic to non-Latin strings).

No component changes were required — the markup was already localized; only the translation entries were missing.