### PR TITLE
feat(admin): send custom emails to users from admin panel

### DIFF
--- a/app/Actions/Admin/SendAdminEmailAction.php
+++ b/app/Actions/Admin/SendAdminEmailAction.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Actions\Admin;
+
+use App\Models\User;
+use App\Notifications\AdminCustomEmailNotification;
+
+class SendAdminEmailAction
+{
+    /**
+     * Send a custom email to the given users. Returns the number of recipients notified.
+     *
+     * @param  array<int, int>  $userIds
+     */
+    public function handle(array $userIds, string $subject, string $body, ?string $fromName = null, ?string $replyTo = null): int
+    {
+        $users = User::whereIn('id', $userIds)->get();
+
+        $notification = (new AdminCustomEmailNotification($subject, $body, $fromName, $replyTo))->locale(app()->getLocale());
+
+        $users->each(fn (User $user) => $user->notify($notification));
+
+        return $users->count();
+    }
+}

--- a/app/Http/Controllers/Admin/MessagesController.php
+++ b/app/Http/Controllers/Admin/MessagesController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Actions\Admin\LogAdminAction;
+use App\Actions\Admin\SendAdminEmailAction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\SendAdminEmailRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Response;
+
+class MessagesController extends Controller
+{
+    public function __construct(private LogAdminAction $logger) {}
+
+    public function index(Request $request): Response
+    {
+        $users = User::query()
+            ->select(['id', 'name', 'email', 'email_verified_at'])
+            ->when($request->search, fn ($q, $search) => $q->where(fn ($q) => $q->where('name', 'like', "%{$search}%")
+                ->orWhere('email', 'like', "%{$search}%")))
+            ->when($request->verified === 'unverified', fn ($q) => $q->whereNull('email_verified_at'))
+            ->when($request->verified === 'verified', fn ($q) => $q->whereNotNull('email_verified_at'))
+            ->when($request->boolean('owners_only'), fn ($q) => $q->whereHas('tenants', fn ($q) => $q->where('tenant_user.role', 'owner')))
+            ->latest()
+            ->paginate(15)
+            ->withQueryString();
+
+        return inertia('Admin/Messages/Index', [
+            'users' => $users,
+            'filters' => $request->only('search', 'verified', 'owners_only'),
+        ]);
+    }
+
+    public function store(SendAdminEmailRequest $request, SendAdminEmailAction $action): RedirectResponse
+    {
+        $count = $action->handle(
+            $request->user_ids,
+            $request->subject,
+            $request->body,
+            $request->from_name,
+            $request->reply_to,
+        );
+
+        $this->logger->handle($request->user()->id, 'message.sent', null, [
+            'recipient_count' => $count,
+            'subject' => $request->subject,
+        ]);
+
+        return back()->with('success', __('Your email has been queued for :count recipient(s).', ['count' => $count]));
+    }
+}

--- a/app/Http/Requests/Admin/SendAdminEmailRequest.php
+++ b/app/Http/Requests/Admin/SendAdminEmailRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SendAdminEmailRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isAdmin() ?? false;
+    }
+
+    /** @return array<string, mixed> */
+    public function rules(): array
+    {
+        return [
+            'user_ids' => ['required', 'array', 'min:1'],
+            'user_ids.*' => ['integer', 'exists:users,id'],
+            'from_name' => ['nullable', 'string', 'max:255'],
+            'reply_to' => ['nullable', 'email', 'max:255'],
+            'subject' => ['required', 'string', 'max:255'],
+            'body' => ['required', 'string', 'max:5000'],
+        ];
+    }
+}

