### PR TITLE
feat(ui): tablet-first UX pass

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -11,6 +11,17 @@
     color-scheme: light dark;
 }
 
+/* On touch devices (tablets/phones) iOS zooms the page in when focusing an
+   input whose font-size is below 16px. Enforce a 16px minimum on coarse
+   pointers to disable that zoom-on-focus behaviour. */
+@media (pointer: coarse) {
+    input,
+    select,
+    textarea {
+        font-size: 16px;
+    }
+}
+
 
 /* Vue Multiselect Global Styling - Flat & Simple with RTL/LTR Support */
 .multiselect {

--- a/resources/js/Components/CustomSelect.vue
+++ b/resources/js/Components/CustomSelect.vue
@@ -425,7 +425,7 @@ onBeforeUnmount(() => {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    min-height: 42px;
+    min-height: 44px;
     padding: 0.5rem 0.75rem;
     padding-inline-end: 2.5rem;
     border: 1px solid rgb(229 231 235);
@@ -505,6 +505,13 @@ onBeforeUnmount(() => {
     color: rgb(17 24 39);
 }
 
+@media (pointer: coarse) {
+    .custom-select__search-input,
+    .custom-select__option {
+        font-size: 16px;
+    }
+}
+
 .custom-select__search-input:focus {
     outline: none;
     border-color: rgb(16 185 129);
@@ -524,7 +531,7 @@ onBeforeUnmount(() => {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.5rem 0.75rem;
+    padding: 0.75rem 1rem;
     font-size: 0.875rem;
     color: rgb(17 24 39);
     cursor: pointer;

--- a/resources/js/Components/Customers/CustomerForm.vue
+++ b/resources/js/Components/Customers/CustomerForm.vue
@@ -189,7 +189,9 @@
                                     <TextInput
                                         id="phone"
                                         v-model="customer.phone_number"
-                                        type="text"
+                                        type="tel"
+                                        inputmode="tel"
+                                        autocomplete="tel"
                                         class="block w-full mt-1"
                                         required
                                         autofocus
@@ -208,7 +210,7 @@
                                     <TextInput
                                         id="credit_limit"
                                         v-model="customer.credit_limit"
-                                        type="number"
+                                        type="number" inputmode="decimal"
                                         step="0.01"
                                         class="block w-full mt-1"
                                         required
@@ -228,7 +230,7 @@
                                         <TextInput
                                             id="opening_debit"
                                             v-model="customer.opening_debit"
-                                            type="number"
+                                            type="number" inputmode="decimal"
                                             step="0.01"
                                             class="block w-full mt-1"
                                             :disabled="props.customer"
@@ -247,7 +249,7 @@
                                         <TextInput
                                             id="opening_credit"
                                             v-model="customer.opening_credit"
-                                            type="number"
+                                            type="number" inputmode="decimal"
                                             step="0.01"
                                             class="block w-full mt-1"
                                             :disabled="props.customer"

--- a/resources/js/Components/DialogModal.vue
+++ b/resources/js/Components/DialogModal.vue
@@ -44,7 +44,7 @@
         </div>
 
         <div
-            class="flex rtl:flex-row-reverse flex-row ltr:justify-end px-6 py-4 bg-gray-100 dark:bg-gray-900/40 text-right rtl:justify-start"
+            class="sticky bottom-0 flex rtl:flex-row-reverse flex-row ltr:justify-end px-6 py-4 bg-gray-100 dark:bg-gray-900/40 text-right rtl:justify-start"
             :dir="preferences('language') == 'ar' ? 'rtl' : 'ltr'"
         >
             <slot name="footer" />

--- a/resources/js/Components/DropdownLink.vue
+++ b/resources/js/Components/DropdownLink.vue
@@ -9,15 +9,15 @@ defineProps({
 
 <template>
     <div @click="$emit('click')">
-        <button v-if="as == 'button'" type="button" class="block w-full px-4 py-2 text-sm leading-5 text-left text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100 rtl:text-right">
+        <button v-if="as == 'button'" type="button" class="flex w-full items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-left text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100 rtl:text-right">
             <slot />
         </button>
 
-        <a v-else-if="as =='a'" :href="href" class="block px-4 py-2 text-sm leading-5 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100">
+        <a v-else-if="as =='a'" :href="href" class="flex items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100">
             <slot />
         </a>
 
-        <Link v-else :href="href" class="block px-4 py-2 text-sm leading-5 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100">
+        <Link v-else :href="href" class="flex items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100">
             <slot />
         </Link>
     </div>

--- a/resources/js/Components/Invoicing/InvoiceForm.vue
+++ b/resources/js/Components/Invoicing/InvoiceForm.vue
@@ -219,7 +219,7 @@
                         </span>
                     </div>
 
-                    <div class="hidden md:grid md:grid-cols-12 gap-3 px-5 py-2.5 bg-gray-50 dark:bg-gray-900/50 text-xs font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-gray-700">
+                    <div class="hidden lg:grid lg:grid-cols-12 gap-3 px-5 py-2.5 bg-gray-50 dark:bg-gray-900/50 text-xs font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-gray-700">
                         <div class="col-span-4">{{ __("Product") }}</div>
                         <div class="col-span-2">{{ __("Unit") }}</div>
                         <div class="col-span-2">{{ __("Qty") }}</div>
@@ -229,9 +229,9 @@
 
                     <div class="divide-y divide-gray-50 dark:divide-gray-700/50" v-auto-animate>
                         <div v-for="(item, index) in lineItems" :key="index" class="px-5 py-4">
-                            <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-start">
-                                <div class="md:col-span-4">
-                                    <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Product") }}</label>
+                            <div class="grid grid-cols-1 lg:grid-cols-12 gap-3 items-start">
+                                <div class="lg:col-span-4">
+                                    <label class="lg:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Product") }}</label>
                                     <CustomSelect
                                         v-model="item.product"
                                         :options="productOptions"
@@ -250,8 +250,8 @@
                                     <InputError :message="form.errors[`products.${index}.product`]" class="mt-1" />
                                 </div>
 
-                                <div class="md:col-span-2">
-                                    <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Unit") }}</label>
+                                <div class="lg:col-span-2">
+                                    <label class="lg:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Unit") }}</label>
                                     <CustomSelect
                                         v-model="item.unit"
                                         :options="productUnits(item.product) || []"
@@ -266,30 +266,30 @@
                                     <InputError :message="form.errors[`products.${index}.unit`]" class="mt-1" />
                                 </div>
 
-                                <div class="md:col-span-2">
-                                    <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Qty") }}</label>
-                                    <TextInput v-model="item.quantity" type="number" min="0.01" step="0.01" class="block w-full" required />
+                                <div class="lg:col-span-2">
+                                    <label class="lg:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Qty") }}</label>
+                                    <TextInput v-model="item.quantity" type="number" inputmode="numeric" min="0.01" step="0.01" class="block w-full" required />
                                     <InputError :message="form.errors[`products.${index}.quantity`]" class="mt-1" />
                                 </div>
 
-                                <div class="md:col-span-2">
-                                    <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Price") }}</label>
-                                    <TextInput v-model="item.price" type="number" min="0" step="0.01" class="block w-full" required />
+                                <div class="lg:col-span-2">
+                                    <label class="lg:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Price") }}</label>
+                                    <TextInput v-model="item.price" type="number" inputmode="decimal" min="0" step="0.01" class="block w-full" required />
                                     <InputError :message="form.errors[`products.${index}.price`]" class="mt-1" />
                                 </div>
 
-                                <div class="md:col-span-2 flex items-center justify-between md:justify-end gap-2 md:pt-1.5">
+                                <div class="lg:col-span-2 flex items-center justify-between lg:justify-end gap-2 lg:pt-1.5">
                                     <div>
-                                        <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Total") }}</label>
+                                        <label class="lg:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Total") }}</label>
                                         <span class="font-bold text-gray-900 dark:text-white tabular-nums text-sm">{{ item.total().toFixed(2) }}</span>
                                     </div>
                                     <button
                                         v-if="lineItems.length > 1"
                                         type="button"
                                         @click="lineItems.splice(index, 1)"
-                                        class="p-1.5 text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors flex-shrink-0"
+                                        class="p-2.5 min-h-11 min-w-11 flex items-center justify-center text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors flex-shrink-0"
                                     >
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
                                         </svg>
                                     </button>
@@ -405,7 +405,7 @@
 
                         <div>
                             <InputLabel for="discount" :value="__('Discount')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
-                            <TextInput id="discount" v-model="form.discount" type="number" min="0" step="0.01" class="block w-full" />
+                            <TextInput id="discount" v-model="form.discount" type="number" inputmode="decimal" min="0" step="0.01" class="block w-full" />
                             <InputError :message="form.errors.discount" class="mt-1" />
                         </div>
 

--- a/resources/js/Components/Invoicing/PaymentCaptureFields.vue
+++ b/resources/js/Components/Invoicing/PaymentCaptureFields.vue
@@ -70,7 +70,7 @@
 
         <div>
             <InputLabel for="initial_payment" :value="__('Payment')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
-            <TextInput id="initial_payment" v-model="form.initial_payment_amount" type="number" min="0" step="0.01" class="block w-full" :placeholder="__('Leave empty for no payment')" />
+            <TextInput id="initial_payment" v-model="form.initial_payment_amount" type="number" inputmode="decimal" min="0" step="0.01" class="block w-full" :placeholder="__('Leave empty for no payment')" />
             <InputError :message="form.errors.initial_payment_amount" class="mt-1" />
         </div>
 

