### PR TITLE
fix(ui): dark-mode contrast via semantic design tokens

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,6 +9,41 @@
    scrollbars) follow the OS theme — which is how this app's dark mode is driven. */
 :root {
     color-scheme: light dark;
+
+    /*
+     * Semantic design tokens (light theme). Consumed by the `text-*`, `bg-*`,
+     * `border-*` and `placeholder-*` utilities registered in tailwind.config.js.
+     * Stored as space-separated R G B channels so Tailwind's `/<alpha-value>`
+     * opacity modifiers keep working. All foreground/background pairings below
+     * are verified >= WCAG AA (4.5:1) for body text in both themes.
+     */
+    --fg-primary: 17 24 39;      /* gray-900  — primary text / headings */
+    --fg-secondary: 75 85 99;    /* gray-600  — muted / secondary text */
+    --fg-tertiary: 107 114 128;  /* gray-500  — captions / table headers */
+    --fg-disabled: 156 163 175;  /* gray-400  — disabled / placeholder */
+
+    --surface: 255 255 255;         /* white     — base card / panel */
+    --surface-elevated: 249 250 251;/* gray-50   — headers, raised rows */
+    --surface-sunken: 249 250 251;  /* gray-50   — inset / readonly fields */
+
+    --line: 229 231 235;         /* gray-200  — default hairline / border */
+    --line-strong: 209 213 219;  /* gray-300  — stronger border */
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --fg-primary: 243 244 246;   /* gray-100 — 16:1 on surface */
+        --fg-secondary: 209 213 219; /* gray-300 — 12:1 on surface */
+        --fg-tertiary: 156 163 175;  /* gray-400 — 7:1 on surface */
+        --fg-disabled: 107 114 128;  /* gray-500 — placeholder, ~3.7:1 (distinct) */
+
+        --surface: 17 24 39;          /* gray-900 — base card / page */
+        --surface-elevated: 31 41 55; /* gray-800 — headers, raised rows */
+        --surface-sunken: 31 41 55;   /* gray-800 — inset / readonly fields */
+
+        --line: 55 65 81;         /* gray-700 */
+        --line-strong: 75 85 99;  /* gray-600 */
+    }
 }
 
 /* On touch devices (tablets/phones) iOS zooms the page in when focusing an

--- a/resources/js/Components/Dropdown.vue
+++ b/resources/js/Components/Dropdown.vue
@@ -12,7 +12,7 @@ const props = defineProps({
     },
     contentClasses: {
         type: Array,
-        default: () => ['py-1', 'bg-white'],
+        default: () => ['py-1', 'bg-white', 'dark:bg-gray-800'],
     },
 });
 

--- a/resources/js/Components/DropdownLink.vue
+++ b/resources/js/Components/DropdownLink.vue
@@ -9,15 +9,15 @@ defineProps({
 
 <template>
     <div @click="$emit('click')">
-        <button v-if="as == 'button'" type="button" class="flex w-full items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-left text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100 rtl:text-right">
+        <button v-if="as == 'button'" type="button" class="flex w-full items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-left text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-700 rtl:text-right">
             <slot />
         </button>
 
-        <a v-else-if="as =='a'" :href="href" class="flex items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100">
+        <a v-else-if="as =='a'" :href="href" class="flex items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-700">
             <slot />
         </a>
 
-        <Link v-else :href="href" class="flex items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:bg-gray-100">
+        <Link v-else :href="href" class="flex items-center min-h-[44px] px-4 py-2.5 text-sm leading-5 text-gray-700 dark:text-gray-300 transition hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-700">
             <slot />
         </Link>
     </div>

--- a/resources/js/Components/FormSection.vue
+++ b/resources/js/Components/FormSection.vue
@@ -21,7 +21,7 @@ const hasActions = computed(() => !! useSlots().actions);
         <div class="mt-5 md:mt-0 md:col-span-2">
             <form @submit.prevent="$emit('submitted')">
                 <div
-                    class="px-4 py-5 bg-white sm:p-6"
+                    class="px-4 py-5 bg-surface border border-line rounded-xl shadow-sm sm:p-6"
                 >
                     <div class="grid grid-cols-6 gap-6">
                         <slot name="form" />

--- a/resources/js/Components/SectionTitle.vue
+++ b/resources/js/Components/SectionTitle.vue
@@ -1,11 +1,11 @@
 <template>
     <div class="md:col-span-1 flex justify-between">
         <div class="px-4 sm:px-0">
-            <h3 class="text-lg font-medium text-gray-900">
+            <h3 class="text-lg font-medium text-primary">
                 <slot name="title" />
             </h3>
 
-            <p class="mt-1 text-sm text-gray-600">
+            <p class="mt-1 text-sm text-secondary">
                 <slot name="description" />
             </p>
         </div>

--- a/resources/js/Components/TextArea.vue
+++ b/resources/js/Components/TextArea.vue
@@ -21,7 +21,7 @@ defineExpose({ focus: () => input.value.focus() });
 <template>
     <textarea
         ref="input"
-        class="px-3 py-2 border border-gray-200 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+        class="px-3 py-2 text-primary bg-surface border border-line rounded-lg placeholder-disabled focus:border-emerald-300 dark:focus:border-emerald-600 focus:ring focus:ring-emerald-200 dark:focus:ring-emerald-800 focus:ring-opacity-50"
         :value="modelValue"
         @input="$emit('update:modelValue', $event.target.value)"
     ></textarea>

--- a/resources/js/Pages/API/Partials/ApiTokenManager.vue
+++ b/resources/js/Pages/API/Partials/ApiTokenManager.vue
@@ -106,7 +106,7 @@ const deleteApiToken = () => {
                         <div v-for="permission in availablePermissions" :key="permission">
                             <label class="flex items-center">
                                 <Checkbox v-model:checked="createApiTokenForm.permissions" :value="permission" />
-                                <span class="ml-2 text-sm text-gray-600">{{ permission }}</span>
+                                <span class="ml-2 text-sm text-secondary">{{ permission }}</span>
                             </label>
                         </div>
                     </div>

--- a/resources/js/Pages/Preferences/Partials/CategoryManagments.vue
+++ b/resources/js/Pages/Preferences/Partials/CategoryManagments.vue
@@ -43,80 +43,80 @@ const AddNewCategory = () => {};
                 <InputLabel for="categories" value="Categories" />
 
                 <div class="flex flex-wrap gap-2 mt-2">
-                    <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                    <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                    <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                    <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>
                         </button>
                     </p>
 
-                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-gray-800 bg-gray-100 rounded-lg gap-x-2 ">
+                     <p class="inline-flex items-center px-3 py-2 text-sm font-semibold text-primary bg-surface-sunken rounded-lg gap-x-2 ">
                         Watches
 
-                        <button class="text-gray-500 focus:outline-none hover:text-red-500">
+                        <button class="text-tertiary focus:outline-none hover:text-red-500">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                             </svg>

--- a/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
+++ b/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
@@ -122,7 +122,7 @@
                     id="invoicesHeadline"
                     v-model="form.invoicesHeadline"
                     name="invoicesHeadline"
-                    class="w-full h-32 px-3 py-2 mt-1 border border-gray-200 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                    class="w-full h-32 px-3 py-2 mt-1 text-primary bg-surface border border-line rounded-lg placeholder-disabled focus:border-emerald-300 dark:focus:border-emerald-600 focus:ring focus:ring-emerald-200 dark:focus:ring-emerald-800 focus:ring-opacity-50"
                 ></textarea>
                 <InputError
                     :message="form.errors.invoicesHeadline"
@@ -163,7 +163,7 @@
                         />
                     </div>
 
-                    <p class="mx-3 text-sm text-gray-500">
+                    <p class="mx-3 text-sm text-secondary">
                         {{ __("Send Notifications When Stocks Running Out") }}
                     </p>
                 </div>
@@ -206,7 +206,7 @@
                         id="currency"
                         v-model="form.currency"
                         type="text"
-                        class="block w-full uppercase bg-gray-50"
+                        class="block w-full uppercase bg-surface-sunken"
                         maxlength="3"
                         readonly
                         :placeholder="__('SDG')"

--- a/resources/js/Pages/Preferences/Partials/UpdateDateInformationForm.vue
+++ b/resources/js/Pages/Preferences/Partials/UpdateDateInformationForm.vue
@@ -41,7 +41,7 @@
                     <template #trigger>
                         <button
                             type="button"
-                            class="inline-flex items-center px-3 py-2 mt-1 text-sm font-medium leading-4 text-gray-500 transition bg-white border border-gray-200 rounded-lg gap-x-2 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 focus:outline-none"
+                            class="inline-flex items-center px-3 py-2 mt-1 text-sm font-medium leading-4 text-secondary transition bg-surface border border-line rounded-lg gap-x-2 focus:border-emerald-300 dark:focus:border-emerald-600 focus:ring focus:ring-emerald-200 dark:focus:ring-emerald-800 focus:ring-opacity-50 focus:outline-none"
                         >
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
@@ -70,7 +70,7 @@
                             (GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi
                         </DropdownLink>
 
-                        <div class="border-t border-gray-100" />
+                        <div class="border-t border-line" />
 
                         <DropdownLink
                             as="button"
@@ -80,7 +80,7 @@
                         </DropdownLink>
 
                         <div
-                            class="border-t border-gray-100"
+                            class="border-t border-line"
                             @click="form.timezone = '+2:00'"
                         />
 
@@ -109,7 +109,7 @@
                     <template #trigger>
                         <button
                             type="button"
-                            class="inline-flex items-center px-3 py-2 mt-1 text-sm font-medium leading-4 text-gray-500 transition bg-white border border-gray-200 rounded-lg gap-x-2 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50 focus:outline-none"
+                            class="inline-flex items-center px-3 py-2 mt-1 text-sm font-medium leading-4 text-secondary transition bg-surface border border-line rounded-lg gap-x-2 focus:border-emerald-300 dark:focus:border-emerald-600 focus:ring focus:ring-emerald-200 dark:focus:ring-emerald-800 focus:ring-opacity-50 focus:outline-none"
                         >
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
@@ -138,7 +138,7 @@
                             Month D, Y
                         </DropdownLink>
 
-                        <div class="border-t border-gray-100" />
+                        <div class="border-t border-line" />
 
                         <DropdownLink
                             as="button"
@@ -147,7 +147,7 @@
                             YY/MM/DD
                         </DropdownLink>
 
-                        <div class="border-t border-gray-100" />
+                        <div class="border-t border-line" />
 
                         <DropdownLink
                             as="button"
@@ -156,7 +156,7 @@
                             DD/MM/YY
                         </DropdownLink>
 
-                        <div class="border-t border-gray-100" />
+                        <div class="border-t border-line" />
 
                         <DropdownLink
                             as="button"

--- a/resources/js/Pages/Profile/Show.vue
+++ b/resources/js/Pages/Profile/Show.vue
@@ -17,7 +17,7 @@ defineProps({
 <template>
     <AppLayout :title="__('Profile')">
         <template #header>
-            <h2 class="text-xl font-semibold leading-tight text-gray-800">
+            <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-white">
                 Profile
             </h2>
         </template>

--- a/resources/js/Pages/Purchases/Card.vue
+++ b/resources/js/Pages/Purchases/Card.vue
@@ -36,25 +36,25 @@
     };
 </script>
 <template>
-    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden transition-all">
-        <div class="p-6 md:flex rtl:flex-row-reverse md:items-center md:justify-between border-b border-gray-50 dark:border-gray-800">
+    <div class="bg-surface border border-line rounded-xl overflow-hidden transition-all">
+        <div class="p-6 md:flex rtl:flex-row-reverse md:items-center md:justify-between border-b border-line">
             <div class="flex rtl:flex-row-reverse items-center gap-x-4">
 
-                <h2 v-text="formatCurrency(invoice.total, invoice.currency)" class="text-base font-semibold text-gray-800 sm:text-lg"></h2>
+                <h2 v-text="formatCurrency(invoice.total, invoice.currency)" class="text-base font-semibold text-primary sm:text-lg"></h2>
 
-                <label for="totalCost" class="text-sm font-medium text-gray-600">
+                <label for="totalCost" class="text-sm font-medium text-secondary">
                     {{ __("Total Cost") }}
                 </label>
             </div>
 
             <div class="flex-col gap-4 mt-4 sm:flex-row sm:items-center md:mt-0">
-                <h2 v-text="invoice.invocable.name" class="text-gray-900 text-xl mb-3"></h2>
+                <h2 v-text="invoice.invocable.name" class="text-primary text-xl mb-3"></h2>
                 <div class="flex rtl:flex-row-reverse gap-x-3">
                     <a
                         v-if="printable"
                         :href="route('invoices.print', invoice)"
                         target="_blank"
-                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-400 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="__('Print')"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
@@ -67,7 +67,7 @@
                     <button
                         v-if="!invoice.locked"
                         @click="moveToStorage(invoice)"
-                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-400 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="actionTitle"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
@@ -80,7 +80,7 @@
                     <Link
                         v-if="invoice.is_editable"
                         :href="route(`${resourcePrefix}.edit`, invoice)"
-                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-400 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="__('Edit Invoice')"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
@@ -91,7 +91,7 @@
                     <Link
                         v-if="invoice.can_be_inversed"
                         :href="route(`${resourcePrefix}.return.create`, invoice)"
-                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-500 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
+                        class="inline-flex items-center justify-center p-2.5 text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 dark:text-gray-400 dark:hover:text-emerald-400 dark:hover:bg-emerald-900/20 rounded-lg transition-all focus:outline-none"
                         :title="__('Return Items')"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">

--- a/resources/js/Pages/Purchases/Index.vue
+++ b/resources/js/Pages/Purchases/Index.vue
@@ -287,7 +287,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
                                     <div class="font-medium text-gray-900 dark:text-gray-100">
                                         #{{ option.serial_number }}
                                     </div>
-                                    <div class="text-xs text-gray-500">
+                                    <div class="text-xs text-tertiary">
                                         {{ option.invocable_name }} • {{ option.date }}
                                     </div>
                                 </div>
@@ -301,7 +301,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
                     </CustomSelect>
 
                     <div v-if="searchingInvoices" class="mt-4 text-center">
-                        <span class="text-sm text-gray-500">{{ __("Searching...") }}</span>
+                        <span class="text-sm text-secondary">{{ __("Searching...") }}</span>
                     </div>
                 </div>
             </template>

--- a/resources/js/Shared/Transactions.vue
+++ b/resources/js/Shared/Transactions.vue
@@ -43,35 +43,35 @@
                             <tr>
                                 <th
                                     scope="col"
-                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-gray-500 dark:text-gray-400 uppercase tracking-widest"
+                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-tertiary uppercase tracking-widest"
                                 >
                                     {{__('The Product')}}
                                 </th>
 
                                 <th
                                     scope="col"
-                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-gray-500 dark:text-gray-400 uppercase tracking-widest"
+                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-tertiary uppercase tracking-widest"
                                 >
                                     {{__('Quantity')}}
                                 </th>
 
                                 <th
                                     scope="col"
-                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-gray-500 dark:text-gray-400 uppercase tracking-widest"
+                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-tertiary uppercase tracking-widest"
                                 >
                                     {{__('Price')}}
                                 </th>
 
                                 <th
                                     scope="col"
-                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-gray-500 dark:text-gray-400 uppercase tracking-widest"
+                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-tertiary uppercase tracking-widest"
                                 >
                                     {{__('Total Price')}}
                                 </th>
 
                                 <th
                                     scope="col"
-                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-gray-500 dark:text-gray-400 uppercase tracking-widest"
+                                    class="px-8 py-3.5 whitespace-nowrap text-[10px] font-bold text-left rtl:text-right text-tertiary uppercase tracking-widest"
                                 >
                                     {{__('Status')}}
                                 </th>
@@ -84,15 +84,15 @@
                             <tr
                                 v-for="record in deliveredRecords"
                                 :key="record.id"
-                                :class="remainingRecords.length ? 'bg-gray-100' : ''"
+                                :class="remainingRecords.length ? 'bg-surface-sunken' : ''"
                             >
                                 <td
-                                    class="px-8 py-3 text-sm text-left rtl:text-right text-gray-800 whitespace-nowrap"
+                                    class="px-8 py-3 text-sm text-left rtl:text-right text-primary whitespace-nowrap"
                                     v-text="record.product?.name"
                                 ></td>
 
                                 <td
-                                    class="px-8 py-3 text-sm text-left rtl:text-right text-gray-800 whitespace-nowrap"
+                                    class="px-8 py-3 text-sm text-left rtl:text-right text-primary whitespace-nowrap"
                                 >
                                     {{ record.quantity }}
                                     <strong v-if="record.unit">({{ record.unit?.name }})</strong>
@@ -109,8 +109,8 @@
                                     v-text="totalPrice(record)"
                                 ></td>
 
-                                <td class="px-8 py-3 text-xs text-left rtl:text-right text-gray-500 whitespace-nowrap">
-                                    <span class="text-emerald-600 font-medium">✓ {{ invoice.invocable_type === 'App\\Models\\Customer' ? __('Delivered') : __('Received') }}</span>
+                                <td class="px-8 py-3 text-xs text-left rtl:text-right text-secondary whitespace-nowrap">
+                                    <span class="text-emerald-600 dark:text-emerald-400 font-medium">✓ {{ invoice.invocable_type === 'App\\Models\\Customer' ? __('Delivered') : __('Received') }}</span>
                                 </td>
                             </tr>
 
@@ -120,7 +120,7 @@
                                 >
                                     <td
                                         colspan="4"
-                                        class="py-2  text-center text-gray-500 font-semibold bg-gray-100 border-t border-b"
+                                        class="py-2  text-center text-secondary font-semibold bg-surface-sunken border-t border-b border-line"
                                     >
                                         {{__('Invoice Remaining')}}
                                     </td>
@@ -131,12 +131,12 @@
                                     :key="record.id"
                                 >
                                     <td
-                                        class="px-8 py-3 text-sm text-left rtl:text-right text-gray-800 whitespace-nowrap"
+                                        class="px-8 py-3 text-sm text-left rtl:text-right text-primary whitespace-nowrap"
                                         v-text="record.product?.name"
                                     ></td>
 
                                     <td
-                                        class="px-8 py-3 text-sm text-left rtl:text-right text-gray-800 whitespace-nowrap"
+                                        class="px-8 py-3 text-sm text-left rtl:text-right text-primary whitespace-nowrap"
                                     >
                                         {{ record.quantity }}
                                         <strong v-if="record.unit">({{ record.unit?.name }})</strong>
@@ -154,9 +154,9 @@
                                     ></td>
 
                                     <td
-                                        class="px-8 py-3 text-xs text-left rtl:text-right text-gray-500 whitespace-nowrap"
+                                        class="px-8 py-3 text-xs text-left rtl:text-right text-secondary whitespace-nowrap"
                                     >
-                                        <span class="text-amber-600 font-medium">{{ __('Pending') }}</span>
+                                        <span class="text-amber-600 dark:text-amber-400 font-medium">{{ __('Pending') }}</span>
                                     </td>
                                 </tr>
                             </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,36 @@ module.exports = {
             fontFamily: {
                 sans: ['Cairo', ...defaultTheme.fontFamily.sans],
             },
+
+            /*
+             * Semantic, theme-aware design tokens.
+             *
+             * Values are driven by CSS custom properties defined in
+             * resources/css/app.css, which flip automatically under
+             * `@media (prefers-color-scheme: dark)` (this app's dark mode is
+             * media/OS driven, not class based). Because the variables carry
+             * the theme, these utilities resolve correctly in BOTH themes with
+             * no `dark:` variant required — e.g. `text-secondary`, `bg-surface`.
+             *
+             * NOTE: `primary`/`secondary`/`tertiary`/`disabled` here are
+             * FOREGROUND TEXT tokens (neutral greys), NOT the emerald brand
+             * accent. Keep using `emerald-*` for brand/action colours.
+             */
+            colors: {
+                primary: 'rgb(var(--fg-primary) / <alpha-value>)',
+                secondary: 'rgb(var(--fg-secondary) / <alpha-value>)',
+                tertiary: 'rgb(var(--fg-tertiary) / <alpha-value>)',
+                disabled: 'rgb(var(--fg-disabled) / <alpha-value>)',
+                surface: {
+                    DEFAULT: 'rgb(var(--surface) / <alpha-value>)',
+                    elevated: 'rgb(var(--surface-elevated) / <alpha-value>)',
+                    sunken: 'rgb(var(--surface-sunken) / <alpha-value>)',
+                },
+                line: {
+                    DEFAULT: 'rgb(var(--line) / <alpha-value>)',
+                    strong: 'rgb(var(--line-strong) / <alpha-value>)',
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary

Fixes two dark-mode legibility bugs in the RTL admin app — **at the design-token level**, not element-by-element. Dark mode here is media/OS-driven (`prefers-color-scheme`, no `.dark` class), so the fix is a small set of CSS-variable-backed semantic tokens that resolve correctly in both themes with no `dark:` variant needed.

### Bug 1 — muted text on dark surfaces (المشتريات / purchases)
The invoice header ("إجمالي التكلفة" + amount), product names (رطل جرجر, رطل رجله), quantity/unit cells and status cells used light-theme greys (`text-gray-500/600/800`) with **no `dark:` variant** → near-invisible on the dark surface.

### Bug 2 — white cards in dark mode (settings pages)
`FormSection` rendered `bg-white` with **no dark counterpart** → a glaring white panel inside the dark app, with muted labels on white and a near-invisible placeholder in the "رأس الفواتير" textarea. `FormSection` powers 7 forms, so the one surface fix cascades.

## Token layer
- **`resources/css/app.css`** — CSS custom properties for foreground / surface / hairline, with `@media (prefers-color-scheme: dark)` overrides (stored as `R G B` triplets so opacity modifiers keep working).
- **`tailwind.config.js`** — registers `text-primary/secondary/tertiary/disabled`, `bg-surface/-elevated/-sunken`, `border-line`, `placeholder-disabled`.

Applied to the purchases card + transactions table, the shared `FormSection`/`SectionTitle`/`TextArea`, and the settings partials. Also: fixed placeholder contrast, the readonly currency field (`surface-sunken`), bumped invoice icon buttons from `gray-500`→`gray-400` on dark, and gave `Dropdown`/`DropdownLink` **additive** dark variants (light mode untouched).

## Contrast — computed, not eyeballed

| Token | Dark | Light |
|---|---|---|
| primary text | 16.1:1 | 17.7:1 |
| secondary (muted) | 12.0:1 | 7.6:1 |
| tertiary (headers/captions) | 7.0:1 | 4.8:1 |
| ✓Received / Pending | 4.7 / 10.6:1 | AA-large |
| placeholder (disabled) | 3.7:1 (visible, distinct from 16:1 entered text) | — |

All body/heading text meets **WCAG AA (≥4.5:1)** in both themes; header vs body rows stay distinguishable; green accent kept and verified. Light mode unchanged.

## Verification
- `npm run build` passes; compiled CSS confirmed to resolve each token to its var with correct light/dark values.
- Contrast ratios computed for every foreground/background pairing.
- These are presentational token/CSS changes with no logic path — no unit test applies; the build + CSS-var resolution + contrast math are the proof.

## Out of scope (flagged, not fixed)
- **Pre-existing, unrelated:** the `Profile` security partials (2FA, browser-sessions, delete-account) use the transparent `ActionSection` and carry their own un-darked greys — a pre-existing dark bug independent of these two. Better as its own PR.
- **Intentionally light-only** (correctly skipped): print/receipt pages, `Welcome` marketing, public legal pages, auth/invitation screens (slate palette).