### PR TITLE
feat(ui): filter drawer + chips, report visibility fixes, payment/ops polish

### DIFF
--- a/app/Actions/StoreInvoiceAction.php
+++ b/app/Actions/StoreInvoiceAction.php
@@ -105,7 +105,7 @@ class StoreInvoiceAction
             'notes' => $method === PaymentMethod::Cash
                 ? ($isSale ? 'Cash payment on sale' : 'Cash payment on purchase')
                 : $data->get('payment_notes'),
-            'metadata' => $method === PaymentMethod::BankTransfer ? ['bank_name' => $data->get('bank_name')] : null,
+            'metadata' => null,
             'receipt_path' => $method === PaymentMethod::BankTransfer
                 ? $this->resolveTemporaryUpload($data->get('receipt'), 'receipts', disk: 'public')
                 : null,

--- a/app/Http/Requests/CreateInvoiceRequest.php
+++ b/app/Http/Requests/CreateInvoiceRequest.php
@@ -57,7 +57,6 @@ class CreateInvoiceRequest extends FormRequest
                 'nullable',
                 Rule::exists('treasury_accounts', 'id')->where('tenant_id', $tenantId),
             ],
-            'bank_name' => 'nullable|string|max:255',
             'cheque_due_date' => 'nullable|date',
             'cheque_bank_id' => 'nullable|integer',
             'cheque_number' => 'nullable|string|max:255',

--- a/resources/js/Components/Invoicing/InvoiceForm.vue
+++ b/resources/js/Components/Invoicing/InvoiceForm.vue
@@ -96,7 +96,6 @@
         initial_payment_amount: 0,
         payment_reference: '',
         payment_notes: '',
-        bank_name: '',
         receipt: null,
         cheque_bank_id: null,
         cheque_due_date: '',

--- a/resources/js/Components/Invoicing/PaymentCaptureFields.vue
+++ b/resources/js/Components/Invoicing/PaymentCaptureFields.vue
@@ -83,11 +83,6 @@
         <!-- Bank Transfer Details -->
         <div v-if="form.payment_method === 'bank_transfer'" class="space-y-4 p-4 bg-emerald-50 dark:bg-emerald-900/10 rounded-lg border border-emerald-200 dark:border-emerald-800">
             <div>
-                <InputLabel for="bank_name" :value="__('Bank Name')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
-                <TextInput id="bank_name" v-model="form.bank_name" type="text" class="block w-full" required />
-                <InputError class="mt-1" :message="form.errors.bank_name" />
-            </div>
-            <div>
                 <InputLabel for="receipt" :value="__('Payment Receipt (Optional)')" class="mb-1.5 text-xs font-semibold uppercase tracking-wider text-gray-500" />
                 <FileUploader v-model="form.receipt" />
                 <InputError class="mt-1" :message="form.errors.receipt" />

--- a/resources/js/Components/OperationsCenter.vue
+++ b/resources/js/Components/OperationsCenter.vue
@@ -55,8 +55,8 @@ function dismiss(id) {
     operations.value = operations.value.filter(o => o.id !== id);
 }
 