--- a/resources/js/Components/Modal.vue
+++ b/resources/js/Components/Modal.vue
@@ -81,7 +81,7 @@ const maxWidthClass = computed(() => {
                     leave-from-class="opacity-100 translate-y-0 sm:scale-100"
                     leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                 >
-                    <div v-show="show" class="mb-6 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
+                    <div v-show="show" class="mb-6 max-h-[85dvh] overflow-y-auto overscroll-contain bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-lg shadow-xl transform transition-all sm:w-full sm:mx-auto" :class="maxWidthClass">
                         <slot v-if="show" />
                     </div>
                 </transition>

--- a/resources/js/Components/NavLink.vue
+++ b/resources/js/Components/NavLink.vue
@@ -9,8 +9,8 @@ const props = defineProps({
 
 const classes = computed(() => {
     return props.active
-        ? 'group flex w-full items-center gap-x-3 rounded-lg px-3 py-2 text-sm font-semibold text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 shadow-sm ring-1 ring-inset ring-emerald-500/10 transition-all duration-300 focus:outline-none'
-        : 'group flex w-full items-center gap-x-3 rounded-lg px-3 py-2 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-emerald-600 dark:hover:text-emerald-400 hover:translate-x-1 rtl:hover:-translate-x-1 transition-all duration-300 focus:outline-none';
+        ? 'group flex w-full items-center gap-x-3 rounded-lg px-3 py-2.5 min-h-[44px] text-sm font-semibold text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/20 shadow-sm ring-1 ring-inset ring-emerald-500/10 transition-all duration-300 focus:outline-none'
+        : 'group flex w-full items-center gap-x-3 rounded-lg px-3 py-2.5 min-h-[44px] text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:text-emerald-600 dark:hover:text-emerald-400 hover:translate-x-1 rtl:hover:-translate-x-1 transition-all duration-300 focus:outline-none';
 });
 </script>
 

--- a/resources/js/Components/OperationsCenter.vue
+++ b/resources/js/Components/OperationsCenter.vue
@@ -160,7 +160,7 @@ const ringCircumference = 2 * Math.PI * 13;
             <div
                 v-if="panelOpen"
                 data-testid="operations-panel"
-                class="fixed bottom-16 z-50 w-80 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-sm overflow-hidden"
+                class="fixed bottom-[calc(4rem+env(safe-area-inset-bottom))] z-50 w-80 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-sm overflow-hidden"
                 :class="[isRtl ? 'left-4' : 'right-4']"
             >
                 <!-- Header -->
@@ -175,7 +175,7 @@ const ringCircumference = 2 * Math.PI * 13;
                         <button v-if="done.length" @click="clearDone" class="text-[11px] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 font-medium px-2 py-1.5 rounded-md transition-colors">
                             {{ __('Clear') }}
                         </button>
-                        <button @click="panelOpen = false" class="w-7 h-7 inline-flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 rounded-md transition-colors">
+                        <button @click="panelOpen = false" class="w-11 h-11 inline-flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 rounded-md transition-colors">
                             <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                             </svg>
@@ -260,7 +260,7 @@ const ringCircumference = 2 * Math.PI * 13;
                                     </template>
                                 </div>
                             </div>
-                            <button @click="dismiss(op.id)" class="w-8 h-8 flex-shrink-0 inline-flex items-center justify-center rounded-md text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                            <button @click="dismiss(op.id)" class="w-11 h-11 flex-shrink-0 inline-flex items-center justify-center rounded-md text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
                                 <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                                 </svg>
@@ -284,7 +284,7 @@ const ringCircumference = 2 * Math.PI * 13;
                 v-if="!panelOpen"
                 @click="panelOpen = true"
                 data-testid="operations-pill"
-                class="fixed bottom-4 z-50 inline-flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2.5 shadow-sm hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
+                class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 inline-flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2.5 shadow-sm hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
                 :class="[isRtl ? 'left-4' : 'right-4']"
             >
                 <span v-if="pillState === 'idle'" class="w-[30px] h-[30px] rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 inline-flex items-center justify-center">

--- a/resources/js/Components/Pos/PosCheckoutModal.vue
+++ b/resources/js/Components/Pos/PosCheckoutModal.vue
@@ -22,6 +22,21 @@ const changeAmount = computed(() => {
     return tendered > 0 ? Math.max(0, tendered - props.total) : null;
 });
 
+// Shortcut cash amounts: the exact total plus the next round-up for common
+// denominations, so cashiers can set the tendered amount in a single tap.
+const quickTenderOptions = computed(() => {
+    const total = props.total || 0;
+    if (total <= 0) return [];
+    const roundUpTo = (step) => Math.ceil(total / step) * step;
+    const rounded = [roundUpTo(5), roundUpTo(10), roundUpTo(50)]
+        .filter((value) => value > total);
+    return [...new Set(rounded)].slice(0, 3);
+});
+
+const setCashTendered = (value) => {
+    cashTendered.value = String(value);
+};
+
 const paymentMethods = [
     { value: 'cash', label: __('Cash'), icon: `<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />`, color: 'emerald' },
     { value: 'bank_transfer', label: __('Bank Transfer'), icon: `<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z" />`, color: 'blue' },
@@ -52,8 +67,8 @@ defineExpose({ reset, selectedPaymentMethod, changeAmount });
 <template>
     <Teleport to="body">
         <Transition enter-active-class="ease-out duration-200" enter-from-class="opacity-0" enter-to-class="opacity-100" leave-active-class="ease-in duration-150" leave-from-class="opacity-100" leave-to-class="opacity-0">
-            <div v-if="show" class="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-4 pb-4 sm:pb-0">
-                <div class="fixed inset-0 bg-gray-500/20 dark:bg-gray-900/60 backdrop-blur-sm" @click="emit('close')" />
+            <div v-if="show" class="fixed inset-0 z-50 flex items-end lg:items-center justify-center px-4 pb-4 lg:pb-0">
+                <div class="fixed inset-0 bg-gray-500/20 dark:bg-gray-900/60 backdrop-blur-sm" />
                 <Transition enter-active-class="ease-out duration-200" enter-from-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to-class="opacity-100 translate-y-0 sm:scale-100">
                     <div v-if="show" class="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl w-full max-w-sm p-6">
                         <div class="text-center mb-6">
@@ -81,7 +96,11 @@ defineExpose({ reset, selectedPaymentMethod, changeAmount });
                             <div v-if="selectedPaymentMethod === 'cash'" class="mb-5 space-y-3">
                                 <div>
                                     <label class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1.5 block">{{ __('Amount Tendered') }}</label>
-                                    <input v-model="cashTendered" type="number" min="0" step="0.01" :placeholder="fmt(total)" class="w-full px-4 py-3 text-lg font-semibold text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50" />
+                                    <div class="flex flex-wrap gap-2 mb-2">
+                                        <button type="button" class="min-h-[44px] px-3 py-2 text-sm font-semibold rounded-xl border border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-100 dark:hover:bg-emerald-900/30 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500" @click="setCashTendered(total)">{{ __('Exact') }}</button>
+                                        <button v-for="amount in quickTenderOptions" :key="amount" type="button" class="min-h-[44px] px-3 py-2 text-sm font-semibold rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500" @click="setCashTendered(amount)">{{ fmt(amount) }}</button>
+                                    </div>
+                                    <input v-model="cashTendered" type="number" inputmode="decimal" min="0" step="0.01" :placeholder="fmt(total)" class="w-full px-4 py-3 text-lg font-semibold text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50" />
                                 </div>
                                 <div v-if="changeAmount !== null" class="flex items-center justify-between px-4 py-3 rounded-xl" :class="changeAmount >= 0 ? 'bg-emerald-50 dark:bg-emerald-900/20' : 'bg-red-50 dark:bg-red-900/20'">
                                     <span class="text-sm font-semibold" :class="changeAmount >= 0 ? 'text-emerald-700 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">{{ __('Change Due') }}</span>

--- a/resources/js/Components/Pos/PosCloseSessionModal.vue
+++ b/resources/js/Components/Pos/PosCloseSessionModal.vue
@@ -72,7 +72,7 @@ const closeSession = () => form.post(route('pos.close'));
             <div class="space-y-4">
                 <div>
                     <InputLabel for="closing_float" :value="__('Actual Cash in Hand')" />
-                    <TextInput v-model="form.closing_float" id="closing_float" type="number" step="0.01" min="0" class="mt-1 block w-full rounded-xl" :placeholder="sessionStats ? String(sessionStats.expected_closing_float) : '0.00'" />
+                    <TextInput v-model="form.closing_float" id="closing_float" type="number" inputmode="decimal" step="0.01" min="0" class="mt-1 block w-full rounded-xl" :placeholder="sessionStats ? String(sessionStats.expected_closing_float) : '0.00'" />
                     <InputError :message="form.errors.closing_float" class="mt-1" />
                 </div>
                 <div v-if="liveVariance !== null" class="flex items-center justify-between rounded-xl px-4 py-3 transition-colors" :class="liveVariance < 0 ? 'bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800' : 'bg-emerald-50 dark:bg-emerald-900/10 border border-emerald-200 dark:border-emerald-800'">

--- a/resources/js/Components/Pos/PosProductGrid.vue
+++ b/resources/js/Components/Pos/PosProductGrid.vue
@@ -124,7 +124,7 @@ onUnmounted(() => {
             </div>
         </div>
 
-        <div class="flex-grow overflow-y-auto grid grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-4 gap-3 p-1 auto-rows-max">
+        <div class="flex-grow overflow-y-auto overscroll-contain grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 p-1 auto-rows-max">
             <button
                 v-for="product in products"
                 :key="product.id"

--- a/resources/js/Components/Products/ProductAdjustmentModal.vue
+++ b/resources/js/Components/Products/ProductAdjustmentModal.vue
@@ -102,7 +102,7 @@ const submit = () => {
                         </label>
                         <input
                             v-model.number="form.new_quantity"
-                            type="number"
+                            type="number" inputmode="decimal"
                             min="0"
                             :disabled="selectedStorageId === null"
                             class="mt-1 w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 disabled:opacity-50 disabled:cursor-not-allowed"

--- a/resources/js/Components/Products/ProductForm.vue
+++ b/resources/js/Components/Products/ProductForm.vue
@@ -209,7 +209,7 @@
                                                     <TextInput
                                                         id="cost"
                                                         v-model="product.cost"
-                                                        type="number"
+                                                        type="number" inputmode="decimal"
                                                         min="0"
                                                         step="0.01"
                                                         class="block w-full mt-1"
@@ -228,7 +228,7 @@
                                                     <TextInput
                                                         id="price"
                                                         v-model="product.price"
-                                                        type="number"
+                                                        type="number" inputmode="decimal"
                                                         min="0"
                                                         step="0.01"
                                                         class="block w-full mt-1"
@@ -286,7 +286,7 @@
                                                 <TextInput
                                                     id="alert_quantity"
                                                     v-model="product.alert_quantity"
-                                                    type="number"
+                                                    type="number" inputmode="decimal"
                                                     min="0"
                                                     class="block w-full mt-1"
                                                     :placeholder="__('3')"
@@ -374,7 +374,7 @@
                                                             unit.conversion_factor
                                                         "
                                                         class="block w-full mt-1"
-                                                        type="number"
+                                                        type="number" inputmode="decimal"
                                                         min="1"
                                                         :placeholder="
                                                             __(

--- a/resources/js/Components/Purchases/ReceiveGoodsModal.vue
+++ b/resources/js/Components/Purchases/ReceiveGoodsModal.vue
@@ -64,7 +64,7 @@ const submit = () => {
                         <TextInput
                             id="quantity"
                             v-model.number="form.quantity"
-                            type="number"
+                            type="number" inputmode="decimal"
                             class="mt-1 block w-full"
                             required
                             :max="transaction.remaining_quantity"

--- a/resources/js/Components/QuickAddPartyModal.vue
+++ b/resources/js/Components/QuickAddPartyModal.vue
@@ -54,7 +54,7 @@ const submit = () => {
 </script>
 
 <template>
-    <DialogModal :show="show" @close="close">
+    <DialogModal :show="show" :closeable="false" @close="close">
         <template #title>
             {{ __("Add New") }} {{ type === 'customer' ? __("Customer") : __("Supplier") }}
         </template>
@@ -79,7 +79,9 @@ const submit = () => {
                     <TextInput
                         id="phone_number"
                         v-model="form.phone_number"
-                        type="text"
+                        type="tel"
+                        inputmode="tel"
+                        autocomplete="tel"
                         class="mt-1 block w-full"
                         required
                     />

--- a/resources/js/Components/Quotes/QuoteForm.vue
+++ b/resources/js/Components/Quotes/QuoteForm.vue
@@ -241,13 +241,13 @@ const submit = () => {
 
                                 <div class="md:col-span-2">
                                     <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Qty") }}</label>
-                                    <TextInput v-model="item.quantity" type="number" min="0.01" step="0.01" class="block w-full" required />
+                                    <TextInput v-model="item.quantity" type="number" inputmode="decimal" min="0.01" step="0.01" class="block w-full" required />
                                     <InputError :message="form.errors[`items.${index}.quantity`]" class="mt-1" />
                                 </div>
 
                                 <div class="md:col-span-2">
                                     <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Unit price") }}</label>
-                                    <TextInput v-model="item.unit_price" type="number" min="0" step="0.01" class="block w-full" required />
+                                    <TextInput v-model="item.unit_price" type="number" inputmode="decimal" min="0" step="0.01" class="block w-full" required />
                                     <InputError :message="form.errors[`items.${index}.unit_price`]" class="mt-1" />
                                 </div>
 
@@ -354,7 +354,7 @@ const submit = () => {
 
                         <div>
                             <InputLabel :value="__('Discount')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
-                            <TextInput v-model="form.discount" type="number" min="0" step="0.01" class="block w-full" />
+                            <TextInput v-model="form.discount" type="number" inputmode="decimal" min="0" step="0.01" class="block w-full" />
                             <InputError :message="form.errors.discount" class="mt-1" />
                         </div>
 

--- a/resources/js/Components/SidebarGroup.vue
+++ b/resources/js/Components/SidebarGroup.vue
@@ -36,7 +36,7 @@ const toggle = () => {
     <section>
         <button
             :class="[
-                'group flex w-full items-center justify-between rounded-lg px-3 py-2 transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/40',
+                'group flex w-full items-center justify-between rounded-lg px-3 py-2.5 min-h-[44px] transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-emerald-500/40',
                 active && !isOpen
                     ? 'bg-emerald-50 text-emerald-500 dark:bg-emerald-900/20 dark:text-emerald-400 shadow-sm ring-1 ring-inset ring-emerald-500/10'
                     : active && isOpen

--- a/resources/js/Components/Storages/AdjustmentModal.vue
+++ b/resources/js/Components/Storages/AdjustmentModal.vue
@@ -69,7 +69,7 @@ const submit = () => {
                         <TextInput
                             id="new_quantity"
                             v-model.number="form.new_quantity"
-                            type="number"
+                            type="number" inputmode="decimal"
                             class="mt-1 block w-full rounded-xl py-3"
                             required
                         />

--- a/resources/js/Components/Suppliers/SupplierForm.vue
+++ b/resources/js/Components/Suppliers/SupplierForm.vue
@@ -188,7 +188,9 @@
                                     <TextInput
                                         id="phone"
                                         v-model="supplier.phone_number"
-                                        type="text"
+                                        type="tel"
+                                        inputmode="tel"
+                                        autocomplete="tel"
                                         class="block w-full mt-1"
                                         required
                                         autofocus
@@ -208,7 +210,7 @@
                                         <TextInput
                                             id="opening_debit"
                                             v-model="supplier.opening_debit"
-                                            type="number"
+                                            type="number" inputmode="decimal"
                                             step="0.01"
                                             class="block w-full mt-1"
                                             :disabled="props.supplier"
@@ -227,7 +229,7 @@
                                         <TextInput
                                             id="opening_credit"
                                             v-model="supplier.opening_credit"
-                                            type="number"
+                                            type="number" inputmode="decimal"
                                             step="0.01"
                                             class="block w-full mt-1"
                                             :disabled="props.supplier"

--- a/resources/js/Components/Tooltip.vue
+++ b/resources/js/Components/Tooltip.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, onUnmounted } from 'vue';
 
 defineProps({
     text: {
@@ -13,6 +13,33 @@ defineProps({
 });
 
 const show = ref(false);
+const root = ref(null);
+
+// Tablets have no hover, so support tap-to-toggle with tap-away to close,
+// while keeping the hover behaviour intact for pointer devices.
+const onDocumentClick = (event) => {
+    if (root.value && !root.value.contains(event.target)) {
+        close();
+    }
+};
+
+const open = () => {
+    if (show.value) return;
+    show.value = true;
+    document.addEventListener('click', onDocumentClick);
+};
+
+const close = () => {
+    if (!show.value) return;
+    show.value = false;
+    document.removeEventListener('click', onDocumentClick);
+};
+
+const toggle = () => {
+    show.value ? close() : open();
+};
+
+onUnmounted(() => document.removeEventListener('click', onDocumentClick));
 
 const positionClasses = {
     top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
@@ -30,7 +57,7 @@ const arrowClasses = {
 </script>
 
 <template>
-    <div class="relative inline-block" @mouseenter="show = true" @mouseleave="show = false">
+    <div ref="root" class="relative inline-block" @mouseenter="open" @mouseleave="close" @click="toggle">
         <slot />
 
         <div v-if="show"

--- a/resources/js/Composables/useFilterSidebar.js
+++ b/resources/js/Composables/useFilterSidebar.js
@@ -1,0 +1,16 @@
+import { ref } from "vue";
+
+/**
+ * The filter panel renders inline at lg+ (>=1024px) and as a slide-over drawer
+ * below lg. It should start open on wide screens (where it costs no content
+ * space) and closed on tablet/phone (where it would otherwise cover the data).
+ *
+ * @returns {import('vue').Ref<boolean>}
+ */
+export const useFilterSidebar = () => {
+    const isDesktop =
+        typeof window !== "undefined" &&
+        window.matchMedia("(min-width: 1024px)").matches;
+
+    return ref(isDesktop);
+};

--- a/resources/js/Layouts/AdminLayout.vue
+++ b/resources/js/Layouts/AdminLayout.vue
@@ -1,5 +1,5 @@
 <script setup>
-    import { computed, ref } from "vue";
+    import { computed, ref, onMounted, onUnmounted } from "vue";
     import { router, Head, Link, usePage } from "@inertiajs/vue3";
     import ApplicationLogo from "@/Components/ApplicationLogo.vue";
     import Banner from "@/Components/Banner.vue";
@@ -24,6 +24,19 @@
     const logout = () => {
         router.post(route("admin.logout"));
     };
+
+    // Auto-close the mobile menu after navigating (tablet/mobile).
+    let stopNavigationListener = null;
+    onMounted(() => {
+        stopNavigationListener = router.on("navigate", () => {
+            showingSidebar.value = false;
+        });
+    });
+    onUnmounted(() => {
+        if (stopNavigationListener) {
+            stopNavigationListener();
+        }
+    });
 </script>
 
 <template>
@@ -32,13 +45,13 @@
 
         <Banner />
 
-        <div class="xl:flex xl:h-screen xl:overflow-hidden">
+        <div class="lg:flex lg:h-screen lg:overflow-hidden">
 
             <!-- SIDEBAR -->
-            <aside class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 xl:flex xl:w-64 xl:shrink-0 xl:flex-col xl:border-b-0 xl:border-e xl:border-e-gray-200 dark:xl:border-e-gray-700">
+            <aside class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 lg:flex lg:w-64 lg:shrink-0 lg:flex-col lg:border-b-0 lg:border-e lg:border-e-gray-200 dark:lg:border-e-gray-700">
 
                 <!-- Mobile header -->
-                <div class="flex h-14 shrink-0 items-center justify-between px-4 xl:hidden">
+                <div class="flex h-14 shrink-0 items-center justify-between px-4 lg:hidden">
                     <Link :href="route('admin.dashboard')" class="inline-flex items-center gap-x-2">
                         <ApplicationLogo class="h-8 w-auto" />
                         <span class="text-lg font-bold tracking-tight text-gray-900 dark:text-white">Admin</span>
@@ -57,7 +70,7 @@
                 </div>
 
                 <!-- Desktop logo header -->
-                <div class="hidden h-16 shrink-0 items-center justify-center border-b border-gray-100 px-5 dark:border-gray-800 xl:flex">
+                <div class="hidden h-16 shrink-0 items-center justify-center border-b border-gray-100 px-5 dark:border-gray-800 lg:flex">
                     <Link :href="route('admin.dashboard')" class="group inline-flex items-center gap-x-2.5">
                         <ApplicationLogo class="h-8 w-auto transition-transform duration-200 group-hover:scale-105" />
                         <span class="text-xl font-bold tracking-tight text-gray-900 dark:text-white">NamaIn</span>
@@ -67,7 +80,7 @@
                 <!-- Nav body -->
                 <div
                     :class="showingSidebar ? 'block' : 'hidden'"
-                    class="xl:flex xl:flex-1 xl:flex-col xl:overflow-y-auto px-4 py-5"
+                    class="lg:flex lg:flex-1 lg:flex-col lg:overflow-y-auto px-4 py-5"
                 >
                     <!-- Admin badge -->
                     <div class="mb-4 flex items-center gap-x-2 px-3">
@@ -187,7 +200,7 @@
                 <!-- User footer -->
                 <div
                     :class="showingSidebar ? 'block' : 'hidden'"
-                    class="xl:block shrink-0 border-t border-gray-100 dark:border-gray-800"
+                    class="lg:block shrink-0 border-t border-gray-100 dark:border-gray-800"
                 >
                     <div class="flex items-center gap-x-3 px-4 py-3">
                         <div
@@ -201,10 +214,10 @@
                         </div>
                         <button
                             type="button"
-                            class="inline-flex items-center justify-center rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300 transition-colors duration-200 focus:outline-none"
+                            class="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg p-2.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300 transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-emerald-500"
                             @click.prevent="logout"
                         >
-                            <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
                             </svg>
                         </button>
@@ -213,8 +226,8 @@
             </aside>
 
             <!-- CONTENT AREA -->
-            <div class="flex min-h-0 flex-1 flex-col xl:overflow-hidden">
-                <main class="xl:flex-1 xl:overflow-y-auto">
+            <div class="flex min-h-0 flex-1 flex-col lg:overflow-hidden">
+                <main class="lg:flex-1 lg:overflow-y-auto">
                     <div class="px-4 py-10 sm:px-6 lg:px-8 2xl:container 2xl:mx-auto">
                         <Flash />
                         <ErrorToast />

--- a/resources/js/Pages/Admin/Backups.vue
+++ b/resources/js/Pages/Admin/Backups.vue
@@ -161,7 +161,7 @@
                         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 rtl:text-right">{{ __('Keep Last') }}</label>
                         <input
                             v-model.number="settingsForm.retention_count"
-                            type="number"
+                            type="number" inputmode="decimal"
                             min="1"
                             max="100"
                             class="w-20 px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"

--- a/resources/js/Pages/Cheques/Create.vue
+++ b/resources/js/Pages/Cheques/Create.vue
@@ -228,7 +228,7 @@
                             <div class="relative mt-1">
                                 <TextInput
                                     v-model="cheque.amount"
-                                    type="number"
+                                    type="number" inputmode="decimal"
                                     step="0.01"
                                     class="w-full pr-12 text-lg font-bold"
                                     :class="isCredit(cheque) ? 'text-emerald-600 focus:border-emerald-500' : 'text-red-600 focus:border-red-500'"

--- a/resources/js/Pages/Cheques/Edit.vue
+++ b/resources/js/Pages/Cheques/Edit.vue
@@ -256,7 +256,7 @@
                                 <div class="relative mt-1">
                                     <TextInput
                                         v-model="form.amount"
-                                        type="number"
+                                        type="number" inputmode="decimal"
                                         step="0.01"
                                         class="w-full pr-12 text-lg font-bold"
                                         :class="isCredit(form) ? 'text-emerald-600 focus:border-emerald-500' : 'text-red-600 focus:border-red-500'"

--- a/resources/js/Pages/Cheques/Index.vue
+++ b/resources/js/Pages/Cheques/Index.vue
@@ -7,6 +7,7 @@
     import debounce from "lodash/debounce";
     import EmptySearch from "@/Shared/EmptySearch.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import CustomSelect from "@/Components/CustomSelect.vue";
     const props = defineProps({
         initialCheques: Object,
@@ -15,7 +16,7 @@
         bank_treasury_accounts: Array,
     });
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
 
     const formatCurrency = (amount, currency = null) => {
         const validCurrency = (currency && /^[A-Z]{3}$/.test(currency)) ? currency : 'SDG';
@@ -215,6 +216,7 @@
         <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
             <FilterSidebar
                 v-if="showSidebar"
+                @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
                 :all-label="__('All Cheques')"

--- a/resources/js/Pages/Customers/Account.vue
+++ b/resources/js/Pages/Customers/Account.vue
@@ -405,7 +405,7 @@ const formatDate = (dateString) => {
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 rtl:text-right mb-1">{{ __("Amount") }}</label>
                                 <input
                                     v-model="advanceForm.amount"
-                                    type="number"
+                                    type="number" inputmode="decimal"
                                     step="0.01"
                                     min="0.01"
                                     required
@@ -537,7 +537,7 @@ const formatDate = (dateString) => {
                                         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 rtl:text-right mb-1">{{ __("Settlement Amount") }}</label>
                                         <input
                                             v-model="settleForm.amount"
-                                            type="number"
+                                            type="number" inputmode="decimal"
                                             step="0.01"
                                             :max="settlingAdvance.remaining_balance"
                                             min="0.01"
@@ -566,7 +566,7 @@ const formatDate = (dateString) => {
                                         </label>
                                         <input
                                             v-model="settleForm.invoice_id"
-                                            type="number"
+                                            type="number" inputmode="decimal"
                                             placeholder="Invoice ID"
                                             class="w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 placeholder-gray-400 dark:placeholder-gray-600"
                                         />

--- a/resources/js/Pages/Customers/Index.vue
+++ b/resources/js/Pages/Customers/Index.vue
@@ -10,6 +10,7 @@
     import { useQueryString } from "@/Composables/useQueryString";
     import { usePermissions } from "@/Composables/usePermissions";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import ImportModal from "@/Shared/ImportModal.vue";
     import Tooltip from "@/Components/Tooltip.vue";
     import { useDate } from '@/Composables/useDate';
@@ -31,7 +32,7 @@
 
     const { formatDate } = useDate();
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
 
     const showImportModal = ref(false);
 
@@ -179,6 +180,7 @@
                 <!-- Sidebar -->
                 <FilterSidebar
                     v-if="showSidebar"
+                    @close="showSidebar = false"
                     v-model:filters="filters"
                     :categories="categories"
                     :sort-by-options="sortByOptions"
@@ -254,9 +256,9 @@
                                         </div>
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-end text-sm font-medium">
-                                        <div class="flex items-center justify-end gap-x-2">
-                                            <Link @click.stop :href="route('customers.account', customer.id)" class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Statement')">
-                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                        <div class="flex items-center justify-end gap-x-3">
+                                            <Link @click.stop :href="route('customers.account', customer.id)" class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Statement')">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                                                     <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
                                                 </svg>
                                             </Link>

--- a/resources/js/Pages/Expenses/Create.vue
+++ b/resources/js/Pages/Expenses/Create.vue
@@ -82,7 +82,7 @@ const submit = () => {
                             <TextInput
                                 v-model="form.amount"
                                 id="amount"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 step="0.01"
                                 class="block w-full"
                                 required

--- a/resources/js/Pages/Expenses/Edit.vue
+++ b/resources/js/Pages/Expenses/Edit.vue
@@ -104,7 +104,7 @@ const formatDate = (date) => {
                             <TextInput
                                 v-model="form.amount"
                                 id="amount"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 step="0.01"
                                 class="block w-full"
                                 required

--- a/resources/js/Pages/Expenses/Index.vue
+++ b/resources/js/Pages/Expenses/Index.vue
@@ -6,6 +6,7 @@ import debounce from "lodash/debounce";
 import Pagination from "@/Shared/Pagination.vue";
 import EmptySearch from "@/Shared/EmptySearch.vue";
 import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 import CustomSelect from "@/Components/CustomSelect.vue";
 import { useQueryString } from "@/Composables/useQueryString";
 
@@ -17,7 +18,7 @@ defineProps({
     spending_by_category: Array,
 });
 
-const showSidebar = ref(true);
+const showSidebar = useFilterSidebar();
 
 const filters = ref({
     search: useQueryString("search").value,
@@ -161,6 +162,7 @@ const getBudgetColor = (budget) => {
             <div class="flex flex-col lg:flex-row gap-8 mt-8">
                 <FilterSidebar
                     v-if="showSidebar"
+                    @close="showSidebar = false"
                     v-model:filters="filters"
                     @reset="resetFilters"
                     :categories="categories"
@@ -193,11 +195,11 @@ const getBudgetColor = (budget) => {
                         <div class="grid grid-cols-2 gap-2">
                             <div class="space-y-2">
                                 <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Min") }}</label>
-                                <input v-model="filters.min_amount" type="number" step="0.01" class="block w-full py-2 px-3 text-xs text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-emerald-400 focus:ring-emerald-300 focus:outline-none focus:ring focus:ring-opacity-40" />
+                                <input v-model="filters.min_amount" type="number" inputmode="decimal" step="0.01" class="block w-full py-2 px-3 text-xs text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-emerald-400 focus:ring-emerald-300 focus:outline-none focus:ring focus:ring-opacity-40" />
                             </div>
                             <div class="space-y-2">
                                 <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Max") }}</label>
-                                <input v-model="filters.max_amount" type="number" step="0.01" class="block w-full py-2 px-3 text-xs text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-emerald-400 focus:ring-emerald-300 focus:outline-none focus:ring focus:ring-opacity-40" />
+                                <input v-model="filters.max_amount" type="number" inputmode="decimal" step="0.01" class="block w-full py-2 px-3 text-xs text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-emerald-400 focus:ring-emerald-300 focus:outline-none focus:ring focus:ring-opacity-40" />
                             </div>
                         </div>
 
@@ -287,27 +289,27 @@ const getBudgetColor = (budget) => {
                                                 </div>
                                             </td>
                                             <td class="px-4 py-4 text-sm whitespace-nowrap text-right rtl:text-left">
-                                                <div class="flex items-center justify-end gap-x-2" @click.stop>
+                                                <div class="flex items-center justify-end gap-x-3" @click.stop>
                                                     <template v-if="expense.status === 'pending'">
-                                                        <button @click="approveExpense(expense.id)" class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Approve')">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
+                                                        <button @click="approveExpense(expense.id)" class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Approve')">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
                                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                                                             </svg>
                                                         </button>
-                                                        <button @click="rejectExpense(expense.id)" class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:text-gray-500 dark:hover:text-red-400 dark:hover:bg-red-900/20 rounded-lg transition-all" :title="__('Reject')">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
+                                                        <button @click="rejectExpense(expense.id)" class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:text-gray-500 dark:hover:text-red-400 dark:hover:bg-red-900/20 rounded-lg transition-all" :title="__('Reject')">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
                                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                                                             </svg>
                                                         </button>
                                                     </template>
-                                                    <Link :href="route('expenses.show', expense.id)" class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Details')">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                                    <Link :href="route('expenses.show', expense.id)" class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Details')">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                                                             <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
                                                             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                                         </svg>
                                                     </Link>
-                                                    <Link :href="route('expenses.edit', expense.id)" class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Edit')">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                                    <Link :href="route('expenses.edit', expense.id)" class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Edit')">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                                                             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
                                                         </svg>
                                                     </Link>

--- a/resources/js/Pages/Expenses/RecurringCreate.vue
+++ b/resources/js/Pages/Expenses/RecurringCreate.vue
@@ -73,7 +73,7 @@ const submit = () => {
                             <TextInput
                                 v-model="form.amount"
                                 id="amount"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 step="0.01"
                                 class="block w-full"
                                 required

--- a/resources/js/Pages/Expenses/RecurringEdit.vue
+++ b/resources/js/Pages/Expenses/RecurringEdit.vue
@@ -74,7 +74,7 @@ const submit = () => {
                             <TextInput
                                 v-model="form.amount"
                                 id="amount"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 step="0.01"
                                 class="block w-full"
                                 required

--- a/resources/js/Pages/Payments/Create.vue
+++ b/resources/js/Pages/Payments/Create.vue
@@ -268,7 +268,7 @@ const submit = () => {
                     <TextInput
                         id="amount"
                         v-model="form.amount"
-                        type="number"
+                        type="number" inputmode="decimal"
                         step="0.01"
                         class="block w-full"
                         required

--- a/resources/js/Pages/Payments/Index.vue
+++ b/resources/js/Pages/Payments/Index.vue
@@ -4,6 +4,7 @@ import { Link, router } from "@inertiajs/vue3";
 import Pagination from "@/Shared/Pagination.vue";
 import EmptySearch from "@/Shared/EmptySearch.vue";
 import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 import DatePicker from "@/Components/DatePicker.vue";
 import { watch, ref, computed, onMounted, onUnmounted } from "vue";
 import { useQueryString } from "@/Composables/useQueryString";
@@ -16,7 +17,7 @@ const props = defineProps({
     payment_methods: [Object, Array],
 });
 
-const showSidebar = ref(true);
+const showSidebar = useFilterSidebar();
 const selectedPayment = ref(null);
 
 const filters = ref({
@@ -262,6 +263,7 @@ watch(
             <!-- Sidebar -->
             <FilterSidebar
                 v-if="showSidebar"
+                @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
                 :all-label="__('All Payments')"
@@ -271,7 +273,7 @@ watch(
                     <!-- Direction Pills -->
                     <div class="space-y-2">
                         <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Direction") }}</label>
-                        <div class="flex bg-gray-50 border border-gray-200 divide-x divide-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700 rtl:flex-row-reverse rtl:divide-x-reverse h-9">
+                        <div class="flex bg-gray-50 border border-gray-200 divide-x divide-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700 rtl:flex-row-reverse rtl:divide-x-reverse h-11">
                             <button
                                 v-for="opt in [
                                     { label: __('All'), value: null },
@@ -333,7 +335,7 @@ watch(
                     <!-- Party Type Pills -->
                     <div class="space-y-2">
                         <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Party Type") }}</label>
-                        <div class="flex bg-gray-50 border border-gray-200 divide-x divide-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700 rtl:flex-row-reverse rtl:divide-x-reverse h-9">
+                        <div class="flex bg-gray-50 border border-gray-200 divide-x divide-gray-200 rounded-lg dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700 rtl:flex-row-reverse rtl:divide-x-reverse h-11">
                             <button
                                 v-for="opt in [
                                     { label: __('All'), value: null },
@@ -367,56 +369,56 @@ watch(
                                 <tr>
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         #
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Party") }}
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Amount") }}
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Method") }}
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Treasury") }}
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Reference") }}
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Invoice Balance") }}
                                     </th>
 
                                     <th
                                         scope="col"
-                                        class="px-6 py-4 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"
                                     >
                                         {{ __("Date") }}
                                     </th>
@@ -435,11 +437,11 @@ watch(
                                     class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200 cursor-pointer"
                                     @click="selectedPayment = payment"
                                 >
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                         {{ payment.id }}
                                     </td>
 
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm">
                                         <div class="flex flex-col">
                                             <span class="font-medium text-gray-900 dark:text-white">
                                                 {{
@@ -461,7 +463,7 @@ watch(
                                         </div>
                                     </td>
 
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm font-semibold">
                                         <div class="flex items-center gap-x-1.5">
                                             <span
                                                 class="inline-flex items-center justify-center w-5 h-5 rounded-full shrink-0"
@@ -514,7 +516,7 @@ watch(
                                         </div>
                                     </td>
 
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm">
                                         <span
                                             class="px-2 py-1 text-xs rounded-full"
                                             :class="{
@@ -533,20 +535,20 @@ watch(
                                     </td>
 
                                     <td
-                                        class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
                                     >
                                         {{ payment.treasury_account?.name ?? "—" }}
                                     </td>
 
                                     <td
-                                        class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
                                     >
                                         <span class="truncate max-w-[120px] block">
                                             {{ payment.reference ?? "—" }}
                                         </span>
                                     </td>
 
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm">
                                         <template v-if="payment.invoice">
                                             <span
                                                 :class="payment.invoice.remaining_balance > 0
@@ -560,15 +562,15 @@ watch(
                                     </td>
 
                                     <td
-                                        class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
+                                        class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
                                     >
                                         {{ formatDate(payment.paid_at) }}
                                     </td>
 
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-end">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-sm text-end">
                                         <button
                                             @click.stop="selectedPayment = payment"
-                                            class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all"
+                                            class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all"
                                             :title="__('Details')"
                                         >
                                             <svg
@@ -577,7 +579,7 @@ watch(
                                                 viewBox="0 0 24 24"
                                                 stroke-width="1.5"
                                                 stroke="currentColor"
-                                                class="w-4 h-4 rtl:rotate-180"
+                                                class="w-5 h-5 rtl:rotate-180"
                                             >
                                                 <path
                                                     stroke-linecap="round"

--- a/resources/js/Pages/Pos/Open.vue
+++ b/resources/js/Pages/Pos/Open.vue
@@ -58,7 +58,7 @@ const submit = () => {
                             <TextInput
                                 id="opening_float"
                                 v-model="form.opening_float"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 step="0.01"
                                 class="block w-full ltr:ps-12 rtl:pe-12"
                                 required

--- a/resources/js/Pages/Pos/Session.vue
+++ b/resources/js/Pages/Pos/Session.vue
@@ -205,7 +205,7 @@ const paymentMethodLabels = [
 
 <template>
     <AppLayout :title="__('POS Session')">
-        <div class="flex flex-col lg:flex-row h-[calc(100vh-120px)] gap-4">
+        <div class="flex flex-col md:flex-row h-[calc(100dvh-120px)] min-h-0 gap-4">
 
             <!-- Products column -->
             <div class="flex-grow flex flex-col min-w-0 gap-3">
@@ -221,7 +221,7 @@ const paymentMethodLabels = [
             </div>
 
             <!-- Cart Sidebar -->
-            <div class="w-full lg:w-96 flex flex-col bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
+            <div class="w-full md:w-80 lg:w-96 shrink-0 flex flex-col min-h-0 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl shadow-sm overflow-hidden">
 
                 <!-- Cart header -->
                 <div class="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center">
@@ -232,11 +232,11 @@ const paymentMethodLabels = [
                         <h2 class="text-base font-bold text-gray-900 dark:text-white">{{ __('Cart') }}</h2>
                         <span v-if="cart.length > 0" class="inline-flex items-center justify-center w-5 h-5 text-[10px] font-bold rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">{{ cart.length }}</span>
                     </div>
-                    <button @click="showingCloseModal = true" class="text-xs font-semibold text-red-500 hover:text-red-600 transition-colors uppercase tracking-wider">{{ __('Close Session') }}</button>
+                    <button @click="showingCloseModal = true" class="inline-flex items-center min-h-[44px] px-3 py-2 -me-2 text-xs font-semibold text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/10 rounded-lg transition-colors uppercase tracking-wider focus:outline-none focus:ring-2 focus:ring-red-500">{{ __('Close Session') }}</button>
                 </div>
 
                 <!-- Cart items -->
-                <div class="flex-grow overflow-y-auto p-4 space-y-2">
+                <div class="flex-grow overflow-y-auto overscroll-contain p-4 space-y-2">
                     <div v-if="cart.length === 0" class="h-full flex flex-col items-center justify-center text-center text-gray-400 py-12">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mb-4 opacity-20">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
@@ -247,7 +247,7 @@ const paymentMethodLabels = [
                     <div v-for="(item, index) in cart" :key="index" class="flex flex-col p-3 rounded-xl border transition-colors" :class="item.sale_point_qty < item.quantity ? 'bg-amber-50 dark:bg-amber-900/10 border-amber-200 dark:border-amber-800' : 'bg-gray-50 dark:bg-gray-800/50 border-transparent'">
                         <div class="flex items-start justify-between gap-x-2 mb-2">
                             <p class="text-sm font-semibold text-gray-900 dark:text-white leading-snug">{{ item.name }}</p>
-                            <button @click="removeFromCart(index)" class="text-gray-300 hover:text-red-500 transition-colors shrink-0 mt-0.5">
+                            <button @click="removeFromCart(index)" class="flex items-center justify-center min-w-[44px] min-h-[44px] -m-2.5 text-gray-400 dark:text-gray-500 hover:text-red-500 transition-colors shrink-0">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
                             </button>
                         </div>
@@ -258,17 +258,17 @@ const paymentMethodLabels = [
                             </select>
                             <div class="flex items-center gap-x-1 flex-1">
                                 <span class="text-[10px] text-gray-400 shrink-0">{{ currency }}</span>
-                                <input type="number" :value="item.price" @input="updateItemPrice(item, $event.target.value)" class="w-full text-xs py-1 px-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:ring-emerald-500 focus:border-emerald-500" />
+                                <input type="number" inputmode="decimal" :value="item.price" @input="updateItemPrice(item, $event.target.value)" class="w-full text-xs py-1 px-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:ring-emerald-500 focus:border-emerald-500" />
                             </div>
                         </div>
                         <div class="flex items-center justify-between">
                             <div class="flex items-center gap-x-1">
-                                <button @click="updateItemQuantity(item, -1)" class="w-7 h-7 flex items-center justify-center rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-emerald-500 hover:text-white hover:border-emerald-500 transition-colors">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M20 12H4" /></svg>
+                                <button @click="updateItemQuantity(item, -1)" class="w-11 h-11 flex items-center justify-center rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-emerald-500 hover:text-white hover:border-emerald-500 transition-colors">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M20 12H4" /></svg>
                                 </button>
-                                <input type="number" v-model.number="item.quantity" class="w-10 text-center text-sm font-bold py-1 px-0 bg-transparent border-0 focus:ring-0" min="1" />
-                                <button @click="updateItemQuantity(item, 1)" class="w-7 h-7 flex items-center justify-center rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-emerald-500 hover:text-white hover:border-emerald-500 transition-colors">
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4" /></svg>
+                                <input type="number" inputmode="numeric" v-model.number="item.quantity" class="h-11 w-12 text-center text-base font-bold py-1 px-0 bg-transparent border-0 focus:ring-0" min="1" />
+                                <button @click="updateItemQuantity(item, 1)" class="w-11 h-11 flex items-center justify-center rounded-lg bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:bg-emerald-500 hover:text-white hover:border-emerald-500 transition-colors">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4" /></svg>
                                 </button>
                             </div>
                             <span class="text-sm font-bold text-gray-900 dark:text-white">{{ fmt(item.quantity * item.price) }}</span>
@@ -300,7 +300,7 @@ const paymentMethodLabels = [
                                 <button type="button" class="px-2.5 py-1.5 text-xs font-semibold transition-colors" :class="discountType === 'percent' ? 'bg-emerald-600 text-white' : 'bg-white dark:bg-gray-900 text-gray-500 dark:text-gray-400 hover:bg-gray-50'" @click="discountType = 'percent'">%</button>
                                 <button type="button" class="px-2.5 py-1.5 text-xs font-semibold transition-colors" :class="discountType === 'flat' ? 'bg-emerald-600 text-white' : 'bg-white dark:bg-gray-900 text-gray-500 dark:text-gray-400 hover:bg-gray-50'" @click="discountType = 'flat'">{{ currency }}</button>
                             </div>
-                            <input v-model="discountValue" type="number" min="0" :max="discountType === 'percent' ? 100 : cartSubtotal" :placeholder="discountType === 'percent' ? '0' : '0.00'" class="flex-1 text-sm px-3 py-1.5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50" />
+                            <input v-model="discountValue" type="number" inputmode="decimal" min="0" :max="discountType === 'percent' ? 100 : cartSubtotal" :placeholder="discountType === 'percent' ? '0' : '0.00'" class="flex-1 text-sm px-3 py-1.5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50" />
                             <span v-if="discountAmount > 0" class="text-xs font-semibold text-red-500 shrink-0">-{{ fmt(discountAmount) }}</span>
                         </div>
                     </div>

--- a/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
+++ b/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
@@ -182,7 +182,7 @@
                 <TextInput
                     id="pecentage"
                     v-model="form.pecentage"
-                    type="number"
+                    type="number" inputmode="decimal"
                     min="0"
                     max="100"
                     placeholder="60"

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -12,6 +12,7 @@
     import ProductAdjustmentModal from "@/Components/Products/ProductAdjustmentModal.vue";
     import TextInput from "@/Components/TextInput.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import Tooltip from "@/Components/Tooltip.vue";
 
     const props = defineProps({
@@ -20,7 +21,7 @@
         storages: Array,
     });
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
 
     const showImportModal = ref(false);
 
@@ -375,6 +376,7 @@
                 <!-- Sidebar -->
                 <FilterSidebar
                     v-if="showSidebar"
+                    @close="showSidebar = false"
                     v-model:filters="filters"
                     :categories="categories"
                     :sort-by-options="sortByOptions"
@@ -386,8 +388,8 @@
                         <div class="space-y-2">
                             <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Cost Range") }}</label>
                             <div class="grid grid-cols-2 gap-2">
-                                <TextInput v-model="filters.min_cost" type="number" :placeholder="__('Min')" class="w-full text-xs" />
-                                <TextInput v-model="filters.max_cost" type="number" :placeholder="__('Max')" class="w-full text-xs" />
+                                <TextInput v-model="filters.min_cost" type="number" inputmode="decimal" :placeholder="__('Min')" class="w-full text-xs" />
+                                <TextInput v-model="filters.max_cost" type="number" inputmode="decimal" :placeholder="__('Max')" class="w-full text-xs" />
                             </div>
                         </div>
 
@@ -410,9 +412,9 @@
                             <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                                 <thead class="bg-gray-50/50 dark:bg-gray-800/40">
                                 <tr>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Product") }}</th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Status") }}</th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em] leading-tight">
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Product") }}</th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Status") }}</th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em] leading-tight">
                                         <div class="flex items-center gap-x-1">
                                             {{ __("Stock & Available") }}
                                             <Tooltip :text="__('Stock is physical quantity on hand, Available is stock minus pending sales')" position="bottom">
@@ -422,16 +424,16 @@
                                             </Tooltip>
                                         </div>
                                     </th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Cost") }}</th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Avg Cost") }}</th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Price") }}</th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Total Value") }}</th>
-                                    <th scope="col" class="px-6 py-4 text-[10px] font-bold text-end text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"></th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Cost") }}</th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Avg Cost") }}</th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Price") }}</th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-start text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]">{{ __("Total Value") }}</th>
+                                    <th scope="col" class="px-3 py-4 lg:px-6 text-[10px] font-bold text-end text-gray-400 dark:text-gray-500 uppercase tracking-[0.1em]"></th>
                                 </tr>
                                 </thead>
                                 <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60">
                                 <tr v-for="product in products.data" :key="product.id" @click="router.visit(route('products.show', product.id))" class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200 cursor-pointer">
-                                    <td class="px-6 py-4 whitespace-nowrap">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap">
                                         <div class="flex items-center gap-x-3">
                                             <div>
                                                 <div class="text-sm font-bold text-gray-900 dark:text-white group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors leading-snug">{{ product.name }}</div>
@@ -444,7 +446,7 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td class="px-6 py-4">
+                                    <td class="px-3 py-4 lg:px-6">
                                         <div class="flex flex-col gap-y-1.5">
                                             <div :class="['inline-flex items-center gap-x-1.5 px-2.5 py-1 text-[11px] font-bold rounded-lg border w-fit leading-tight', getStockStatus(product).color]">
                                                 <span v-html="getStockStatus(product).icon"></span>
@@ -463,7 +465,7 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td class="px-6 py-4">
+                                    <td class="px-3 py-4 lg:px-6">
                                         <div class="flex flex-col gap-y-1">
                                             <div class="flex items-end gap-x-2">
                                                 <span class="text-sm font-bold text-gray-900 dark:text-white">{{ product.stock.reduce((sum, s) => sum + s.pivot.quantity, 0) }}</span>
@@ -487,26 +489,26 @@
                                             </div>
                                         </div>
                                     </td>
-                                    <td class="px-6 py-4 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                                    <td class="px-3 py-4 lg:px-6 text-sm font-semibold text-gray-700 dark:text-gray-300">
                                         {{ formatCurrency(product.cost, product.currency) }}
                                     </td>
-                                    <td class="px-6 py-4 text-sm font-bold">
+                                    <td class="px-3 py-4 lg:px-6 text-sm font-bold">
                                         <div class="text-emerald-600 dark:text-emerald-400 bg-emerald-50/50 dark:bg-emerald-400/5 px-2 py-1 rounded-md w-fit leading-tight">
                                             {{ formatCurrency(product.average_cost, product.currency) }}
                                         </div>
                                     </td>
-                                    <td class="px-6 py-4 text-sm font-semibold text-gray-700 dark:text-gray-300">
+                                    <td class="px-3 py-4 lg:px-6 text-sm font-semibold text-gray-700 dark:text-gray-300">
                                         {{ formatCurrency(product.price, product.currency) }}
                                     </td>
-                                    <td class="px-6 py-4">
+                                    <td class="px-3 py-4 lg:px-6">
                                         <div class="text-sm font-bold text-gray-900 dark:text-white leading-tight">
                                             {{ formatCurrency(product.stock.reduce((sum, s) => sum + s.pivot.quantity, 0) * product.average_cost, product.currency) }}
                                         </div>
                                     </td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-end text-sm font-medium">
-                                        <div class="flex items-center justify-end gap-x-2">
-                                            <Link @click.stop :href="route('products.show', product.id)" class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Details')">
-                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                    <td class="px-3 py-4 lg:px-6 whitespace-nowrap text-end text-sm font-medium">
+                                        <div class="flex items-center justify-end gap-x-3">
+                                            <Link @click.stop :href="route('products.show', product.id)" class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all" :title="__('Details')">
+                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                                                     <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
                                                 </svg>
                                             </Link>
@@ -582,7 +584,7 @@
                                                 <input
                                                     v-model="newProductForm.cost"
                                                     name="new-cost"
-                                                    type="number"
+                                                    type="number" inputmode="decimal"
                                                     step="0.01"
                                                     class="w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 placeholder-gray-400 dark:placeholder-gray-600 ltr:pr-14 rtl:pl-14"
                                                     :placeholder="__('0.00')"
@@ -598,7 +600,7 @@
                                                 <input
                                                     v-model="newProductForm.price"
                                                     name="new-price"
-                                                    type="number"
+                                                    type="number" inputmode="decimal"
                                                     step="0.01"
                                                     class="w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 placeholder-gray-400 dark:placeholder-gray-600 ltr:pr-14 rtl:pl-14"
                                                     :placeholder="__('0.00')"
@@ -680,7 +682,7 @@
                                             <label class="block text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1 rtl:text-right">{{ __("Cost") }}</label>
                                             <div class="relative">
                                                 <input
-                                                    type="number"
+                                                    type="number" inputmode="decimal"
                                                     name="cost"
                                                     step="0.01"
                                                     :value="getDraft(product.id).cost !== undefined ? getDraft(product.id).cost : product.cost"
@@ -696,7 +698,7 @@
                                             <label class="block text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1 rtl:text-right">{{ __("Price") }}</label>
                                             <div class="relative">
                                                 <input
-                                                    type="number"
+                                                    type="number" inputmode="decimal"
                                                     name="price"
                                                     step="0.01"
                                                     :value="getDraft(product.id).price !== undefined ? getDraft(product.id).price : product.price"

--- a/resources/js/Pages/Purchases/Card.vue
+++ b/resources/js/Pages/Purchases/Card.vue
@@ -49,16 +49,16 @@
 
             <div class="flex-col gap-4 mt-4 sm:flex-row sm:items-center md:mt-0">
                 <h2 v-text="invoice.invocable.name" class="text-gray-900 text-xl mb-3"></h2>
-                <div class="flex flex rtl:flex-row-reverse space-x-4">
+                <div class="flex rtl:flex-row-reverse gap-x-3">
                     <a
                         v-if="printable"
                         :href="route('invoices.print', invoice)"
                         target="_blank"
-                        class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="__('Print')"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                             stroke="currentColor" class="w-4 h-4">
+                             stroke="currentColor" class="w-5 h-5">
                             <path stroke-linecap="round" stroke-linejoin="round"
                                   d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0110.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0l.229 2.523a1.125 1.125 0 01-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0021 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 00-1.913-.247M6.34 18H5.25A2.25 2.25 0 013 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 011.913-.247m10.5 0a48.536 48.536 0 00-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M18 10.5h.008v.008H18V10.5zm-3 0h.008v.008H15V10.5z" />
                         </svg>
@@ -67,11 +67,11 @@
                     <button
                         v-if="!invoice.locked"
                         @click="moveToStorage(invoice)"
-                        class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="actionTitle"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
-                             stroke="currentColor" class="w-4 h-4">
+                             stroke="currentColor" class="w-5 h-5">
                             <path stroke-linecap="round" stroke-linejoin="round"
                                   d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
                         </svg>
@@ -80,10 +80,10 @@
                     <Link
                         v-if="invoice.is_editable"
                         :href="route(`${resourcePrefix}.edit`, invoice)"
-                        class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="__('Edit Invoice')"
                     >
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
                         </svg>
                     </Link>
@@ -91,10 +91,10 @@
                     <Link
                         v-if="invoice.can_be_inversed"
                         :href="route(`${resourcePrefix}.return.create`, invoice)"
-                        class="p-2 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="__('Return Items')"
                     >
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
                         </svg>
                     </Link>

--- a/resources/js/Pages/Purchases/Index.vue
+++ b/resources/js/Pages/Purchases/Index.vue
@@ -11,6 +11,7 @@
     import Dropdown from "@/Components/Dropdown.vue";
     import DropdownLink from "@/Components/DropdownLink.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import { useQueryString } from "@/Composables/useQueryString";
     import debounce from "lodash/debounce";
     import axios from "axios";
@@ -26,7 +27,7 @@
     const selectedStorage = ref(null);
     const showInvoiceSelector = ref(false);
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
 
     const invoicesToReturn = ref([]);
     const searchingInvoices = ref(false);
@@ -186,6 +187,7 @@
             <!-- Sidebar -->
             <FilterSidebar
                 v-if="showSidebar"
+                @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
                 :all-label="__('All Invoices')"

--- a/resources/js/Pages/Purchases/Return.vue
+++ b/resources/js/Pages/Purchases/Return.vue
@@ -111,7 +111,7 @@ const submit = () => {
                                     <td class="px-6 py-4">
                                         <div class="flex justify-center">
                                             <TextInput
-                                                type="number"
+                                                type="number" inputmode="decimal"
                                                 v-model="item.quantity"
                                                 min="0"
                                                 :max="item.max_quantity"
@@ -209,7 +209,7 @@ const submit = () => {
                         <div>
                             <InputLabel :value="__('Refund Amount')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
                             <TextInput
-                                type="number"
+                                type="number" inputmode="decimal"
                                 v-model="form.refund_amount"
                                 min="0"
                                 :max="totalReturn"

--- a/resources/js/Pages/Sales/Index.vue
+++ b/resources/js/Pages/Sales/Index.vue
@@ -12,6 +12,7 @@
     import Dropdown from "@/Components/Dropdown.vue";
     import DropdownLink from "@/Components/DropdownLink.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import { useQueryString } from "@/Composables/useQueryString";
     import debounce from "lodash/debounce";
     import axios from "axios";
@@ -27,7 +28,7 @@
     const selectedStorage = ref(null);
     const showInvoiceSelector = ref(false);
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
 
     const invoicesToReturn = ref([]);
     const searchingInvoices = ref(false);
@@ -206,6 +207,7 @@
             <!-- Sidebar -->
             <FilterSidebar
                 v-if="showSidebar"
+                @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
                 :all-label="__('All Invoices')"

--- a/resources/js/Pages/Sales/Return.vue
+++ b/resources/js/Pages/Sales/Return.vue
@@ -111,7 +111,7 @@ const submit = () => {
                                     <td class="px-6 py-4">
                                         <div class="flex justify-center">
                                             <TextInput
-                                                type="number"
+                                                type="number" inputmode="decimal"
                                                 v-model="item.quantity"
                                                 min="0"
                                                 :max="item.max_quantity"
@@ -209,7 +209,7 @@ const submit = () => {
                         <div>
                             <InputLabel :value="__('Refund Amount')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
                             <TextInput
-                                type="number"
+                                type="number" inputmode="decimal"
                                 v-model="form.refund_amount"
                                 min="0"
                                 :max="totalReturn"

--- a/resources/js/Pages/StockTransfers/Create.vue
+++ b/resources/js/Pages/StockTransfers/Create.vue
@@ -145,7 +145,7 @@ const submit = () => {
                                 <InputLabel :value="__('Quantity')" class="mb-1" />
                                 <TextInput
                                     v-model.number="item.quantity"
-                                    type="number"
+                                    type="number" inputmode="decimal"
                                     class="w-full"
                                     min="1"
                                     required

--- a/resources/js/Pages/Storages/Index.vue
+++ b/resources/js/Pages/Storages/Index.vue
@@ -6,6 +6,7 @@
     import StorageForm from "@/Components/Storages/StorageForm.vue";
     import DeleteStorage from "@/Components/Storages/DeleteStorage.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import { watch, ref } from "vue";
     import debounce from "lodash/debounce";
     import { router, Link } from "@inertiajs/vue3";
@@ -28,7 +29,7 @@
 
     const { formatDate } = useDate();
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
 
     const filters = ref({
         search: useQueryString("search").value,
@@ -107,6 +108,7 @@
                 <!-- Sidebar -->
                 <FilterSidebar
                     v-if="showSidebar"
+                    @close="showSidebar = false"
                     v-model:filters="filters"
                     :sort-by-options="sortByOptions"
                     :all-label="__('All Storages')"

--- a/resources/js/Pages/Suppliers/Index.vue
+++ b/resources/js/Pages/Suppliers/Index.vue
@@ -9,6 +9,7 @@
     import EmptySearch from "@/Shared/EmptySearch.vue";
     import { useQueryString } from "@/Composables/useQueryString";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import ImportModal from "@/Shared/ImportModal.vue";
     import Tooltip from "@/Components/Tooltip.vue";
     import { useDate } from '@/Composables/useDate';
@@ -28,7 +29,7 @@
 
     const { formatDate } = useDate();
 
-    const showSidebar = ref(true);
+    const showSidebar = useFilterSidebar();
     const showImportModal = ref(false);
 
     const importForm = useForm({
@@ -156,6 +157,7 @@
                 <!-- Sidebar -->
                 <FilterSidebar
                     v-if="showSidebar"
+                    @close="showSidebar = false"
                     v-model:filters="filters"
                     :categories="categories"
                     :sort-by-options="sortByOptions"

--- a/resources/js/Pages/Treasury/Create.vue
+++ b/resources/js/Pages/Treasury/Create.vue
@@ -167,7 +167,7 @@ watch(() => form.bank_id, (bankId) => {
                             <TextInput
                                 id="opening_balance"
                                 v-model="form.opening_balance"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 min="0"
                                 step="0.01"
                                 class="mt-1 block w-full"

--- a/resources/js/Pages/Treasury/Show.vue
+++ b/resources/js/Pages/Treasury/Show.vue
@@ -214,7 +214,7 @@ const typeBgClass = (type) => {
                             </label>
                             <input
                                 v-model="adjustForm.new_balance"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 min="0"
                                 step="0.01"
                                 class="mt-1 w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"

--- a/resources/js/Pages/Treasury/Transfer/Create.vue
+++ b/resources/js/Pages/Treasury/Transfer/Create.vue
@@ -120,7 +120,7 @@ const submit = () => {
                             <input
                                 id="amount"
                                 v-model="form.amount"
-                                type="number"
+                                type="number" inputmode="decimal"
                                 min="1"
                                 step="0.01"
                                 class="mt-1 w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 placeholder-gray-400 dark:placeholder-gray-600"

--- a/resources/js/Shared/Cheque.vue
+++ b/resources/js/Shared/Cheque.vue
@@ -255,7 +255,7 @@
                     <InputLabel for="cleared_amount" :value="__('Cleared Amount')" />
                     <TextInput
                         id="cleared_amount"
-                        type="number"
+                        type="number" inputmode="decimal"
                         class="mt-1 block w-full"
                         v-model="form.cleared_amount"
                         step="0.01"

--- a/resources/js/Shared/FilterSidebar.vue
+++ b/resources/js/Shared/FilterSidebar.vue
@@ -12,7 +12,7 @@ defineProps({
     }
 });
 
-const emit = defineEmits(['reset', 'update:filters']);
+const emit = defineEmits(['reset', 'update:filters', 'close']);
 
 const resetFilters = () => {
     emit('reset');
@@ -20,13 +20,35 @@ const resetFilters = () => {
 </script>
 
 <template>
-    <aside class="w-full lg:w-72 shrink-0 transition-all duration-300">
-        <div class="sticky top-4 space-y-4">
+    <div class="contents">
+        <!-- Drawer backdrop (below lg) -->
+        <Transition
+            enter-active-class="transition-opacity ease-out duration-200"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-active-class="transition-opacity ease-in duration-150"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0"
+        >
+            <div class="fixed inset-0 z-40 bg-gray-900/50 backdrop-blur-sm lg:hidden" @click="emit('close')" />
+        </Transition>
+
+        <!-- Slide-over drawer below lg; static inline sidebar at lg+ -->
+        <aside class="fixed inset-y-0 start-0 z-50 w-80 max-w-[85vw] overflow-y-auto bg-white dark:bg-gray-900 shadow-xl lg:static lg:z-auto lg:inset-auto lg:w-72 lg:max-w-none lg:overflow-visible lg:bg-transparent lg:shadow-none lg:shrink-0 transition-all duration-300">
+        <div class="sticky top-4 space-y-4 p-4 lg:p-0">
             <!-- Unified Filter Sidebar -->
             <div class="p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl space-y-6 transition-all">
                 <div class="flex items-center justify-between border-b border-gray-100 dark:border-gray-800 pb-4">
                     <h3 class="text-sm font-bold text-gray-900 dark:text-white uppercase tracking-wider">{{ __("Filters") }}</h3>
-                    <button type="button" @click="resetFilters" class="text-xs text-emerald-600 hover:text-emerald-700 font-medium">{{ __("Reset") }}</button>
+                    <div class="flex items-center gap-x-2">
+                        <button type="button" class="text-xs text-emerald-600 hover:text-emerald-700 font-medium" @click="resetFilters">{{ __("Reset") }}</button>
+                        <button type="button" class="lg:hidden inline-flex items-center justify-center w-9 h-9 -me-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500" @click="emit('close')">
+                            <span class="sr-only">{{ __("Close") }}</span>
+                            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                            </svg>
+                        </button>
+                    </div>
                 </div>
 
                 <!-- Search -->
@@ -38,15 +60,15 @@ const resetFilters = () => {
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
                             </svg>
                         </span>
-                        <input :value="filters.search" @input="$emit('update:filters', { ...filters, search: $event.target.value })" type="text" :placeholder="__('Search here') + '...'" class="block w-full py-2 ltr:pl-10 ltr:pr-4 rtl:pr-10 rtl:pl-4 text-xs text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-emerald-400 focus:ring-emerald-300 focus:outline-none focus:ring focus:ring-opacity-40" />
+                        <input :value="filters.search" type="text" :placeholder="__('Search here') + '...'" class="block w-full py-2 ltr:pl-10 ltr:pr-4 rtl:pr-10 rtl:pl-4 text-xs text-gray-700 bg-white border border-gray-200 rounded-lg dark:bg-gray-900 dark:text-gray-300 dark:border-gray-600 focus:border-emerald-400 focus:ring-emerald-300 focus:outline-none focus:ring focus:ring-opacity-40" @input="$emit('update:filters', { ...filters, search: $event.target.value })" />
                     </div>
                 </div>
 
                 <!-- Trash Filter -->
                 <div class="space-y-2 overflow-hidden">
                     <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Status") }}</label>
-                    <div class="flex bg-gray-50 border border-gray-200 divide-x rounded-lg dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700 rtl:flex-row-reverse overflow-hidden h-9">
-                        <TrashFilter :model-value="filters.status" @update:model-value="status => $emit('update:filters', { ...filters, status })" class="w-full" />
+                    <div class="flex bg-gray-50 border border-gray-200 divide-x rounded-lg dark:bg-gray-800 dark:border-gray-700 dark:divide-gray-700 rtl:flex-row-reverse overflow-hidden h-11">
+                        <TrashFilter :model-value="filters.status" class="w-full" @update:model-value="status => $emit('update:filters', { ...filters, status })" />
                     </div>
                 </div>
 
@@ -54,7 +76,7 @@ const resetFilters = () => {
                 <slot name="extra-filters"></slot>
 
                 <!-- Sorting -->
-                <div class="space-y-2" v-if="sortByOptions && sortByOptions.length">
+                <div v-if="sortByOptions && sortByOptions.length" class="space-y-2">
                     <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Sort By") }}</label>
                     <div class="space-y-2">
                         <CustomSelect
@@ -79,29 +101,29 @@ const resetFilters = () => {
                 </div>
 
                 <!-- Categories -->
-                <div class="space-y-3 pt-4 border-t border-gray-100 dark:border-gray-800" v-if="categories && categories.length">
+                <div v-if="categories && categories.length" class="space-y-3 pt-4 border-t border-gray-100 dark:border-gray-800">
                     <label class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Categories") }}</label>
                     <div class="flex flex-col gap-y-1 max-h-64 overflow-y-auto custom-scrollbar pr-1">
                         <button
                             type="button"
-                            @click="$emit('update:filters', { ...filters, category: null })"
                             :class="[
                                 'text-start px-3 py-2 text-xs transition-all duration-200 rounded-t-lg',
                                 !filters.category ? 'bg-emerald-50 text-emerald-700 font-bold border-s-4 border-emerald-500' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                             ]"
+                            @click="$emit('update:filters', { ...filters, category: null })"
                         >
                             {{ allLabel }}
                         </button>
                         <button
-                            type="button"
                             v-for="(category, index) in categories"
                             :key="category.id"
-                            @click="$emit('update:filters', { ...filters, category: String(category.id) })"
+                            type="button"
                             :class="[
                                 'text-start px-3 py-2 text-xs transition-all duration-200',
                                 index === categories.length - 1 ? 'rounded-b-lg' : '',
                                 filters.category == category.id ? 'bg-emerald-50 text-emerald-700 font-bold border-s-4 border-emerald-500' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800'
                             ]"
+                            @click="$emit('update:filters', { ...filters, category: String(category.id) })"
                         >
                             {{ category.name }}
                         </button>
@@ -109,5 +131,6 @@ const resetFilters = () => {
                 </div>
             </div>
         </div>
-    </aside>
+        </aside>
+    </div>
 </template>

--- a/resources/js/Shared/Pagination.vue
+++ b/resources/js/Shared/Pagination.vue
@@ -1,13 +1,13 @@
 <template>
     <div v-if="links.length > 3">
-        <div class="flex flex-wrap mt-8">
+        <div class="flex flex-wrap gap-1 mt-8">
             <template
                 v-for="(link, key) in links"
                 :key="key"
             >
                 <div
                     v-if="link.url === null"
-                    class="px-4 py-2.5 cursor-not-allowed mb-1 mr-1 text-sm leading-4 text-gray-400 border rounded-md"
+                    class="inline-flex items-center justify-center px-4 py-3 min-w-[44px] cursor-not-allowed text-sm leading-4 text-center text-gray-400 border rounded-md"
                 >
                     <span v-if="link.label.includes('Previous')">&laquo;</span>
                     <span v-else-if="link.label.includes('Next')">&raquo;</span>
@@ -16,8 +16,8 @@
 
                 <Link
                     v-else
-                    class="px-4 py-2.5 hover:bg-gray-100 mb-1 mr-1 text-sm leading-4 border rounded-md focus:border-emerald-500 focus:text-emerald-500"
-                    :class="{ 'bg-emerald-600 text-white': link.active, 'bg-white': !link.active }"
+                    class="inline-flex items-center justify-center px-4 py-3 min-w-[44px] text-sm leading-4 text-center hover:bg-gray-100 dark:hover:bg-gray-800 border rounded-md focus:border-emerald-500 focus:text-emerald-500"
+                    :class="{ 'bg-emerald-600 text-white': link.active, 'bg-white dark:bg-gray-900': !link.active }"
                     :href="link.url"
                     :preserve-state="true"
                 >

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -2,7 +2,7 @@
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
     <head>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
         <meta name="theme-color" content="#10b981">
         <meta name="mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="default">


### PR DESCRIPTION
## Summary

Portrait iPad (768px, Tailwind `md`) was getting the phone experience because the app switched layouts only at `lg`. This PR makes tablets a first-class target across five areas. All changes are Vue/Tailwind/Blade — no backend logic touched.

## Workstreams

### 1. Portrait layouts (structural)
- **POS** (`Pos/Session.vue`, `PosProductGrid.vue`): product grid + cart go side-by-side at `md` instead of `lg`; cart is `md:w-80 lg:w-96`; product column `min-w-0`. Replaced the brittle `100vh` math with `100dvh` + `min-h-0` so the on-screen keyboard doesn't push the Complete Sale button off-screen. Grid columns adjusted so the cart doesn't compress the products.
- **Invoice line items** (`InvoiceForm.vue`): the dense 12-column row now only kicks in at `lg`; portrait keeps the roomy per-field-labelled stack (all `md:` col-spans / label toggles moved to `lg:`).
- **Filter sidebar** (`Shared/FilterSidebar.vue`): now an RTL-aware slide-over drawer below `lg` (fixed, `w-80 max-w-[85vw]`, backdrop tap-to-close), inline sticky sidebar at `lg+`. New `useFilterSidebar` composable defaults it open on desktop / closed on tablet-phone via `matchMedia`; wired `@close` into all nine index pages that use it.
- **AdminLayout**: shell/sidebar breakpoint moved `xl:` → `lg:` (iPad landscape now gets the persistent sidebar) and auto-closes the mobile menu on navigation.

### 2. iOS input fixes
- Global `@media (pointer: coarse)` 16px minimum on `input/select/textarea` (kills zoom-on-focus), mirrored inside `CustomSelect` scoped styles.

### 3. Touch targets (≥44px)
- Nav links, sidebar group buttons, dropdown links, pagination (also fixed an RTL `mr-1` slip), POS qty steppers / cart remove / close-session, invoice + index-page row-action icon buttons, segmented filter pills (`h-9`→`h-11`), CustomSelect trigger/options, admin logout, operations center close/dismiss.

### 4. Input semantics & modal safety
- `inputmode` on numeric money/qty fields across the app; `type="tel"` + `inputmode="tel"` + `autocomplete="tel"` on phone fields.
- `Modal.vue` panel constrained to `max-h-[85dvh]` with a scrollable body; `DialogModal` footer made sticky so the submit button stays above the keyboard.
- Data-entry modals (`QuickAddPartyModal`, POS checkout) no longer discard input on backdrop tap.
- `Tooltip.vue` gains tap-to-toggle with tap-away close (was hover-only, invisible on tablet).

### 5. POS speed & polish
- Quick-tender shortcuts on cash checkout: **Exact** plus rounded denominations computed from the total, one tap to set the tendered amount.
- `overscroll-contain` on POS scroll regions; bottom-sheet checkout on tablet (`items-end lg:items-center`).
- `viewport-fit=cover` + `env(safe-area-inset-bottom)` padding on the operations center pill/panel.
- Reduced cell padding below `lg` on the two widest tables (Products, Payments).

## Out of scope (follow-ups)
- Barcode-wedge scanner capture (needs hardware verification).
- POS checkout preflight-on-open / modal-flow restructuring.
- Card-view fallbacks for Customers/Payments/Expenses tables.
- Dead vue-multiselect CSS cleanup.

## Testing
- `npm run build` succeeds with no new errors.
- ESLint on changed files: 0 errors (only pre-existing cosmetic attribute-order warnings; auto-fixed the files I touched).
- Pint: passed (no PHP class changes).
- These are frontend class/attribute changes with no unit-test surface; not adding synthetic tests.