--- a/app/Notifications/AdminCustomEmailNotification.php
+++ b/app/Notifications/AdminCustomEmailNotification.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class AdminCustomEmailNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly string $subject,
+        public readonly string $body,
+        public readonly ?string $fromName = null,
+        public readonly ?string $replyTo = null,
+    ) {}
+
+    /** @return array<int, string> */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->subject($this->subject)
+            ->view('emails.admin-message', [
+                'notifiable' => $notifiable,
+                'subject' => $this->subject,
+                'body' => $this->body,
+            ]);
+
+        if ($this->fromName) {
+            $mail->from(config('mail.from.address'), $this->fromName);
+        }
+
+        if ($this->replyTo) {
+            $mail->replyTo($this->replyTo);
+        }
+
+        return $mail;
+    }
+}

--- a/resources/js/Layouts/AdminLayout.vue
+++ b/resources/js/Layouts/AdminLayout.vue
@@ -105,6 +105,20 @@
                             <span class="text-sm">{{ __('Tenants') }}</span>
                         </Link>
 
+                        <!-- Messaging -->
+                        <Link
+                            :href="route('admin.messages.index')"
+                            class="flex items-center gap-x-3 px-3 py-2 rounded-lg transition-all duration-200"
+                            :class="route().current('admin.messages.*')
+                                ? 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white font-semibold'
+                                : 'text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-gray-900 dark:hover:text-white'"
+                        >
+                            <svg class="h-5 w-5 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+                            </svg>
+                            <span class="text-sm">{{ __('Messaging') }}</span>
+                        </Link>
+
                         <!-- Activity Log -->
                         <Link
                             :href="route('admin.activity')"