-function clearDone() {
-    operations.value = operations.value.filter(o => o.status !== 'completed' && o.status !== 'failed');
+function clearAll() {
+    operations.value = [];
 }
 
 // ─── Event handlers ─────────────────────────────────────────────────
@@ -172,7 +172,7 @@ const ringCircumference = 2 * Math.PI * 13;
                         </div>
                     </div>
                     <div class="flex items-center gap-1">
-                        <button v-if="done.length" @click="clearDone" class="text-[11px] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 font-medium px-2 py-1.5 rounded-md transition-colors">
+                        <button v-if="operations.length" @click="clearAll" class="text-[11px] text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 font-medium px-2 py-1.5 rounded-md transition-colors">
                             {{ __('Clear') }}
                         </button>
                         <button @click="panelOpen = false" class="w-11 h-11 inline-flex items-center justify-center text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 rounded-md transition-colors">
@@ -220,6 +220,11 @@ const ringCircumference = 2 * Math.PI * 13;
                                     {{ statusText(op) }}
                                 </div>
                             </div>
+                            <button @click="dismiss(op.id)" class="w-11 h-11 flex-shrink-0 inline-flex items-center justify-center rounded-md text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                                <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
                         </div>
                     </template>
 
@@ -281,18 +286,13 @@ const ringCircumference = 2 * Math.PI * 13;
             leave-to-class="opacity-0 scale-90"
         >
             <button
-                v-if="!panelOpen"
+                v-if="!panelOpen && pillState !== 'idle'"
                 @click="panelOpen = true"
                 data-testid="operations-pill"
                 class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 inline-flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2.5 shadow-sm hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
                 :class="[isRtl ? 'left-4' : 'right-4']"
             >
-                <span v-if="pillState === 'idle'" class="w-[30px] h-[30px] rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 inline-flex items-center justify-center">
-                    <svg class="h-[15px] w-[15px]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75v-.7V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
-                    </svg>
-                </span>
-                <span v-else class="relative w-[30px] h-[30px] flex-shrink-0">
+                <span class="relative w-[30px] h-[30px] flex-shrink-0">
                     <svg width="30" height="30" class="-rotate-90">
                         <circle cx="15" cy="15" r="13" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-100 dark:text-gray-800" />
                         <circle cx="15" cy="15" r="13" fill="none"
@@ -311,9 +311,35 @@ const ringCircumference = 2 * Math.PI * 13;
                     </span>
                 </span>
                 <span class="text-sm font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                    <template v-if="pillState === 'idle'">{{ __('Operations') }}</template>
-                    <template v-else-if="pillState === 'active'">{{ active.length }} {{ __('in progress') }}</template>
+                    <template v-if="pillState === 'active'">{{ active.length }} {{ __('in progress') }}</template>
                     <template v-else>{{ __('Done') }}</template>
+                </span>
+            </button>
+        </Transition>
+
+        <!-- Idle nudge — a tab tucked against the screen edge when there is no work -->
+        <Transition
+            enter-active-class="transition ease-out duration-200"
+            enter-from-class="opacity-0 translate-x-2 rtl:-translate-x-2"
+            enter-to-class="opacity-100 translate-x-0"
+            leave-active-class="transition ease-in duration-150"
+            leave-from-class="opacity-100 translate-x-0"
+            leave-to-class="opacity-0 translate-x-2 rtl:-translate-x-2"
+        >
+            <button
+                v-if="!panelOpen && pillState === 'idle'"
+                @click="panelOpen = true"
+                data-testid="operations-pill"
+                class="group fixed top-1/2 -translate-y-1/2 z-50 inline-flex items-center gap-2 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 shadow-sm py-3 px-2.5 hover:px-3 transition-all duration-200 cursor-pointer"
+                :class="[isRtl ? 'left-0 rounded-e-xl border-s-0' : 'right-0 rounded-s-xl border-e-0']"
+            >
+                <span class="w-7 h-7 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-400 dark:text-gray-500 inline-flex items-center justify-center flex-shrink-0">
+                    <svg class="h-[15px] w-[15px]" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75v-.7V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
+                    </svg>
+                </span>
+                <span class="max-w-0 overflow-hidden opacity-0 group-hover:max-w-[8rem] group-hover:opacity-100 transition-all duration-200 text-sm font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                    {{ __('Operations') }}
                 </span>
             </button>
         </Transition>

--- a/resources/js/Composables/useFilterChips.js
+++ b/resources/js/Composables/useFilterChips.js
@@ -1,0 +1,77 @@
+import { computed } from "vue";
+
+/**
+ * Derive removable filter chips from a reactive filters object.
+ *
+ * Each descriptor maps a filter key to a human-readable label and, optionally,
+ * how to display its value (a formatter or an option list to resolve the label
+ * from). A chip is emitted only when the filter holds a meaningful value — an
+ * empty string, null/undefined, or a value equal to the descriptor default is
+ * treated as inactive.
+ *
+ * @param {import('vue').Ref<Object>} filters
+ * @param {Array<{
+ *   key: string,
+ *   label: string,
+ *   default?: *,
+ *   format?: (value: *) => string,
+ *   options?: Array<Object>,
+ *   optionValue?: string,
+ *   optionLabel?: string,
+ * }>} descriptors
+ * @returns {{ chips: import('vue').ComputedRef<Array>, removeChip: (key: string) => void }}
+ */
+export const useFilterChips = (filters, descriptors) => {
+    const isInactive = (value, defaultValue) => {
+        if (value === null || value === undefined || value === "") {
+            return true;
+        }
+
+        if (Array.isArray(value)) {
+            return value.length === 0;
+        }
+
+        return defaultValue !== undefined && String(value) === String(defaultValue);
+    };
+
+    const displayValue = (descriptor, value) => {
+        if (descriptor.format) {
+            return descriptor.format(value);
+        }
+
+        if (descriptor.options) {
+            const valueKey = descriptor.optionValue ?? "value";
+            const labelKey = descriptor.optionLabel ?? "label";
+            const match = descriptor.options.find(
+                (option) => String(option[valueKey]) === String(value)
+            );
+
+            if (match) {
+                return match[labelKey];
+            }
+        }
+
+        return value;
+    };
+
+    const chips = computed(() =>
+        descriptors
+            .filter((descriptor) => !isInactive(filters.value[descriptor.key], descriptor.default))
+            .map((descriptor) => ({
+                key: descriptor.key,
+                label: descriptor.label,
+                value: displayValue(descriptor, filters.value[descriptor.key]),
+            }))
+    );
+
+    const removeChip = (key) => {
+        const descriptor = descriptors.find((descriptor) => descriptor.key === key);
+
+        filters.value = {
+            ...filters.value,
+            [key]: descriptor?.default ?? null,
+        };
+    };
+
+    return { chips, removeChip };
+};

--- a/resources/js/Composables/useFilterSidebar.js
+++ b/resources/js/Composables/useFilterSidebar.js
@@ -1,16 +1,12 @@
 import { ref } from "vue";
 
 /**
- * The filter panel renders inline at lg+ (>=1024px) and as a slide-over drawer
- * below lg. It should start open on wide screens (where it costs no content
- * space) and closed on tablet/phone (where it would otherwise cover the data).
+ * The filter panel is a slide-over drawer at every breakpoint. It stays closed
+ * until the user opens it from the "Filters" button so it never covers the data
+ * on load; applied filters remain visible as removable chips above the content.
  *
  * @returns {import('vue').Ref<boolean>}
  */
 export const useFilterSidebar = () => {
-    const isDesktop =
-        typeof window !== "undefined" &&
-        window.matchMedia("(min-width: 1024px)").matches;
-
-    return ref(isDesktop);
+    return ref(false);
 };

--- a/resources/js/Pages/Cheques/Index.vue
+++ b/resources/js/Pages/Cheques/Index.vue
@@ -7,7 +7,9 @@
     import debounce from "lodash/debounce";
     import EmptySearch from "@/Shared/EmptySearch.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import CustomSelect from "@/Components/CustomSelect.vue";
     const props = defineProps({
         initialCheques: Object,
@@ -56,6 +58,25 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "asc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "type",
+            label: __("Type"),
+            options: [
+                { value: 1, label: __("Receivable") },
+                { value: 0, label: __("Payable") },
+            ],
+        },
+        {
+            key: "status",
+            label: __("Status"),
+            default: [],
+            format: (value) => (Array.isArray(value) ? value.map((option) => option.label ?? option).join(", ") : value),
+        },
+        { key: "due", label: __("Due Before") },
+    ]);
 
     const loadMore = () => {
         if (!props.initialCheques.next_page_url) return;
@@ -215,7 +236,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
         <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
             <FilterSidebar
-                v-if="showSidebar"
+                :show="showSidebar"
                 @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
@@ -281,6 +302,8 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             </FilterSidebar>
 
             <div class="flex-1 min-w-0">
+                <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                 <div v-if="cheques.length">
                     <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
                         <Cheque

--- a/resources/js/Pages/Customers/Index.vue
+++ b/resources/js/Pages/Customers/Index.vue
@@ -10,14 +10,16 @@
     import { useQueryString } from "@/Composables/useQueryString";
     import { usePermissions } from "@/Composables/usePermissions";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import ImportModal from "@/Shared/ImportModal.vue";
     import Tooltip from "@/Components/Tooltip.vue";
     import { useDate } from '@/Composables/useDate';
 
     const { can } = usePermissions();
 
-    defineProps({
+    const props = defineProps({
         customers: Object,
         categories: Array
     });
@@ -85,6 +87,20 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "asc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "status",
+            label: __("Status"),
+            default: "all",
+            options: [
+                { value: "withTrash", label: __("With Trashed") },
+                { value: "trash", label: __("Trashed") },
+            ],
+        },
+        { key: "category", label: __("Category"), options: props.categories, optionValue: "id", optionLabel: "name" },
+    ]);
 
     const sortByOptions = [
         { label: __("Name"), value: "name" },
@@ -179,7 +195,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
                 <!-- Sidebar -->
                 <FilterSidebar
-                    v-if="showSidebar"
+                    :show="showSidebar"
                     @close="showSidebar = false"
                     v-model:filters="filters"
                     :categories="categories"
@@ -190,6 +206,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
                 <!-- Table Content -->
                 <div class="flex-grow min-w-0 overflow-hidden">
+                    <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
                     <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
                         <div class="overflow-x-auto">
                             <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/resources/js/Pages/Expenses/Index.vue
+++ b/resources/js/Pages/Expenses/Index.vue
@@ -6,11 +6,13 @@ import debounce from "lodash/debounce";
 import Pagination from "@/Shared/Pagination.vue";
 import EmptySearch from "@/Shared/EmptySearch.vue";
 import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+import { useFilterChips } from "@/Composables/useFilterChips";
 import CustomSelect from "@/Components/CustomSelect.vue";
 import { useQueryString } from "@/Composables/useQueryString";
 
-defineProps({
+const props = defineProps({
     expenses: Object,
     categories: Array,
     users: Array,
@@ -43,6 +45,25 @@ const resetFilters = () => {
         created_by: null,
     };
 };
+
+const { chips, removeChip } = useFilterChips(filters, [
+    { key: "search", label: __("Search") },
+    { key: "category", label: __("Category"), options: props.categories, optionValue: "id", optionLabel: "name" },
+    {
+        key: "status",
+        label: __("Status"),
+        options: [
+            { value: "pending", label: __("Pending") },
+            { value: "approved", label: __("Approved") },
+            { value: "rejected", label: __("Rejected") },
+        ],
+    },
+    { key: "from_date", label: __("From Date") },
+    { key: "to_date", label: __("To Date") },
+    { key: "min_amount", label: __("Min Amount") },
+    { key: "max_amount", label: __("Max Amount") },
+    { key: "created_by", label: __("Created By"), options: props.users, optionValue: "id", optionLabel: "name" },
+]);
 
 watch(
     filters,
@@ -161,7 +182,7 @@ const getBudgetColor = (budget) => {
 
             <div class="flex flex-col lg:flex-row gap-8 mt-8">
                 <FilterSidebar
-                    v-if="showSidebar"
+                    :show="showSidebar"
                     @close="showSidebar = false"
                     v-model:filters="filters"
                     @reset="resetFilters"
@@ -219,6 +240,8 @@ const getBudgetColor = (budget) => {
                 </FilterSidebar>
 
                 <div class="flex-1 overflow-hidden">
+                    <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                     <div v-if="spending_by_category && spending_by_category.length" class="mb-6 p-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl transition-all">
                         <h3 class="text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest mb-4">{{ __("Spending by Category") }}</h3>
                         <div class="flex flex-wrap gap-4">

--- a/resources/js/Pages/Payments/Index.vue
+++ b/resources/js/Pages/Payments/Index.vue
@@ -4,7 +4,9 @@ import { Link, router } from "@inertiajs/vue3";
 import Pagination from "@/Shared/Pagination.vue";
 import EmptySearch from "@/Shared/EmptySearch.vue";
 import FilterSidebar from "@/Shared/FilterSidebar.vue";
+import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+import { useFilterChips } from "@/Composables/useFilterChips";
 import DatePicker from "@/Components/DatePicker.vue";
 import { watch, ref, computed, onMounted, onUnmounted } from "vue";
 import { useQueryString } from "@/Composables/useQueryString";
@@ -70,6 +72,38 @@ const methodLabel = (method) => {
     const found = methodOptions.value.find(m => m.value === method);
     return found ? __(found.label) : __(method);
 };
+
+const { chips, removeChip } = useFilterChips(filters, [
+    { key: "search", label: __("Search") },
+    {
+        key: "status",
+        label: __("Status"),
+        default: "all",
+        options: [
+            { value: "withTrash", label: __("With Trashed") },
+            { value: "trash", label: __("Trashed") },
+        ],
+    },
+    {
+        key: "direction",
+        label: __("Direction"),
+        options: [
+            { value: "in", label: __("Incoming") },
+            { value: "out", label: __("Outgoing") },
+        ],
+    },
+    { key: "method", label: __("Method"), format: methodLabel },
+    { key: "date_from", label: __("Date From") },
+    { key: "date_to", label: __("Date To") },
+    {
+        key: "party_type",
+        label: __("Party Type"),
+        options: [
+            { value: "Customer", label: __("Customer") },
+            { value: "Supplier", label: __("Supplier") },
+        ],
+    },
+]);
 
 function isIncoming(payment) {
     return payment.direction === "in";
@@ -264,7 +298,7 @@ watch(
         <div class="flex flex-col lg:flex-row lg:gap-x-6">
             <!-- Sidebar -->
             <FilterSidebar
-                v-if="showSidebar"
+                :show="showSidebar"
                 @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
@@ -362,6 +396,8 @@ watch(
 
             <!-- Payments List -->
             <div class="flex-1 min-w-0 overflow-hidden">
+                <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                 <div
                     class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden transition-all"
                 >

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -12,7 +12,9 @@
     import ProductAdjustmentModal from "@/Components/Products/ProductAdjustmentModal.vue";
     import TextInput from "@/Components/TextInput.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import Tooltip from "@/Components/Tooltip.vue";
 
     const props = defineProps({
@@ -60,6 +62,24 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "desc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "status",
+            label: __("Status"),
+            default: "all",
+            options: [
+                { value: "withTrash", label: __("With Trashed") },
+                { value: "trash", label: __("Trashed") },
+            ],
+        },
+        { key: "category", label: __("Category"), options: props.categories, optionValue: "id", optionLabel: "name" },
+        { key: "min_cost", label: __("Min Cost") },
+        { key: "max_cost", label: __("Max Cost") },
+        { key: "expire_from", label: __("Expires From") },
+        { key: "expire_to", label: __("Expires To") },
+    ]);
 
     const sortByOptions = [
         { label: __("Availability"), value: "quantity_on_hand" },
@@ -375,7 +395,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
                 <!-- Sidebar -->
                 <FilterSidebar
-                    v-if="showSidebar"
+                    :show="showSidebar"
                     @close="showSidebar = false"
                     v-model:filters="filters"
                     :categories="categories"
@@ -406,6 +426,8 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
                 <!-- Products List -->
                 <div class="flex-1 min-w-0 overflow-hidden">
+                    <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                     <!-- Table Mode -->
                     <div v-if="layout === 'table'" class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
                         <div class="overflow-x-auto">
@@ -531,7 +553,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
                     <!-- Cards Mode -->
                     <div v-if="layout === 'cards'" data-testid="product-cards-grid">
-                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4">
                             <!-- New Product Card -->
                             <div
                                 class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-sm overflow-hidden"

--- a/resources/js/Pages/Purchases/Index.vue
+++ b/resources/js/Pages/Purchases/Index.vue
@@ -11,7 +11,9 @@
     import Dropdown from "@/Components/Dropdown.vue";
     import DropdownLink from "@/Components/DropdownLink.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import { useQueryString } from "@/Composables/useQueryString";
     import debounce from "lodash/debounce";
     import axios from "axios";
@@ -77,6 +79,19 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "desc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "status",
+            label: __("Status"),
+            default: "all",
+            options: [
+                { value: "withTrash", label: __("With Trashed") },
+                { value: "trash", label: __("Trashed") },
+            ],
+        },
+    ]);
 
     const sortByOptions = [
         { label: __("Date"), value: "created_at" },
@@ -186,7 +201,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
         <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
             <!-- Sidebar -->
             <FilterSidebar
-                v-if="showSidebar"
+                :show="showSidebar"
                 @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
@@ -196,6 +211,8 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
             <!-- Invoices List -->
             <div class="flex-1 min-w-0">
+                <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                 <div class="space-y-6">
                     <div
                         v-for="invoice in invoices.data"

--- a/resources/js/Pages/Reports/CustomerAging.vue
+++ b/resources/js/Pages/Reports/CustomerAging.vue
@@ -112,14 +112,14 @@ function requestExport() {
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60">
-                                    <tr v-for="row in data" :key="row.customer" class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.customer }}</td>
+                                    <tr v-for="row in data" :key="row.customer_id" class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.customer_name }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatCurrency(row.bucket_0_30) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatCurrency(row.bucket_31_60) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatCurrency(row.bucket_61_90) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold"
-                                            :class="(row.bucket_over_90 ?? 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'">
-                                            {{ formatCurrency(row.bucket_over_90) }}
+                                            :class="(row.bucket_90_plus ?? 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'">
+                                            {{ formatCurrency(row.bucket_90_plus) }}
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900 dark:text-white">{{ formatCurrency(row.total) }}</td>
                                     </tr>

--- a/resources/js/Pages/Reports/SupplierAging.vue
+++ b/resources/js/Pages/Reports/SupplierAging.vue
@@ -112,14 +112,14 @@ function requestExport() {
                                     </tr>
                                 </thead>
                                 <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60">
-                                    <tr v-for="row in data" :key="row.supplier" class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.supplier }}</td>
+                                    <tr v-for="row in data" :key="row.supplier_id" class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.supplier_name }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatCurrency(row.bucket_0_30) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatCurrency(row.bucket_31_60) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatCurrency(row.bucket_61_90) }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold"
-                                            :class="(row.bucket_over_90 ?? 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'">
-                                            {{ formatCurrency(row.bucket_over_90) }}
+                                            :class="(row.bucket_90_plus ?? 0) > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'">
+                                            {{ formatCurrency(row.bucket_90_plus) }}
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-900 dark:text-white">{{ formatCurrency(row.total) }}</td>
                                     </tr>

--- a/resources/js/Pages/Reports/TreasuryReconciliation.vue
+++ b/resources/js/Pages/Reports/TreasuryReconciliation.vue
@@ -122,8 +122,8 @@ function requestExport() {
                                 </thead>
                                 <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60">
                                     <tr v-for="(row, index) in data" :key="index" class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.account }}</td>
-                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ row.date }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.account_name }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ row.occurred_at }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ row.reason }}</td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold"
                                             :class="(row.amount ?? 0) > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">

