### PR TITLE
fix(ui): anchor filter drawer to edge opposite nav; cap content width

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -498,7 +498,7 @@
 
                 <!-- Main content -->
                 <main class="lg:flex-1 dark:bg-gray-900 lg:overflow-y-auto">
-                    <div class="px-4 py-10 sm:px-6 lg:px-8 max-w-[1800px] 2xl:mx-auto min-h-screen lg:min-h-full">
+                    <div class="px-4 py-10 sm:px-6 lg:px-8 max-w-[1400px] mx-auto min-h-screen lg:min-h-full">
                         <Flash />
                         <ErrorToast />
                         <OperationsCenter />

--- a/resources/js/Shared/FilterSidebar.vue
+++ b/resources/js/Shared/FilterSidebar.vue
@@ -37,16 +37,16 @@ const resetFilters = () => {
             <div v-if="show" class="fixed inset-0 z-40 bg-gray-900/50 backdrop-blur-sm" @click="emit('close')" />
         </Transition>
 
-        <!-- Slide-over drawer (all breakpoints) -->
+        <!-- Slide-over drawer, anchored to the edge opposite the nav (all breakpoints) -->
         <Transition
             enter-active-class="transition ease-out duration-300"
-            enter-from-class="-translate-x-full rtl:translate-x-full opacity-0"
+            enter-from-class="translate-x-full rtl:-translate-x-full opacity-0"
             enter-to-class="translate-x-0 opacity-100"
             leave-active-class="transition ease-in duration-200"
             leave-from-class="translate-x-0 opacity-100"
-            leave-to-class="-translate-x-full rtl:translate-x-full opacity-0"
+            leave-to-class="translate-x-full rtl:-translate-x-full opacity-0"
         >
-        <aside v-if="show" class="fixed inset-y-0 start-0 z-50 w-80 max-w-[85vw] overflow-y-auto bg-white dark:bg-gray-900 shadow-xl">
+        <aside v-if="show" class="fixed inset-y-0 end-0 z-50 w-80 max-w-[85vw] overflow-y-auto bg-white dark:bg-gray-900 shadow-xl">
         <div class="space-y-4 p-4">
             <!-- Unified Filter Sidebar -->
             <div class="p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl space-y-6 transition-all">


### PR DESCRIPTION
Follow-up to #51 (which merged without these two refinements).

## Changes

### Filter drawer anchored opposite the navigation
The nav sidebar is anchored to the inline-**start** edge (`start-0`, static at `lg+`). The filter drawer was also sliding in from the start edge, so it overlapped the nav side. It now slides in from the **end** edge (direction-aware, RTL-safe), i.e. the side opposite the navigation.

### Cap the main content width
Now that filters are a drawer instead of an inline column, page content stretched full-bleed on large screens. Reduced the `AppLayout` content container from `max-w-[1800px]` (centered only at `2xl`) to `max-w-[1400px] mx-auto` so content stays comfortable on large displays. This is a global layout change affecting all pages.

## Testing
- `npm run build` passes.

## Note
`1400px` is a balanced value for the data-heavy tables (which scroll horizontally when needed); easy to tune narrower if preferred.