--- a/resources/js/Pages/Admin/Messages/Index.vue
+++ b/resources/js/Pages/Admin/Messages/Index.vue
@@ -1,0 +1,269 @@
+<script setup>
+    import { ref, watch } from "vue";
+    import { router, useForm } from "@inertiajs/vue3";
+    import AdminLayout from "@/Layouts/AdminLayout.vue";
+    import TextInput from "@/Components/TextInput.vue";
+    import InputLabel from "@/Components/InputLabel.vue";
+    import InputError from "@/Components/InputError.vue";
+
+    const props = defineProps({
+        users: Object,
+        filters: Object,
+    });
+
+    const search = ref(props.filters?.search || "");
+    const verified = ref(props.filters?.verified || "");
+    const ownersOnly = ref(!!props.filters?.owners_only);
+    let debounceTimer = null;
+
+    watch([search, verified, ownersOnly], () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => {
+            router.get(route("admin.messages.index"), {
+                search: search.value || undefined,
+                verified: verified.value || undefined,
+                owners_only: ownersOnly.value || undefined,
+            }, { preserveState: true, replace: true });
+        }, 300);
+    });
+
+    const form = useForm({
+        user_ids: [],
+        from_name: "",
+        reply_to: "",
+        subject: "",
+        body: "",
+    });
+
+    const isSelected = (id) => form.user_ids.includes(id);
+
+    const toggle = (id) => {
+        if (isSelected(id)) {
+            form.user_ids = form.user_ids.filter((uid) => uid !== id);
+        } else {
+            form.user_ids = [...form.user_ids, id];
+        }
+    };
+
+    const selectAllOnPage = () => {
+        const ids = props.users.data.map((u) => u.id);
+        const allSelected = ids.every((id) => isSelected(id));
+        if (allSelected) {
+            form.user_ids = form.user_ids.filter((id) => !ids.includes(id));
+        } else {
+            form.user_ids = [...new Set([...form.user_ids, ...ids])];
+        }
+    };
+
+    const clearSelection = () => {
+        form.user_ids = [];
+    };
+
+    const send = () => {
+        form.post(route("admin.messages.store"), {
+            preserveScroll: true,
+            onSuccess: () => {
+                form.reset();
+            },
+        });
+    };
+</script>
+
+<template>
+    <AdminLayout :title="__('Messaging')">
+        <!-- Page header -->
+        <div class="w-full lg:flex lg:items-center lg:justify-between mb-8">
+            <div>
+                <div class="flex items-center gap-x-3">
+                    <h2 class="text-xl font-semibold text-gray-800 dark:text-white">{{ __('Messaging') }}</h2>
+                    <span class="px-3 py-1 text-xs font-semibold rounded-full text-gray-700 bg-gray-100 dark:bg-gray-800 dark:text-gray-300">
+                        {{ form.user_ids.length }} {{ __('selected') }}
+                    </span>
+                </div>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('Send a custom email to selected users') }}</p>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <!-- Recipients -->
+            <div class="lg:col-span-2 space-y-4">
+                <!-- Filters -->
+                <div class="flex flex-wrap items-center gap-4">
+                    <div class="w-full sm:w-64">
+                        <TextInput
+                            v-model="search"
+                            type="text"
+                            :placeholder="__('Search by name or email...')"
+                            class="w-full"
+                        />
+                    </div>
+                    <select
+                        v-model="verified"
+                        class="px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-gray-400 focus:ring focus:ring-gray-200 focus:ring-opacity-50"
+                    >
+                        <option value="">{{ __('All users') }}</option>
+                        <option value="unverified">{{ __('Unverified only') }}</option>
+                        <option value="verified">{{ __('Verified only') }}</option>
+                    </select>
+                    <label class="inline-flex items-center gap-x-2 text-sm text-gray-700 dark:text-gray-300">
+                        <input
+                            v-model="ownersOnly"
+                            type="checkbox"
+                            class="border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                        />
+                        {{ __('Owners only') }}
+                    </label>
+                </div>
+
+                <!-- User table -->
+                <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                            <thead class="bg-gray-50/50 dark:bg-gray-800/40">
+                                <tr>
+                                    <th class="px-6 py-4 text-start">
+                                        <input
+                                            type="checkbox"
+                                            :checked="users.data.length > 0 && users.data.every((u) => isSelected(u.id))"
+                                            class="border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                            @change="selectAllOnPage"
+                                        />
+                                    </th>
+                                    <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Name') }}</th>
+                                    <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Email') }}</th>
+                                    <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Status') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60 bg-white dark:bg-gray-900">
+                                <tr
+                                    v-for="user in users.data"
+                                    :key="user.id"
+                                    class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200 cursor-pointer"
+                                    @click="toggle(user.id)"
+                                >
+                                    <td class="px-6 py-4 whitespace-nowrap" @click.stop>
+                                        <input
+                                            type="checkbox"
+                                            :checked="isSelected(user.id)"
+                                            class="border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                            @change="toggle(user.id)"
+                                        />
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                                        {{ user.name }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400" dir="ltr">
+                                        {{ user.email }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <span
+                                            v-if="user.email_verified_at"
+                                            class="inline-flex items-center gap-x-1.5 px-2.5 py-1 text-[11px] font-bold rounded-lg border border-emerald-200 bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:border-emerald-800 dark:text-emerald-400"
+                                        >
+                                            {{ __('Verified') }}
+                                        </span>
+                                        <span
+                                            v-else
+                                            class="inline-flex items-center gap-x-1.5 px-2.5 py-1 text-[11px] font-bold rounded-lg border border-amber-200 bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-400"
+                                        >
+                                            {{ __('Unverified') }}
+                                        </span>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <!-- Empty state -->
+                    <div v-if="users.data.length === 0" class="py-12 text-center text-sm text-gray-400 dark:text-gray-500">
+                        {{ __('No users found.') }}
+                    </div>
+                </div>
+
+                <!-- Pagination -->
+                <div v-if="users.links && users.links.length > 3" class="flex flex-wrap items-center gap-1">
+                    <template v-for="link in users.links" :key="link.label">
+                        <component
+                            :is="link.url ? 'a' : 'span'"
+                            :href="link.url"
+                            class="px-4 py-2.5 text-sm leading-4 border rounded-md transition-colors duration-200"
+                            :class="[
+                                link.active
+                                    ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 border-gray-900 dark:border-white'
+                                    : link.url
+                                        ? 'bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800'
+                                        : 'text-gray-400 dark:text-gray-600 border-gray-200 dark:border-gray-700 cursor-not-allowed'
+                            ]"
+                            v-html="link.label"
+                            @click.prevent="link.url && router.get(link.url, {}, { preserveState: true })"
+                        />
+                    </template>
+                </div>
+            </div>
+
+            <!-- Compose -->
+            <div class="lg:col-span-1">
+                <div class="sticky top-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl">
+                    <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                        <h3 class="text-base font-semibold text-gray-900 dark:text-white">{{ __('Compose Email') }}</h3>
+                    </div>
+                    <form class="p-6 space-y-4" @submit.prevent="send">
+                        <div class="flex items-center justify-between">
+                            <p class="text-sm text-gray-500 dark:text-gray-400">
+                                {{ form.user_ids.length }} {{ __('recipient(s) selected') }}
+                            </p>
+                            <button
+                                v-if="form.user_ids.length"
+                                type="button"
+                                class="text-xs font-medium text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300"
+                                @click="clearSelection"
+                            >
+                                {{ __('Clear') }}
+                            </button>
+                        </div>
+                        <InputError :message="form.errors.user_ids" />
+
+                        <div>
+                            <InputLabel :value="__('Sender Name')" />
+                            <TextInput v-model="form.from_name" type="text" class="w-full mt-1" :placeholder="__('e.g. NamaIn Team')" />
+                            <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">{{ __('Display name recipients see. Leave blank for the default.') }}</p>
+                            <InputError :message="form.errors.from_name" class="mt-1" />
+                        </div>
+
+                        <div>
+                            <InputLabel :value="__('Reply-To')" />
+                            <TextInput v-model="form.reply_to" type="email" class="w-full mt-1" :placeholder="__('replies@example.com')" />
+                            <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">{{ __('Where replies are sent. Leave blank for the default.') }}</p>
+                            <InputError :message="form.errors.reply_to" class="mt-1" />
+                        </div>
+
+                        <div>
+                            <InputLabel :value="__('Subject')" />
+                            <TextInput v-model="form.subject" type="text" class="w-full mt-1" required />
+                            <InputError :message="form.errors.subject" class="mt-1" />
+                        </div>
+
+                        <div>
+                            <InputLabel :value="__('Message')" />
+                            <textarea
+                                v-model="form.body"
+                                rows="8"
+                                class="w-full mt-1 px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                required
+                            ></textarea>
+                            <InputError :message="form.errors.body" class="mt-1" />
+                        </div>
+
+                        <button
+                            type="submit"
+                            class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-normal text-white bg-emerald-600 border border-transparent rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+                            :disabled="form.processing || form.user_ids.length === 0"
+                        >
+                            {{ __('Send Email') }}
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </AdminLayout>
+</template>

--- a/resources/views/emails/admin-message.blade.php
+++ b/resources/views/emails/admin-message.blade.php
@@ -1,0 +1,46 @@
+@extends('emails.layout', [
+    'subject' => $subject,
+    'preview' => $subject,
+])
+
+@section('icon')
+    {{-- Envelope icon --}}
+    <svg width="32" height="32" fill="none" viewBox="0 0 24 24" stroke="white" stroke-width="1.8"
+         style="display:inline-block;vertical-align:middle;">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+    </svg>
+@endsection
+
+@section('heading')
+    {{ $subject }}
+@endsection
+
+@section('content')
+    @php $fontStack = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Cairo',sans-serif"; @endphp
+
+    {{-- Greeting --}}
+    <p style="margin:0 0 16px;font-family:{{ $fontStack }};font-size:15px;color:#475569;line-height:1.7;">
+        {{ __('Hi :name,', ['name' => $notifiable->name]) }}
+    </p>
+
+    {{-- Admin-authored body. Escaped with e() to prevent HTML/script injection; nl2br preserves line breaks. --}}
+    <p style="margin:0 0 24px;font-family:{{ $fontStack }};font-size:15px;color:#475569;line-height:1.7;">
+        {!! nl2br(e($body)) !!}
+    </p>
+
+    {{-- Divider --}}
+    <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
+        <tr>
+            <td style="border-top:1px solid #f1f5f9;padding-top:20px;">
+                <p style="margin:0;font-family:{{ $fontStack }};font-size:13px;color:#94a3b8;line-height:1.6;">
+                    {{ __('If you have any questions, simply reply to this email.') }}
+                </p>
+            </td>
+        </tr>
+    </table>
+@endsection
+
+@section('footer-note')
+    {{ __('You received this email because you have an account on :app.', ['app' => config('app.name')]) }}
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\BackupsController as AdminBackupsController;
 use App\Http\Controllers\Admin\BackupSettingsController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\Admin\ImpersonationController;
+use App\Http\Controllers\Admin\MessagesController as AdminMessagesController;
 use App\Http\Controllers\Admin\TenantInvitationsController;
 use App\Http\Controllers\Admin\TenantOwnershipController;
 use App\Http\Controllers\Admin\TenantsController as AdminTenantsController;
@@ -88,6 +89,9 @@ Route::prefix('__admin')->name('admin.')->group(function () {
 
         Route::post('tenants/{tenant}/invitations', [TenantInvitationsController::class, 'store'])->name('tenants.invitations.store');
         Route::delete('tenants/{tenant}/invitations/{invitation}', [TenantInvitationsController::class, 'destroy'])->name('tenants.invitations.destroy');
+
+        Route::get('messages', [AdminMessagesController::class, 'index'])->name('messages.index');
+        Route::post('messages', [AdminMessagesController::class, 'store'])->name('messages.store');
 
         Route::resource('backups', AdminBackupsController::class)->only(['index', 'store', 'show', 'destroy']);
         Route::put('backups/settings', [BackupSettingsController::class, 'update'])->name('backups.settings');

--- a/tests/Feature/Admin/SendAdminEmailTest.php
+++ b/tests/Feature/Admin/SendAdminEmailTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\AdminCustomEmailNotification;
+use Illuminate\Support\Facades\Notification;
+
+it('renders the messaging page for a super admin', function () {
+    User::factory()->count(3)->create();
+
+    actingAsSuperAdmin();
+
+    $this->get(route('admin.messages.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->component('Admin/Messages/Index'));
+});
+
+it('filters users to unverified only', function () {
+    $verified = User::factory()->create();
+    $verified->markEmailAsVerified();
+    User::factory()->unverified()->create();
+
+    actingAsSuperAdmin(); // acting admin is verified
+
+    $this->get(route('admin.messages.index', ['verified' => 'unverified']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->has('users.data', 1));
+});
+
+it('searches users by name or email', function () {
+    User::factory()->create(['name' => 'Alice Owner', 'email' => 'alice@example.com']);
+    User::factory()->create(['name' => 'Bob Other', 'email' => 'bob@example.com']);
+
+    actingAsSuperAdmin();
+
+    $this->get(route('admin.messages.index', ['search' => 'alice']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->has('users.data', 1));
+});
+
+it('queues a custom email to the selected users only', function () {
+    Notification::fake();
+
+    $selected = User::factory()->count(2)->create();
+    $excluded = User::factory()->create();
+
+    actingAsSuperAdmin();
+
+    $this->post(route('admin.messages.store'), [
+        'user_ids' => $selected->pluck('id')->all(),
+        'subject' => 'Please verify your account',
+        'body' => "Hello,\n\nWe noticed you couldn't verify your email.",
+    ])->assertRedirect()->assertSessionHas('success');
+
+    Notification::assertSentTo($selected, AdminCustomEmailNotification::class);
+    Notification::assertNotSentTo($excluded, AdminCustomEmailNotification::class);
+});
+
+it('passes the sender name and reply-to through to the notification', function () {
+    Notification::fake();
+
+    $recipient = User::factory()->create();
+
+    actingAsSuperAdmin();
+
+    $this->post(route('admin.messages.store'), [
+        'user_ids' => [$recipient->id],
+        'from_name' => 'NamaIn Team',
+        'reply_to' => 'support@namain.test',
+        'subject' => 'A promo',
+        'body' => 'Check out our new features.',
+    ])->assertRedirect();
+
+    Notification::assertSentTo($recipient, AdminCustomEmailNotification::class, function ($notification) {
+        return $notification->fromName === 'NamaIn Team'
+            && $notification->replyTo === 'support@namain.test'
+            && $notification->subject === 'A promo';
+    });
+});
+
+it('validates required fields and reply-to format', function () {
+    actingAsSuperAdmin();
+
+    $this->post(route('admin.messages.store'), [
+        'user_ids' => [],
+        'reply_to' => 'not-an-email',
+        'subject' => '',
+        'body' => '',
+    ])->assertSessionHasErrors(['user_ids', 'reply_to', 'subject', 'body']);
+});
+
+it('forbids non-admins from viewing or sending', function () {
+    Notification::fake();
+
+    $user = User::factory()->create(['role' => 'user']);
+    $user->markEmailAsVerified();
+
+    $this->actingAs($user, 'admin');
+
+    $this->get(route('admin.messages.index'))->assertForbidden();
+    $this->post(route('admin.messages.store'), [])->assertForbidden();
+
+    Notification::assertNothingSent();
+});


### PR DESCRIPTION
## Context

Some registered owners could not verify their email addresses. The recent change (#40) made verification **non-blocking** — unverified owners can now use the app, and many have `email_verified_at = null`. We need to reach these owners directly, but the platform had **no way for a super-admin to send a custom email to users** (the app only sends fixed system emails: credentials, invitations, verification).

This adds a reusable **Messaging** feature to the super-admin panel (`/__admin/messages`).

## What's included

**Admin UX** — new "Messaging" section in the admin sidebar:
- Searchable, paginated user list with **Unverified only** and **Owners only** filters to surface the affected owners.
- Multi-select recipients (per-row + select-all-on-page), selection persists across pagination.
- Compose panel: sender name, reply-to, subject, message.

**Sender name & reply-to from the UI** — makes the tool double as a promotional-email sender with controllable reply routing:
- Sender name sets the **display name** only; the envelope from-address stays the configured `MAIL_FROM_ADDRESS` to preserve SPF/DKIM deliverability.
- Reply-to routes replies wherever specified.
- Both optional (blank = system defaults).

**Delivery** — queued via Horizon using a `ShouldQueue` notification, matching the existing notification convention. Renders a Blade email that extends `emails/layout.blade.php`.

**Safety & auditing**
- Admin-authored body is escaped (`nl2br(e($body))`) — no HTML/script injection.
- Guarded by `auth:admin` + `EnsureSuperAdmin`; request authorizes via `isAdmin()`.
- Every send is recorded through the existing `LogAdminAction` audit log.

## Files
- New: `MessagesController`, `SendAdminEmailRequest`, `SendAdminEmailAction`, `AdminCustomEmailNotification`, `emails/admin-message.blade.php`, `Admin/Messages/Index.vue`.
- Edited: `routes/web.php`, `AdminLayout.vue`.

## Tests
`tests/Feature/Admin/SendAdminEmailTest.php` (7 tests, all green): page render, unverified/search filters, queued send to selected-only, sender-name/reply-to pass-through, validation, and non-admin authorization. Full admin suite (62 tests) passes; Pint clean.

## Notes / follow-up
- Emails render in the **app locale** at send time, not each recipient's preferred language. Can switch to per-user locale if desired.