--- a/resources/js/Pages/Sales/Index.vue
+++ b/resources/js/Pages/Sales/Index.vue
@@ -12,7 +12,9 @@
     import Dropdown from "@/Components/Dropdown.vue";
     import DropdownLink from "@/Components/DropdownLink.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import { useQueryString } from "@/Composables/useQueryString";
     import debounce from "lodash/debounce";
     import axios from "axios";
@@ -78,6 +80,19 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "desc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "status",
+            label: __("Status"),
+            default: "all",
+            options: [
+                { value: "withTrash", label: __("With Trashed") },
+                { value: "trash", label: __("Trashed") },
+            ],
+        },
+    ]);
 
     const sortByOptions = [
         { label: __("Date"), value: "created_at" },
@@ -206,7 +221,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
         <div class="flex flex-col mt-6 lg:flex-row lg:gap-x-6">
             <!-- Sidebar -->
             <FilterSidebar
-                v-if="showSidebar"
+                :show="showSidebar"
                 @close="showSidebar = false"
                 v-model:filters="filters"
                 :sort-by-options="sortByOptions"
@@ -216,6 +231,8 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
             <!-- Invoices List -->
             <div class="flex-1 min-w-0">
+                <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                 <div class="space-y-6">
                     <div
                         v-for="invoice in invoices.data"

--- a/resources/js/Pages/Storages/Index.vue
+++ b/resources/js/Pages/Storages/Index.vue
@@ -6,7 +6,9 @@
     import StorageForm from "@/Components/Storages/StorageForm.vue";
     import DeleteStorage from "@/Components/Storages/DeleteStorage.vue";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import { watch, ref } from "vue";
     import debounce from "lodash/debounce";
     import { router, Link } from "@inertiajs/vue3";
@@ -46,6 +48,19 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "asc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "status",
+            label: __("Status"),
+            default: "all",
+            options: [
+                { value: "withTrash", label: __("With Trashed") },
+                { value: "trash", label: __("Trashed") },
+            ],
+        },
+    ]);
 
     const sortByOptions = [
         { label: __("Name"), value: "name" },
@@ -107,7 +122,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
                 <!-- Sidebar -->
                 <FilterSidebar
-                    v-if="showSidebar"
+                    :show="showSidebar"
                     @close="showSidebar = false"
                     v-model:filters="filters"
                     :sort-by-options="sortByOptions"
@@ -117,6 +132,8 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
                 <!-- Table Content -->
                 <div class="flex-grow min-w-0 overflow-hidden">
+                    <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
+
                     <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
                         <div class="overflow-x-auto">
                             <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/resources/js/Pages/Suppliers/Index.vue
+++ b/resources/js/Pages/Suppliers/Index.vue
@@ -9,12 +9,14 @@
     import EmptySearch from "@/Shared/EmptySearch.vue";
     import { useQueryString } from "@/Composables/useQueryString";
     import FilterSidebar from "@/Shared/FilterSidebar.vue";
+    import ActiveFilterChips from "@/Shared/ActiveFilterChips.vue";
 import { useFilterSidebar } from "@/Composables/useFilterSidebar";
+    import { useFilterChips } from "@/Composables/useFilterChips";
     import ImportModal from "@/Shared/ImportModal.vue";
     import Tooltip from "@/Components/Tooltip.vue";
     import { useDate } from '@/Composables/useDate';
 
-    defineProps({
+    const props = defineProps({
         suppliers: Object,
         categories: Array
     });
@@ -60,6 +62,20 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             sort_order: "asc"
         };
     };
+
+    const { chips, removeChip } = useFilterChips(filters, [
+        { key: "search", label: __("Search") },
+        {
+            key: "status",
+            label: __("Status"),
+            default: "all",
+            options: [
+                { value: "withTrash", label: __("With Trashed") },
+                { value: "trash", label: __("Trashed") },
+            ],
+        },
+        { key: "category", label: __("Category"), options: props.categories, optionValue: "id", optionLabel: "name" },
+    ]);
 
     const sortByOptions = [
         { label: __("Name"), value: "name" },
@@ -156,7 +172,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             <div class="flex flex-col mt-8 lg:flex-row lg:gap-x-6">
                 <!-- Sidebar -->
                 <FilterSidebar
-                    v-if="showSidebar"
+                    :show="showSidebar"
                     @close="showSidebar = false"
                     v-model:filters="filters"
                     :categories="categories"
@@ -167,6 +183,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
 
                 <!-- Table Content -->
                 <div class="flex-grow min-w-0 overflow-hidden">
+                    <ActiveFilterChips :chips="chips" @remove="removeChip" @clear="resetFilters" />
                     <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
                         <div class="overflow-x-auto">
                             <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/resources/js/Shared/ActiveFilterChips.vue
+++ b/resources/js/Shared/ActiveFilterChips.vue
@@ -1,0 +1,40 @@
+<script setup>
+defineProps({
+    chips: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+defineEmits(["remove", "clear"]);
+</script>
+
+<template>
+    <div v-if="chips.length" class="flex flex-wrap items-center gap-2 mb-6">
+        <span class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ __("Active filters") }}:</span>
+        <span
+            v-for="chip in chips"
+            :key="chip.key"
+            class="inline-flex items-center gap-x-1.5 ps-3 pe-1 py-1 text-xs font-medium bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 rounded-full"
+        >
+            <span><span class="text-gray-400 dark:text-gray-500">{{ chip.label }}:</span> {{ chip.value }}</span>
+            <button
+                type="button"
+                class="inline-flex items-center justify-center w-4 h-4 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 transition-colors"
+                @click="$emit('remove', chip.key)"
+            >
+                <span class="sr-only">{{ __("Remove filter") }}</span>
+                <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </span>
+        <button
+            type="button"
+            class="text-xs font-medium text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 focus:outline-none"
+            @click="$emit('clear')"
+        >
+            {{ __("Clear all") }}
+        </button>
+    </div>
+</template>

--- a/resources/js/Shared/FilterSidebar.vue
+++ b/resources/js/Shared/FilterSidebar.vue
@@ -3,6 +3,10 @@ import TrashFilter from "@/Shared/TrashFilter.vue";
 import CustomSelect from "@/Components/CustomSelect.vue";
 
 defineProps({
+    show: {
+        type: Boolean,
+        default: false
+    },
     filters: Object,
     categories: Array,
     sortByOptions: Array,
@@ -21,7 +25,7 @@ const resetFilters = () => {
 
 <template>
     <div class="contents">
-        <!-- Drawer backdrop (below lg) -->
+        <!-- Drawer backdrop -->
         <Transition
             enter-active-class="transition-opacity ease-out duration-200"
             enter-from-class="opacity-0"
@@ -30,19 +34,27 @@ const resetFilters = () => {
             leave-from-class="opacity-100"
             leave-to-class="opacity-0"
         >
-            <div class="fixed inset-0 z-40 bg-gray-900/50 backdrop-blur-sm lg:hidden" @click="emit('close')" />
+            <div v-if="show" class="fixed inset-0 z-40 bg-gray-900/50 backdrop-blur-sm" @click="emit('close')" />
         </Transition>
 
-        <!-- Slide-over drawer below lg; static inline sidebar at lg+ -->
-        <aside class="fixed inset-y-0 start-0 z-50 w-80 max-w-[85vw] overflow-y-auto bg-white dark:bg-gray-900 shadow-xl lg:static lg:z-auto lg:inset-auto lg:w-72 lg:max-w-none lg:overflow-visible lg:bg-transparent lg:shadow-none lg:shrink-0 transition-all duration-300">
-        <div class="sticky top-4 space-y-4 p-4 lg:p-0">
+        <!-- Slide-over drawer (all breakpoints) -->
+        <Transition
+            enter-active-class="transition ease-out duration-300"
+            enter-from-class="-translate-x-full rtl:translate-x-full opacity-0"
+            enter-to-class="translate-x-0 opacity-100"
+            leave-active-class="transition ease-in duration-200"
+            leave-from-class="translate-x-0 opacity-100"
+            leave-to-class="-translate-x-full rtl:translate-x-full opacity-0"
+        >
+        <aside v-if="show" class="fixed inset-y-0 start-0 z-50 w-80 max-w-[85vw] overflow-y-auto bg-white dark:bg-gray-900 shadow-xl">
+        <div class="space-y-4 p-4">
             <!-- Unified Filter Sidebar -->
             <div class="p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl space-y-6 transition-all">
                 <div class="flex items-center justify-between border-b border-gray-100 dark:border-gray-800 pb-4">
                     <h3 class="text-sm font-bold text-gray-900 dark:text-white uppercase tracking-wider">{{ __("Filters") }}</h3>
                     <div class="flex items-center gap-x-2">
                         <button type="button" class="text-xs text-emerald-600 hover:text-emerald-700 font-medium" @click="resetFilters">{{ __("Reset") }}</button>
-                        <button type="button" class="lg:hidden inline-flex items-center justify-center w-9 h-9 -me-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500" @click="emit('close')">
+                        <button type="button" class="inline-flex items-center justify-center w-9 h-9 -me-2 rounded-lg text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500" @click="emit('close')">
                             <span class="sr-only">{{ __("Close") }}</span>
                             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -132,5 +144,6 @@ const resetFilters = () => {
             </div>
         </div>
         </aside>
+        </Transition>
     </div>
 </template>

--- a/tests/Feature/PurchasesControllerTest.php
+++ b/tests/Feature/PurchasesControllerTest.php
@@ -122,7 +122,6 @@ test('it can store a purchase with bank transfer payment', function () {
         'payment_method' => PaymentMethod::BankTransfer->value,
         'initial_payment_amount' => 500,
         'payment_reference' => 'BT-001',
-        'bank_name' => 'Test Bank',
         'receipt' => $tempFilename,
     ];
 
@@ -138,7 +137,7 @@ test('it can store a purchase with bank transfer payment', function () {
     ]);
 
     $payment = $invoice->payments->first();
-    expect($payment->metadata['bank_name'])->toBe('Test Bank');
+    expect($payment->metadata)->toBeNull();
     Illuminate\Support\Facades\Storage::disk('public')->assertExists($payment->receipt_path);
     Illuminate\Support\Facades\Storage::disk('local')->assertMissing('tmp/'.$tempFilename);
 });

--- a/tests/cypress/integration/reports-with-data.cy.js
+++ b/tests/cypress/integration/reports-with-data.cy.js
@@ -180,7 +180,8 @@ describe('Inventory Valuation with data', () => {
 describe('Customer Aging with data', () => {
     it('shows customers with outstanding balances', () => {
         cy.visit('/reports/customer-aging');
-        cy.contains('Cypress Customer').should('exist');
+        // The customer name column must render the real name (not blank).
+        cy.get('table tbody').contains('td', 'Cypress Customer').should('be.visible');
     });
 
     it('shows amounts in aging buckets', () => {
@@ -192,7 +193,8 @@ describe('Customer Aging with data', () => {
 describe('Supplier Aging with data', () => {
     it('shows suppliers with outstanding balances', () => {
         cy.visit('/reports/supplier-aging');
-        cy.contains('Cypress Supplier').should('exist');
+        // The supplier name column must render the real name (not blank).
+        cy.get('table tbody').contains('td', 'Cypress Supplier').should('be.visible');
     });
 });
 
@@ -207,5 +209,12 @@ describe('Treasury Reconciliation with data', () => {
     it('shows treasury movements', () => {
         cy.visit('/reports/treasury-reconciliation');
         cy.get('table tbody tr').should('have.length.at.least', 1);
+    });
+
+    it('renders the account name and date in the table', () => {
+        cy.visit('/reports/treasury-reconciliation');
+        // Account (1st cell) and Date (2nd cell) columns must render, not be blank.
+        cy.get('table tbody').contains('td', 'Main Cash').should('be.visible');
+        cy.get('table tbody tr').first().find('td').eq(1).invoke('text').should('not.be.empty');
     });
 });


### PR DESCRIPTION
UI polish batch addressing six reported issues. All items are on one branch off `master` as agreed.

## Changes

### Report visibility bugs (data-binding key mismatches)
- **Treasury reconciliation**: account name and date were bound to `row.account` / `row.date` but the query emits `account_name` / `occurred_at` — cells rendered blank. Fixed.
- **Customer / supplier aging**: party name bound to `row.customer` / `row.supplier` but the query emits `customer_name` / `supplier_name` — fixed. Also fixed the "90+ Days" column (`bucket_over_90` → `bucket_90_plus`), a latent bug in the same tables.
- Strengthened `reports-with-data.cy.js` to assert those names/dates actually render (the treasury test previously only counted rows).

### Redundant free-text bank field on payments
- Removed the free-text "Bank Name" input from the sale/purchase payment capture (`PaymentCaptureFields`, `InvoiceForm`, `CreateInvoiceRequest`, `StoreInvoiceAction`). The selected treasury account already identifies the bank.
- The separate standalone Payments module is intentionally untouched (it still validates `bank_name`); its tests remain green.

### Filters → drawer + active-filter chips
- `FilterSidebar` is now a slide-over drawer at **every** breakpoint (`:show` prop, animated open/close), opened from the Filters button.
- New `useFilterChips` composable + `ActiveFilterChips` component render removable chips above the content, with clear-all. Applied to all 9 index pages (Products, Sales, Purchases, Customers, Suppliers, Payments, Expenses, Storages, Cheques).

### Product card grid
- Defer the 4-column layout from `xl` to `2xl` so cards stay roomy on mid-size screens (e.g. MacBook Air).

### Operations center
- Idle state is now a nudge tucked against the screen edge (label expands on hover).
- Every operation — active ones included — is dismissable, plus a clear-all.

## Testing
- `npm run build` passes; Pint clean.
- PHP: Sales/Purchases + full Payment/Invoice feature suites pass (~119 tests) — confirms the standalone payment path is intact.
- Report fixes are covered by the strengthened cypress specs (require the browser runner).

## Reviewer notes
- **Desktop no longer has the always-inline filter sidebar** — per the request ("filters should be a drawer that opens when you click filter"), filters are now a drawer at all breakpoints.
- **Pre-existing Expenses `status` double-bind** (FilterSidebar's TrashFilter and a custom approval-status select share `filters.status`) is left as-is; it predates this work and warrants its own fix.