### PR TITLE
docs(inventory): stock-movement ledger migration PRDs

### DIFF
--- a/docs/inventory-ledger/M1-ledger-hardening.md
+++ b/docs/inventory-ledger/M1-ledger-hardening.md
@@ -1,0 +1,91 @@
+# PRD — M1: Ledger hardening
+
+**Status:** Draft · **Milestone:** M1 · **Depends on:** — · **PR grouping:** one PR
+
+## 1. Problem
+
+`stock_movements` is already a signed, polymorphic, complete record of every runtime stock change, but it is not yet a trustworthy *source of truth*: its `reason` is a free-form string (not a typed vocabulary), and nothing prevents a row from being updated or deleted. Before we can derive balances from it or migrate reads onto it (M2, M9, M10), the ledger must be typed and immutable. This milestone hardens the existing recording without changing any behavior — reads and writes stay exactly as they are today (dual-write with `stocks.quantity`).
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Introduce a typed `MovementType` enum and persist it on every movement.
+- Backfill `movement_type` for all existing rows from `reason`.
+- Enforce append-only at the model layer (no updates, no deletes, no soft-deletes).
+
+**Non-goals**
+- Reading balances from the ledger (M2).
+- Removing the `reason` column (kept for continuity; may retire post-cutover).
+- Any strategy/enforcement/overselling behavior (M3/M4).
+- Product variants (out of scope entirely — no variants in schema).
+
+## 3. Current state (from audit)
+
+- Single write choke point: `Storage::addStock` (`app/Models/Storage.php:108`), `deductStock` (`:144`), `setStockTo` (`:173`), all calling `recordMovement()` (`:198`) which `->create()`s a `stock_movements` row with `tenant_id, storage_id, product_id, user_id, movable_type/id, reason, quantity (signed), quantity_before, quantity_after`.
+- Reasons in use today: `purchase_receipt, invoice_addition, invoice_deduction, sale_delivery, adjustment, transfer_out, transfer_in, sales_return, purchase_return` (from `ReceiveGoodsAction`, `Transaction::add/deduct`, `DeliverTransactionAction`, `RecordAdjustmentAction`, `TransferStockAction`, `ReverseTransactionAction`).
+- Model `app/Models/StockMovement.php` has no immutability guard, no `SoftDeletes`. Grep confirms nothing updates/deletes movements today — append-only is convention, not enforced.
+- Migration `2026_04_22_131838_create_stock_movements_table.php` defines the table.
+
+## 4. Design & behavior
+
+Add `App\Enums\MovementType` (string-backed) covering the nine existing reasons **plus** `opening_balance` (used by M9). `recordMovement()` accepts/derives a `MovementType` and writes it to a new `movement_type` column alongside the existing `reason` (dual-write; `reason` unchanged). A `MovementType::fromReason(string): self` mapping keeps callers that still pass a reason string working and drives the backfill. The `StockMovement` model gains a `booted()` guard that throws on `updating` and `deleting` events, making immutability a hard runtime invariant.
+
+No behavior visible to users changes; this is a structural/foundation milestone.
+
+## 5. Data model / schema changes
+
+- **New migration** on `stock_movements`: add `movement_type` (string, nullable initially for backfill, then indexed). Optionally a second migration to set `NOT NULL` after backfill.
+- Backfill `movement_type = MovementType::fromReason(reason)` for all existing rows.
+- No column removed. Reversible (`down()` drops `movement_type`).
+
+## 6. Task specs
+
+### T1.1 — `MovementType` enum · **S**
+- **Behavior:** string-backed enum, cases `OpeningBalance='opening_balance', PurchaseReceipt='purchase_receipt', InvoiceAddition='invoice_addition', InvoiceDeduction='invoice_deduction', SaleDelivery='sale_delivery', Adjustment='adjustment', TransferIn='transfer_in', TransferOut='transfer_out', SalesReturn='sales_return', PurchaseReturn='purchase_return'`. Static `fromReason(string $reason): self` returns the matching case (throws/logs on unknown). Optional `isIncrease(): bool` helper.
+- **Files:** *new* `app/Enums/MovementType.php`.
+- **Edge cases:** an unrecognized legacy `reason` — `fromReason` must fail loudly in tests but be handled (fallback to a generic case or exception) so backfill surfaces surprises.
+- **Acceptance criteria:** every reason string currently emitted maps to exactly one case; `fromReason` round-trips for all known reasons.
+- **Test plan:** unit test asserting each known reason → expected case; unknown reason behavior asserted.
+
+### T1.2 — `movement_type` column + backfill · **S**
+- **Behavior:** migration adds nullable `movement_type` string + index; a backfill step updates every existing row via `fromReason(reason)`.
+- **Files:** *new* migration under `database/migrations/`.
+- **Edge cases:** large tables — backfill in chunks; run inside the same migration or a follow-up command; must be idempotent/reversible.
+- **Acceptance criteria:** after migrate, no `stock_movements` row has null `movement_type`; column indexed; `down()` cleanly drops it.
+- **Test plan:** migration test seeding rows with legacy reasons, asserting populated `movement_type` post-migrate.
+
+### T1.3 — Typed movement recording · **M**
+- **Behavior:** `recordMovement()` sets `movement_type` (derived from the passed reason, or accept an explicit `MovementType` param defaulted from reason). Callers may keep passing reason strings; ideally pass a `MovementType` where natural. Keep `reason` written (dual-write).
+- **Files:** `app/Models/Storage.php:198` and callers: `app/Actions/Stock/*`, `app/Actions/Purchase/ReceiveGoodsAction.php`, `app/Models/Transaction.php:151,173`.
+- **Edge cases:** ensure `setStockTo` (delta path) and both increase/decrease paths all set type; transfers set `transfer_in`/`transfer_out` distinctly.
+- **Acceptance criteria:** each of the nine write paths persists the correct `movement_type`.
+- **Test plan:** one feature test per path (purchase receive, invoice add/deduct, sale delivery, adjustment, transfer in/out, sales/purchase return) asserting the persisted `movement_type`.
+
+### T1.4 — Append-only enforcement · **S**
+- **Behavior:** `StockMovement::booted()` registers `updating` and `deleting` listeners that throw a domain exception; ensure model does **not** use `SoftDeletes`.
+- **Files:** `app/Models/StockMovement.php`.
+- **Edge cases:** the M9 opening-balance backfill must *create* rows, never update — verify it isn't blocked. FK `cascadeOnDelete` still deletes rows if a parent tenant/storage/product is hard-deleted (DB-level, outside Eloquent) — document this as accepted.
+- **Acceptance criteria:** calling `->update()`/`->save()` on a dirty movement or `->delete()` throws; creating a new movement still works.
+- **Test plan:** unit test asserting update and delete throw; create succeeds.
+
+## 7. Edge cases (cross-task)
+
+- Unknown legacy reason strings from any historical data → backfill must surface, not silently mislabel.
+- Cascade deletes via FK bypass the Eloquent guard — acceptable and documented (tenant/product/storage teardown).
+
+## 8. Test plan (summary)
+
+- Enum mapping unit test (T1.1).
+- Migration + backfill test (T1.2).
+- Per-path `movement_type` feature tests (T1.3).
+- Immutability unit test (T1.4).
+- Regression: existing stock feature tests still green (no behavior change).
+
+## 9. Rollout & backwards compatibility
+
+Fully additive and reversible. No behavior change; `reason` retained. Ship as one PR. Safe to deploy ahead of all other milestones; it is their prerequisite.
+
+## 10. Open questions
+
+- Do we retain `reason` long-term (human note) or retire it after cutover once `movement_type` + `movable` cover all needs? (Lean: retain as free-text note.)
+- Should `fromReason` on an unknown string throw or map to a generic `Adjustment`? (Lean: throw in tests/backfill, log+generic in runtime.)

--- a/docs/inventory-ledger/M10-cutover.md
+++ b/docs/inventory-ledger/M10-cutover.md
@@ -1,0 +1,96 @@
+# PRD — M10: Cutover (reads → ledger, cache retained)
+
+**Status:** Draft · **Milestone:** M10 · **Depends on:** M9 (opening balances) · **PR grouping:** one PR (or incremental commits — one read surface per commit)
+
+## 1. Problem
+
+Every read of stock today goes to the mutable `stocks.quantity` column, treating it as the authoritative number. The target design retires that *mentality*: movement records become authoritative and current stock is `SUM(signed_quantity)`, with a cached/denormalized balance for read performance. NamaIn is already most of the way there — `stocks.quantity` is an incrementally-updated, row-locked balance cache (`Storage::addStock/deductStock/setStockTo`), and after M9 the ledger reconciles to it exactly. This final milestone flips the framing: reads become *ledger-consistent* (sourced from the reconciled balance helper), `stocks.quantity` is demoted to a pure cache, and nothing is destructively dropped. This is the only milestone permitted non-additive changes — and even here we keep the column.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Route the ~15 stock-read surfaces through the reconciled balance helper (M2.T2.1) instead of reading `stocks.quantity` directly.
+- Preserve O(1) POS-speed reads by keeping `stocks.quantity` as the maintained cache — never sum the ledger on a hot path.
+- Correctly surface negative balances in reads/reports (stop silently dropping them).
+- Formally retire the "column is source of truth" mentality via docs + guardrails, with the ledger authoritative.
+
+**Non-goals**
+- Dropping `stocks.quantity` (it survives as the derived cache).
+- Any strategy/enforcement changes (M3/M4) or costing changes (M8).
+- Rebuilding the write path — writes already maintain both ledger and cache.
+- Product variants (out of scope).
+
+## 3. Current state (from audit)
+
+Read surfaces that hit `stocks.quantity` / `average_cost` directly and become cutover change points:
+- `app/Queries/Reports/InventoryValuationQuery.php:34-47` — `stocks.quantity * COALESCE(average_cost,cost,0)`, **filters `quantity > 0`** (`:39`) so negatives are silently excluded.
+- `app/Queries/DashboardStatsQuery.php` — `totalInventoryValue()` (`:87`), `lowStockProducts()` (`:206`, `SUM(quantity) <= alert_quantity`); `topSellingProducts()` (`:171`) reads `transactions`, not on-hand (leave as-is).
+- `app/Http/Controllers/Inventory/StoragesController.php:30-41` — per-storage value/quantity in PHP over the `stock` pivot.
+- `app/Http/Controllers/Catalog/ProductsController.php:26` + `Product::scopeWithStockAggregates` (`app/Models/Product.php:186`) + `Product::quantityOnHand()` (`:263`).
+- `app/Http/Controllers/Sales/PosSessionController.php` — availability joins on `stocks.quantity`.
+- `app/Http/Controllers/Inventory/StockTransfersController.php` — reads on-hand for transfer source.
+- `app/Models/Stock.php:28-41` — `average_cost`/`total_cost` accessors appended to every serialized pivot.
+- Exports + Vue: `InventoryValuationExport`; `resources/js/Pages/Reports/InventoryValuation.vue`, `Dashboard.vue`, `Storages/{Index,Show}.vue`, `Products/{Index,Show}.vue`.
+
+By M9, `SUM(stock_movements.quantity) == stocks.quantity` per `(tenant, product, storage)` holds by construction, so switching reads is a source-swap, not a value change (except where negatives were being dropped).
+
+## 4. Design & behavior
+
+Introduce the balance read through the M2.T2.1 helper (`StockBalanceQuery` / `Product`/`Storage` balance methods) as the canonical way to obtain on-hand. Two read tiers:
+- **Hot path (POS, availability, product lists):** read the `stocks.quantity` cache — it *is* the denormalized balance, kept correct on every write under a row lock. Keep O(1); never `SUM` the ledger here.
+- **Reporting/valuation path:** read via the balance helper so the number is definitionally the reconciled ledger balance; where a raw `stocks` join is retained for performance, it is documented as "cache == ledger (guaranteed by M9 reconciliation)".
+
+Migrate one surface per commit so each is independently verifiable against the reconciled balance. After all surfaces are switched, add a guardrail test asserting the cache-equals-ledger invariant across the suite, and update docs to declare the ledger authoritative and `stocks.quantity` a cache. `stocks.quantity` is **not** dropped.
+
+## 5. Data model / schema changes
+
+- **None destructive.** `stocks.quantity` is retained as the cache column.
+- No new tables/columns required (the balance helper and reconciliation land in M2).
+- The only "change" is conceptual + code-level (read source) plus a documented invariant; fully reversible per surface by reverting the commit.
+
+## 6. Task specs
+
+### T10.1 — Switch read surfaces to the reconciled balance · **L**
+- **Behavior:** replace each direct `stocks.quantity` read with the M2.T2.1 balance helper, keeping `stocks.quantity` as the O(1) cache on hot paths. Incremental — one surface per commit, each verified against the reconciled balance.
+- **Files:** `app/Queries/Reports/InventoryValuationQuery.php:34-47`; `app/Queries/DashboardStatsQuery.php:87,206`; `app/Http/Controllers/Inventory/StoragesController.php:30-41`; `app/Http/Controllers/Catalog/ProductsController.php:26` + `app/Models/Product.php:186,263`; `app/Http/Controllers/Sales/PosSessionController.php`; `app/Http/Controllers/Inventory/StockTransfersController.php`; `app/Models/Stock.php:28-41`; `app/Exports/Reports/InventoryValuationExport.php`; Vue: `resources/js/Pages/Reports/InventoryValuation.vue`, `Dashboard.vue`, `Storages/{Index,Show}.vue`, `Products/{Index,Show}.vue`.
+- **Edge cases:** POS availability and product-list sorting must stay O(1) — keep the cache read, do not sum the ledger; `topSellingProducts` (`:171`) is transactions-based, not on-hand — leave untouched; `withStockAggregates` subselects (`pending_sales_qty`/`pending_purchases_qty`) are transaction-derived and unaffected.
+- **Acceptance criteria:** each migrated report/screen returns values identical to the reconciled ledger balance; POS balance reads remain O(1) (no per-request ledger `SUM`); no surface still treats the column as authoritative in comments/semantics.
+- **Test plan:** per-surface feature test asserting reported balance/value equals `SUM(stock_movements.quantity)` for a fixture with mixed movements; a POS test asserting availability read does not trigger a ledger aggregation.
+
+### T10.2 — Include negatives where correct · **M**
+- **Behavior:** revisit the `quantity > 0` filter so negative balances are not silently dropped from stock views/valuation; define and document the valuation treatment of negative on-hand (e.g. negative value contribution vs. excluded-but-listed).
+- **Files:** `app/Queries/Reports/InventoryValuationQuery.php:39` and any view/report mirroring that filter.
+- **Edge cases:** negative × `average_cost` yields negative valuation — confirm this is the intended accounting treatment or explicitly list-but-exclude; ensure the M7 negative-stock report and the valuation report agree on which products are negative.
+- **Acceptance criteria:** negative balances appear where expected (not dropped); valuation treatment of negatives is documented and covered by a test; valuation and M7 report reconcile on the negative set.
+- **Test plan:** test with a product driven negative asserting it is visible in stock views and handled per the documented valuation rule.
+
+### T10.3 — Retire authoritative-column mentality · **S**
+- **Behavior:** docs + guardrails declaring the ledger authoritative and `stocks.quantity` a derived cache; verify every writer still maintains the cache; explicitly **no** destructive drop of `stocks.quantity`.
+- **Files:** `docs/inventory-ledger/` (this milestone's closeout notes) and a suite-level invariant test.
+- **Edge cases:** any future writer that mutates `stocks` must also emit a movement — the M1 append-only guard + M2 reconciliation command are the safety net; wire reconciliation into CI or a scheduled check.
+- **Acceptance criteria:** cache-equals-ledger invariant test is green across the suite; `stocks.quantity` still exists; documentation states the source-of-truth switch.
+- **Test plan:** invariant test asserting `SUM(stock_movements.quantity) == stocks.quantity` per `(product,storage)` after representative operation sequences; grep/arch guard that no non-`Storage` writer mutates `stocks.quantity`.
+
+## 7. Edge cases (cross-task)
+
+- Cache drift: if any pre-existing bug left cache ≠ ledger, M9 reconciliation already folded it into an opening balance; the invariant test (T10.3) is the ongoing tripwire.
+- Performance regression risk: accidentally routing a hot path (POS/product list) through a ledger `SUM` — guarded by T10.1 acceptance criteria and an explicit O(1) test.
+- Negative balances interacting with `average_cost` costing (M8) — valuation of negatives must not double-count with provisional-cost handling.
+
+## 8. Test plan (summary)
+
+- Per-surface parity tests: migrated read == reconciled ledger balance (T10.1).
+- POS O(1) read test: no ledger aggregation on the hot path (T10.1).
+- Negative-balance visibility + valuation-treatment test (T10.2).
+- Suite-wide cache-equals-ledger invariant + no-rogue-writer guard (T10.3).
+- Regression: all existing report/dashboard/product/storage tests green with unchanged values (except intended negative handling).
+
+## 9. Rollout & backwards compatibility
+
+Ship incrementally — one read surface per commit, each independently revertible — behind the guarantee that M9 made cache == ledger. Values are unchanged for existing tenants except where negatives were previously dropped (now surfaced intentionally). No destructive schema change: `stocks.quantity` remains as the cache, so rollback is a code revert with zero data migration. This is the last milestone; on completion the ledger is authoritative and the column is documented as a cache.
+
+## 10. Open questions
+
+- Valuation treatment of negative on-hand: contribute negative value to total inventory worth, or list-but-exclude from the valuation sum? (Lean: contribute negative value so valuation ties to the ledger; document clearly.)
+- Do we schedule the M2 reconciliation command in CI/production as a standing tripwire, and at what cadence? (Lean: nightly per-tenant check with alerting on drift.)
+- Long-term: once reads are ledger-consistent and stable, is there appetite to eventually drop `reason`/other legacy columns — deferred beyond this milestone.

--- a/docs/inventory-ledger/M2-balance-reconciliation.md
+++ b/docs/inventory-ledger/M2-balance-reconciliation.md
@@ -1,0 +1,84 @@
+# PRD — M2: Balance helper + reconciliation
+
+**Status:** Draft · **Milestone:** M2 · **Depends on:** M1 · **PR grouping:** one PR
+
+## 1. Problem
+
+Once the ledger is typed and immutable (M1), it can serve as the authoritative record of stock — but nothing yet *derives* a balance from it, and nothing verifies that the mutable cache (`stocks.quantity`) still agrees with the sum of movements. We need (a) a first-class way to compute the ledger balance, and (b) a reconciliation tool that detects drift between the cache and the ledger. This is the safety net that lets later milestones (M9 opening balances, M10 read cutover) trust the ledger and lets us flip existing tenants over with confidence. Crucially, the cache stays the hot-path source of reads — the ledger sum is never summed at POS speed.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Provide a tenant-scoped helper computing `SUM(stock_movements.quantity)` per product (and per product×storage).
+- Provide a `stock:reconcile` command that reports drift between `stocks.quantity` and the ledger sum.
+- Lock in the invariant `SUM(movements) == stocks.quantity` per (product,storage) with a test.
+
+**Non-goals**
+- Switching any read surface onto the balance helper (M10).
+- Auto-correcting drift or inserting compensating movements (M9 owns opening-balance backfill).
+- Changing how writes maintain `stocks.quantity` — it remains the O(1) row-locked cache (`Storage::addStock/deductStock/setStockTo`).
+- Any strategy/overselling behavior (M3/M4).
+
+## 3. Current state (from audit)
+
+- The cache is maintained by the single write choke point: `Storage::addStock` (`app/Models/Storage.php:108`), `deductStock` (`:144`), `setStockTo` (`:173`), each locking the `stocks` row and calling `recordMovement()` (`:198`).
+- Balance is read today from the cache, never the ledger: `Product::quantityOnHand()` (`app/Models/Product.php:263`), `scopeWithStockAggregates` (`app/Models/Product.php:186`), and ~15 report/UI surfaces (the M10 change set).
+- The ledger (`stock_movements`) is currently latent — no reader derives balances from it.
+- Known drift sources are non-production only: seeder bypasses `database/seeders/DatabaseSeeder.php:58` (`stock()->attach`) and `database/seeders/DashboardExampleSeeder.php:58` (`syncWithoutDetaching`), plus `database/factories/StockFactory.php`. All runtime paths funnel through the choke point, so real tenants should reconcile cleanly.
+
+## 4. Design & behavior
+
+A dedicated query object computes the ledger balance as `SUM(stock_movements.quantity)`, grouped per product or per product×storage, tenant-scoped (movements carry `tenant_id`; reads go through the tenant-scoped path). On clean data this equals `stocks.quantity`.
+
+A console command `stock:reconcile` iterates every (tenant, product, storage) with either a `stocks` row or movements, computes cache-vs-ledger, and reports every non-zero delta (product, storage, cache qty, ledger qty, drift). Human-readable table by default; `--json` for machine consumption / CI. The command is read-only — it never mutates stock; it only surfaces drift for M9 to absorb into opening balances.
+
+The reconciliation invariant is asserted by a test that runs a representative sequence of operations (purchase receive, sale delivery, adjustment, transfer, return) and checks `SUM(movements) == stocks.quantity` for every (product,storage).
+
+## 5. Data model / schema changes
+
+None. This milestone is pure read/query + a command. No migrations.
+
+## 6. Task specs
+
+### T2.1 — Ledger balance helper · **S**
+- **Behavior:** new `app/Queries/StockBalanceQuery.php` (or methods on `Product`/`Storage`) returning `SUM(stock_movements.quantity)` per (product) and per (product,storage), tenant-scoped. Mirrors the semantics of `Product::quantityOnHand()` but sourced from the ledger.
+- **Files:** *new* `app/Queries/StockBalanceQuery.php`; optional thin accessor on `app/Models/Product.php` / `app/Models/Storage.php`.
+- **Edge cases:** product/storage with zero movements → balance `0` (not null); soft-deleted products still summable; ensure the query doesn't accidentally sum across tenants.
+- **Acceptance criteria:** on clean fixture data the helper returns the same value as `stocks.quantity` for every (product,storage); tenant isolation holds.
+- **Test plan:** unit/feature test seeding movements via the choke point, asserting helper equals `stocks.quantity`; a second tenant's movements excluded.
+
+### T2.2 — Reconcile command · **M**
+- **Behavior:** new `app/Console/Commands/ReconcileStockCommand.php` signature `stock:reconcile {--json} {--tenant=}`. Per (tenant,product,storage) compares `stocks.quantity` (cache) vs `StockBalanceQuery` (ledger); prints only drifting rows with cache, ledger, and delta; summary count. `--json` emits structured output; exit code non-zero when drift found (CI-friendly).
+- **Files:** *new* `app/Console/Commands/ReconcileStockCommand.php`.
+- **Edge cases:** rows present in `stocks` but with no movements (seeder bypass) → full quantity reported as drift; movements present but no `stocks` row → negative-only ledger reported; must not choke on large tenants (chunk iteration).
+- **Acceptance criteria:** clean data → zero drift, exit 0; a seeded (bypassed) tenant → reports the exact gap, exit non-zero; `--json` well-formed.
+- **Test plan:** feature test with a clean tenant (no drift) and a bypass-seeded tenant (known drift), asserting reported deltas and exit code; `--json` shape asserted.
+
+### T2.3 — Reconciliation invariant test · **S**
+- **Behavior:** test-only guard asserting the core invariant after an arbitrary op sequence.
+- **Files:** *new* test under `tests/Feature/Inventory/`.
+- **Edge cases:** include a transfer (net-zero across two storages) and a return to exercise sign handling; assert per (product,storage), not just per product.
+- **Acceptance criteria:** after purchase→sale→adjustment→transfer→return, `SUM(movements) == stocks.quantity` for every (product,storage).
+- **Test plan:** Pest feature test driving the actions and asserting the invariant.
+
+## 7. Edge cases (cross-task)
+
+- Seeder/factory bypass rows (`DatabaseSeeder.php:58`, `DashboardExampleSeeder.php:58`, `StockFactory`) will surface as drift — this is expected and is exactly what M9.T9.2 fixes and M9.T9.1 absorbs.
+- `stocks` rows and movements can each exist without the other; the command must handle both directions of drift.
+- Tenant scoping: reconcile per tenant; never sum movements across tenants.
+
+## 8. Test plan (summary)
+
+- Balance-helper equals cache on clean data + tenant isolation (T2.1).
+- Reconcile command: clean vs drifting tenant, exit codes, `--json` (T2.2).
+- Invariant after mixed op sequence (T2.3).
+- Regression: existing stock feature tests still green (no behavior change).
+
+## 9. Rollout & backwards compatibility
+
+Pure additive tooling — no schema, no behavior change, no read-path change. `stocks.quantity` remains the authoritative read cache throughout. Safe to deploy immediately after M1. The `stock:reconcile` command is the pre-flight gate reused by M9.T9.3 before the opening-balance backfill.
+
+## 10. Open questions
+
+- Should `stock:reconcile` be scheduled (e.g. nightly) to catch future drift, or run on demand only? (Lean: on-demand now; consider a scheduled health check post-cutover.)
+- Do we want a `--fix` mode later that emits compensating movements, or keep correction exclusively in M9's opening-balance path? (Lean: keep correction in M9 to avoid two reconciliation code paths.)

--- a/docs/inventory-ledger/M3-strategy-setting.md
+++ b/docs/inventory-ledger/M3-strategy-setting.md
@@ -1,0 +1,98 @@
+# PRD — M3: Strategy setting + policy layer
+
+**Status:** Draft · **Milestone:** M3 · **Depends on:** M2 · **PR grouping:** one PR (T3.1, T3.2, T3.4) + one **separate** hygiene PR (T3.3, prerequisite)
+
+## 1. Problem
+
+Today inventory behavior is hard-coded: positive stock enters (almost) only via purchase invoices, and `Storage::deductStock` blocks unconditionally when stock is short. Merchants split into two camps — one wants strict purchase-driven discipline, the other wants to manage quantities freely and even oversell into negative. We need a per-tenant setting that answers **"how do you want to manage your inventory?"** and a single policy layer that turns that answer into concrete validation rules, so enforcement isn't scattered across controllers/actions. This milestone introduces the setting and the policy contract but does **not** yet wire enforcement into the write paths (that is M4) — it ships behavior-neutral with every tenant defaulting to `purchase_driven` (exactly today's behavior).
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A per-tenant `inventory_strategy` (`purchase_driven` | `free_form`) with a nested `allow_overselling` boolean (only meaningful under `free_form`).
+- A single `InventoryStrategy` policy layer that resolves the tenant's setting into rule methods — the one place M4 (and everything after) asks "can this deduction proceed?" / "may stock be manually increased?".
+- Owner/admin settings UI to choose the strategy, with the overselling toggle shown only for `free_form`.
+- Default `purchase_driven` for all existing and new tenants — no behavior change on ship.
+
+**Non-goals**
+- Wiring the strategy into `deductStock`/POS/adjustments or making the DB column signed (all M4).
+- Recording a dated settings-change audit event (M6).
+- Any costing/reporting change (M7/M8).
+
+## 3. Current state (from audit)
+
+- Preferences are a tenant-scoped key/value store: model `app/Models/Preference.php`, read helper `preference($key, $default)` (`bootstrap/helpers.php:60`), written via `app/Actions/UpdatePreferences.php` (`updateOrCreate` + `Cache::forget('preferences')`), UI `app/Http/Controllers/Core/PreferenceController.php` → `resources/js/Pages/Preferences/Show.vue`, gated to owner/admin.
+- **Allowed keys are whitelisted** in `app/Http/Requests/PreferenceRequest.php:19` (`logo, invoicesHeadline, alerts, currency, pecentage`) — any key not listed is silently dropped by `$request->validated()`. There is **no unique `(tenant_id, key)` index** on `preferences`.
+- Today's only hard enforcement point is `Storage::deductStock` (`app/Models/Storage.php:156-158`), which throws `InsufficientStockException` unconditionally; POS has its own advisory precheck (`ProcessPosCheckoutAction.php:67-81`). Net-new positive stock without an invoice is possible only via Adjustments (`RecordAdjustmentAction`).
+- **Preferences cache key is not tenant-qualified:** `Cache::rememberForever('preferences', …)` at `ResolveTenant.php:33`, `HandleInertiaRequests.php:124`, `HandleLocale.php:29`, `User.php:181`, invalidated with the same flat key at `UpdatePreferences.php:26` — a cross-tenant staleness/leak risk on shared cache stores.
+
+## 4. Design & behavior
+
+Add two preference keys. `inventory_strategy` selects the primary mode; `allow_overselling` is a nested sub-setting that is only read/shown under `free_form` (under `purchase_driven` it is irrelevant and hidden — strict mode always blocks). The **ledger schema is identical in every configuration**; the strategy only changes which entry paths are permitted and how deductions validate.
+
+Enforcement rules live behind an `InventoryStrategy` contract with two concrete implementations resolved from the tenant's setting:
+
+- `PurchaseDrivenStrategy`: `allowsManualStockIncrease() = false`, `allowsOverselling() = false`, `assertCanDeduct()` throws when `requested > available`.
+- `FreeFormStrategy`: `allowsManualStockIncrease() = true`, `allowsOverselling()` = the `allow_overselling` flag, `assertCanDeduct()` is a no-op when overselling is allowed, otherwise blocks at zero.
+
+A resolver (bound in the container / a small factory) reads `preference('inventory_strategy', 'purchase_driven')` + `preference('allow_overselling', false)` and returns the right instance. This is the single seam M4 consumes. The settings UI presents a primary radio and a conditionally-visible overselling toggle.
+
+## 5. Data model / schema changes
+
+- **No table/column changes.** New behavior rides on the existing key/value `preferences` table via two new keys (`inventory_strategy`, `allow_overselling`).
+- **Recommended (in T3.3 hygiene PR):** add a unique index on `preferences (tenant_id, key)` — none exists today, and strategy correctness depends on a single row per key per tenant. (Guarded/optional if legacy duplicate rows exist — dedupe first.)
+- The signed-`stocks.quantity` migration is explicitly deferred to M4.
+
+## 6. Task specs
+
+### T3.1 — `InventoryStrategy` policy layer · **M**
+- **Behavior:** contract `App\Services\Inventory\InventoryStrategy` with `allowsManualStockIncrease(): bool`, `allowsOverselling(): bool`, `assertCanDeduct(int $available, int $requested): void` (throws `InsufficientStockException`-family / a dedicated `OversellNotAllowedException` when blocking). Two implementations `PurchaseDrivenStrategy`, `FreeFormStrategy`. A resolver (`InventoryStrategyResolver` or container binding) maps the tenant's preferences → the concrete strategy; default `purchase_driven`.
+- **Files:** *new* `app/Services/Inventory/InventoryStrategy.php` (contract), `PurchaseDrivenStrategy.php`, `FreeFormStrategy.php`, resolver/factory; register in a service provider (e.g. `app/Providers/AppServiceProvider.php`).
+- **Edge cases:** missing/blank preference → default `purchase_driven`; `free_form` with `allow_overselling` unset → treat as `false` (block at zero); `allow_overselling=true` under `purchase_driven` → ignored (strict always blocks).
+- **Acceptance criteria:** resolver returns `PurchaseDrivenStrategy` by default; each method returns the correct value for both strategies and both overselling states; `assertCanDeduct` throws only when it should.
+- **Test plan:** unit tests for each strategy × method × overselling state; resolver test asserting default and each configured combination; assert `purchase_driven` ignores `allow_overselling`.
+
+### T3.2 — Preference keys · **S**
+- **Behavior:** add `inventory_strategy` (`required|in:purchase_driven,free_form`, default `purchase_driven`) and `allow_overselling` (`boolean`, default `false`) to the whitelist so `UpdatePreferences` persists them; expose current values to the settings page.
+- **Files:** `app/Http/Requests/PreferenceRequest.php:19` (rules), `app/Actions/UpdatePreferences.php` (already generic — verify boolean casting), `app/Http/Controllers/Core/PreferenceController.php` (pass current values to Inertia).
+- **Edge cases:** boolean coercion from checkbox ('0'/'1'/'true'); `allow_overselling` submitted while `purchase_driven` → persist but never read under strict (harmless); unknown values rejected by `in:` rule.
+- **Acceptance criteria:** both keys round-trip through save; invalid `inventory_strategy` rejected; defaults apply when absent.
+- **Test plan:** feature test posting each strategy + toggle asserting persisted `Preference` rows and validation rejects bad values.
+
+### T3.3 — (SEPARATE PR, prerequisite) Tenant-qualify preferences cache key · **M**
+- **Behavior:** replace the flat `'preferences'` cache key with a per-tenant key `"preferences:{tenantId}"` at every read/write/invalidation site so tenants never share cached preferences (correctness precondition for reading the strategy via cache).
+- **Files:** `app/Http/Middleware/ResolveTenant.php:33`, `app/Http/Middleware/HandleInertiaRequests.php:124`, `app/Http/Middleware/HandleLocale.php:29`, `app/Models/User.php:181`, `app/Actions/UpdatePreferences.php:26`.
+- **Edge cases:** no resolved tenant (central/admin context) → skip cache or use a sentinel; invalidation must forget the correct tenant key after a save; existing warm caches under the old flat key become orphaned (harmless, expire/ignored).
+- **Acceptance criteria:** two tenants with different preferences never read each other's cached values; saving a preference invalidates only that tenant's cache.
+- **Test plan:** feature regression test: set differing preferences for two tenants, assert cross-tenant isolation of cached reads; assert invalidation after update.
+
+### T3.4 — Settings UI · **M**
+- **Behavior:** on `Preferences/Show.vue`, add an "inventory strategy" section — a primary radio/segmented control (`purchase_driven` vs `free_form`) with helper copy framed as "how do you want to manage your inventory?", and an `allow_overselling` toggle rendered **only when** `free_form` is selected (hidden/disabled under `purchase_driven`). Localized (`__()`), RTL, dark-mode per `.ai/Design rules`.
+- **Files:** `resources/js/Pages/Preferences/Show.vue` (+ any shared toggle/radio component under `resources/js/Components`).
+- **Edge cases:** switching to `purchase_driven` should hide (and not submit a misleading) overselling value; ensure the toggle state persists correctly on reload; all strings translatable including the two mode descriptions.
+- **Acceptance criteria:** overselling toggle hidden under purchase_driven and visible under free_form; selection saves and reloads correctly; no hard-coded English.
+- **Test plan:** Inertia/feature test asserting the page receives current strategy props and save round-trips; (optional) a Dusk/browser check that the toggle shows only for free_form.
+
+## 7. Edge cases (cross-task)
+
+- No resolved tenant (admin/central routes) → strategy resolver and cache must degrade to the safe default without querying tenant preferences.
+- Legacy duplicate `preferences` rows for the same key (no unique index today) → dedupe before adding the unique index in T3.3, else the migration fails.
+- Because M4 is not yet shipped, choosing `free_form` in the UI has **no runtime effect** on deductions until M4 lands — acceptable for this milestone; call it out in the PR description.
+
+## 8. Test plan (summary)
+
+- Strategy unit tests: every strategy × method × overselling state, plus resolver default (T3.1).
+- Preference persistence + validation feature test (T3.2).
+- Cross-tenant cache isolation + invalidation regression test (T3.3).
+- Settings page prop/round-trip test (T3.4).
+- Regression: existing preference and stock feature tests still green (no behavior change this milestone).
+
+## 9. Rollout & backwards compatibility
+
+Fully additive and behavior-neutral: default `purchase_driven` reproduces today's behavior exactly, and enforcement isn't wired until M4, so shipping M3 changes nothing for existing tenants. T3.3 must land first (separate hygiene PR) so the strategy can be read through a correctly-scoped cache. Ship T3.1/T3.2/T3.4 as one PR after T3.3.
+
+## 10. Open questions
+
+- Store `allow_overselling` as its own key vs. encoding a single richer `inventory_strategy` value (e.g. `free_form_oversell`)? (Lean: two keys — matches the nested-toggle UI and keeps the strict case clean.)
+- Should the strategy resolver cache the resolved instance per request (it reads two preferences) or resolve lazily each call? (Lean: resolve once per request via container binding.)
+- Do we add the unique `(tenant_id, key)` index now (T3.3) or as a standalone data-hygiene migration? (Lean: include in T3.3 with a dedupe step.)

--- a/docs/inventory-ledger/M4-free-form-mode.md
+++ b/docs/inventory-ledger/M4-free-form-mode.md
@@ -1,0 +1,113 @@
+# PRD — M4: Free-form mode + single-point enforcement
+
+**Status:** Draft · **Milestone:** M4 · **Depends on:** M3 (strategy layer) · **Ship with:** M8 (provisional costing) · **PR grouping:** one PR
+
+## 1. Problem
+
+Today stock can only be *added* by creating a purchase invoice, and sales are *blocked* the moment on-hand would go below zero — the `stocks.quantity` column is `UNSIGNED`, so negatives are physically impossible, and `Storage::deductStock` throws unconditionally on a shortage. A large merchant segment does not want inventory to gate sales at all: they want to sell freely and let the balance go negative for later reconciliation. Another segment wants the strict discipline preserved. M3 introduced a per-tenant `InventoryStrategy`; M4 makes it *actually change behavior* by (a) allowing the physical representation of negative stock and (b) routing every sufficiency decision through the strategy layer at the single existing choke point — never scattering `if (overselling)` checks across controllers. Because free-form overselling makes the pre-existing zero/stale-COGS bug frequent, M4 ships together with M8.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Make `stocks.quantity` capable of holding negative balances (signed column).
+- Enforce the three strategy behaviors at one place (`Storage::deductStock`), inside the existing row lock:
+  - **`purchase_driven`** → sales check the balance; block if the sale would drive it negative.
+  - **`free_form` + `allow_overselling` ON** → sales never block; the balance goes negative and is surfaced for reconciliation.
+  - **`free_form` + `allow_overselling` OFF** → sales still block at zero (free quantity management without purchase invoices, guardrail retained).
+- Make the POS precheck and preflight *advisory-consistent* with the strategy (never the authority).
+- Gate manual upward adjustments by strategy (free under `free_form`; blocked/flagged under `purchase_driven`).
+
+**Non-goals**
+- The strategy resolver/contract itself (delivered in M3).
+- Surfacing negatives in reports / the negative-stock report (M7).
+- Provisional cost handling of oversold lines (M8, shipped alongside).
+- Reconciliation/opening balances (M9). Reads still come from `stocks.quantity` (cache), unchanged here.
+
+## 3. Current state (from audit)
+
+- `stocks.quantity` is `unsignedBigInteger` (`database/migrations/2023_01_07_162613_create_stocks_table.php`, widened in `2026_04_10_181858_fix_stocks_quantity_type_for_postgres.php`) — the DB forbids negatives.
+- Only hard guard: `Storage::deductStock` (`app/Models/Storage.php:144-168`) locks the `stocks` row `forUpdate` and throws `InsufficientStockException` (`:156-158`) if the row is missing or `quantity < requested`. Every deduction ultimately hits this.
+- POS adds an upfront precheck: `ProcessPosCheckoutAction.php:67-81` compares `Storage::quantityOf` vs needed and throws (`:76`), or triggers cross-warehouse `replenish()` (`:170-198`) when transfers are acknowledged. `PosPreflightAction.php:45-62` returns advisory (non-blocking) JSON.
+- Non-POS sales invoice creation does **not** check/deduct stock; the invoice-deduction path (`DeductStockFromInvoice.php:27-31`) prefers **partial-delivery splitting** over blocking.
+- Adjustments: `RecordAdjustmentAction` → `Storage::setStockTo` (`app/Models/Storage.php:173`); UI `resources/js/Components/Storages/AdjustmentModal.vue`; request `StockAdjustmentRequest` (`new_quantity min:0`, `type` unconstrained server-side). No strategy gate today; the only guard is permission `inventory.manage`.
+
+## 4. Design & behavior
+
+The strategy is resolved once per operation (M3) and consulted **inside** `deductStock`'s locked transaction so the allow/deny decision cannot race the balance it read. `deductStock` gains one branch:
+
+```
+lock row → available = quantity
+if strategy.allowsOverselling():        // free_form + ON
+    decrement (may go negative), record movement
+else:
+    strategy.assertCanDeduct(available, requested)  // throws InsufficientStockException at zero
+    decrement, record movement
+```
+
+`purchase_driven` and `free_form`-OFF both take the `else` branch (identical block-at-zero behavior); only overselling ON permits the decrement past zero. This keeps enforcement in exactly one method — controllers, POS, and delivery actions call `deductStock` and inherit correct behavior automatically.
+
+POS precheck and preflight consult `strategy.allowsOverselling()` so the UX matches: when overselling is ON they stop warning/blocking on shortage (and skip the replenishment prompt), but `deductStock` remains the sole authority. Manual upward adjustments consult `strategy.allowsManualStockIncrease()` (M3): under `purchase_driven` an upward `setStockTo` is blocked (or permitted only with an explicit, clearly-flagged reason); under `free_form` it is unrestricted.
+
+All existing tenants default to `purchase_driven` (M3), so behavior is bit-for-bit unchanged until a tenant opts into free-form.
+
+## 5. Data model / schema changes
+
+- **New migration**: convert `stocks.quantity` from unsigned to **signed** `BIGINT`. Follow the driver-split pattern of `2026_04_10_181858_fix_stocks_quantity_type_for_postgres.php`:
+  - pgsql: `ALTER TABLE stocks ALTER COLUMN quantity TYPE BIGINT USING quantity::BIGINT` + keep `DEFAULT 0` (Postgres BIGINT is already signed; the change is dropping any check/unsigned semantics).
+  - sqlite/mysql: `$table->bigInteger('quantity')->default(0)->change();` (drops `unsigned`).
+  - Values preserved; `down()` restores `unsignedBigInteger`.
+- No other schema change in M4. (Provisional-cost columns come from M8.)
+
+## 6. Task specs
+
+### T4.1 — Signed `stocks.quantity` · **M**
+- **Behavior:** additive, reversible migration flipping the column to signed BIGINT across pgsql/sqlite/mysql, mirroring the existing postgres-fix migration's driver switch.
+- **Files:** *new* migration under `database/migrations/`.
+- **Edge cases:** the `['storage_id','quantity']` index (`2026_07_09_100002`) and the FK constraints must survive the type change; Postgres `USING` cast for existing data; ensure no app code relies on the column being unsigned.
+- **Acceptance criteria:** a negative value can be persisted to `stocks.quantity`; all existing values unchanged post-migrate; `down()` restores unsigned and the migration is reversible on all three drivers.
+- **Test plan:** migration test inserting a negative quantity succeeds after `up()`; existing rows unchanged; assert index still present.
+
+### T4.2 — Strategy-gated deduction · **M**
+- **Behavior:** `deductStock` resolves the tenant strategy and branches inside the locked transaction as in §4: overselling ON decrements without throwing (balance may go negative); otherwise `assertCanDeduct` throws `InsufficientStockException` at zero. A movement is recorded in every case (negative balances included).
+- **Files:** `app/Models/Storage.php:144-168`.
+- **Edge cases:** decision must be inside the same `lockForUpdate` transaction (check-then-act race); a missing `stocks` row under overselling should be created at 0 then driven negative (parity with `addStock`'s insert path); ensure `quantity_before/after` on the recorded movement reflect the true signed values.
+- **Acceptance criteria:** `free_form`+ON drives the balance negative and records a movement with negative `quantity_after`; `purchase_driven` and `free_form`+OFF both throw at zero and leave the balance untouched; all under a row lock.
+- **Test plan:** feature tests for the three modes deducting past available; concurrency test (two deductions racing) asserts no double-spend under `purchase_driven` and consistent negative accounting under overselling.
+
+### T4.3 — POS + preflight consult strategy (advisory) · **M**
+- **Behavior:** `ProcessPosCheckoutAction` precheck and `PosPreflightAction` respect `allowsOverselling()` — when ON they neither throw on shortage nor prompt replenishment; `deductStock` (T4.2) stays the authority. When OFF, current behavior is preserved.
+- **Files:** `app/Actions/Pos/ProcessPosCheckoutAction.php:67-81` (and `replenish()` gate at `:170`), `app/Actions/Pos/PosPreflightAction.php:45-62`.
+- **Edge cases:** cross-warehouse replenishment should be skipped (not just tolerated) under overselling to avoid unnecessary transfers; preflight response shape must stay backward-compatible with the POS UI; a strategy flip mid-session is read per-checkout, not cached stale.
+- **Acceptance criteria:** `free_form`+ON POS checkout succeeds into a negative balance without a replenishment prompt; `purchase_driven` POS behavior is unchanged (precheck + replenishment intact).
+- **Test plan:** POS checkout feature tests per strategy; preflight test asserting advisory `available`/`unavailable` entries flip with `allow_overselling`.
+
+### T4.4 — Adjustment gating · **M**
+- **Behavior:** manual upward adjustments consult `allowsManualStockIncrease()` — blocked (or permitted only with an explicit, clearly-flagged reason) under `purchase_driven`; unrestricted under `free_form`. Downward adjustments (loss/damage/correction) remain allowed in both.
+- **Files:** `app/Actions/Stock/RecordAdjustmentAction.php`, `app/Http/Controllers/Inventory/StockAdjustmentController.php`, `resources/js/Components/Storages/AdjustmentModal.vue` (localized, RTL, dark: hide/disable the upward path or require a reason under strict mode; surface a clear message).
+- **Edge cases:** an adjustment that both crosses upward and is under strict mode must fail validation server-side (not just UI), since `type` is currently unconstrained server-side; ensure the `Adjustment` audit row is still written for permitted adjustments.
+- **Acceptance criteria:** upward adjustment is rejected/flagged under `purchase_driven` and accepted under `free_form`; downward adjustments unaffected; server-side enforced (not UI-only).
+- **Test plan:** feature tests: upward adjustment blocked in strict mode, allowed in free-form; downward allowed in both; UI conditionally renders the guard.
+
+## 7. Edge cases (cross-task)
+
+- **Strategy switch with existing stock:** flipping overselling OFF while a balance is already negative must **not** force reconciliation — the negative carries over; only *new* deductions are blocked (see M6). `deductStock` naturally yields this because it only checks *new* requests.
+- **Reads still from cache:** all balance reads remain on `stocks.quantity` in M4; negatives will now appear in read surfaces that don't filter them — most are fine, but `InventoryValuationQuery` filters `quantity > 0` so it silently drops negatives (addressed in M7/M10, noted here as expected interim behavior).
+- **Provisional cost:** oversold sale lines have no cost basis → zero/stale COGS; this is why M8 ships together. Without M8, margins on oversold lines would be visibly wrong.
+
+## 8. Test plan (summary)
+
+- Signed-column migration test (T4.1).
+- Three-mode deduction feature tests + concurrency test (T4.2).
+- POS checkout + preflight per-strategy tests (T4.3).
+- Adjustment gating tests, server-side enforced (T4.4).
+- Regression: full existing stock/POS suite green under default `purchase_driven`.
+
+## 9. Rollout & backwards compatibility
+
+Additive and reversible. With every tenant defaulting to `purchase_driven` (M3), deploying M4 changes nothing observable until a tenant opts into `free_form`. The signed-column migration preserves all values and is reversible. Ship M4 and M8 in the same release so free-form tenants never see inflated margins. Feature-flag not required — the strategy setting *is* the flag.
+
+## 10. Open questions
+
+- Under `purchase_driven`, should an upward adjustment be hard-blocked or allowed with a mandatory reason + flag? (Brief allows either; lean: allow with mandatory reason, clearly flagged, so shrinkage corrections stay possible.)
+- Should overselling ON fully skip the cross-warehouse replenishment prompt, or still offer it as an option? (Lean: skip by default; revisit if merchants want it.)
+- Do we clamp any read surface to zero for display, or always show the true negative? (Lean: show true negative everywhere except where a report explicitly defines otherwise — decided in M7/M10.)

--- a/docs/inventory-ledger/M5-product-edit-delta.md
+++ b/docs/inventory-ledger/M5-product-edit-delta.md
@@ -1,0 +1,85 @@
+# PRD — M5: Product-edit-as-adjustment-delta
+
+**Status:** Draft · **Milestone:** M5 · **Depends on:** M2 (balance helper), M3/M4 (strategy layer, for gating upward deltas) · **PR grouping:** one PR
+
+## 1. Problem
+
+The product edit screen cannot change on-hand quantity today — quantity lives entirely in the `stocks` ledger and is only reachable through purchase/adjustment/transfer/POS flows. Merchants (especially free-form ones) expect to correct a product's quantity right where they edit its name and price. The target design is explicit: editing quantity on the product screen must **not overwrite** anything — it must compute `delta = new_quantity − current_balance` and append an **adjustment movement** for that delta. The edit UI is sugar over the ledger. The delta mechanic already exists (`Storage::setStockTo`), so this milestone is about exposing it safely on the product form, not building new stock plumbing.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Add an optional on-hand quantity field to the product create/edit form, prefilled from the current balance.
+- On save, translate any quantity change into a delta and record it through the existing ledger write path (an `adjustment` movement), never a direct `stocks.quantity` overwrite.
+- Respect the per-tenant strategy: an upward delta under `purchase_driven` is a manual stock increase and must be gated/flagged exactly like a manual adjustment.
+
+**Non-goals**
+- Replacing or removing the dedicated Adjustment modal (`AdjustmentModal.vue`) — this is a convenience path, not a replacement.
+- Multi-line/bulk quantity editing.
+- Any change to costing (product-edit deltas do not touch cost, consistent with adjustments today).
+- Product variants (out of scope everywhere).
+
+## 3. Current state (from audit)
+
+- **No quantity field on the product form.** `resources/js/Components/Products/ProductForm.vue` `useForm` fields are `name, cost, price, expire_date, currency, alert_quantity, categories, units` — no quantity input anywhere. There is no `Products/Create.vue`/`Edit.vue`; the modal component is the form.
+- **Controller never touches stock.** `ProductsController::store` (`app/Http/Controllers/Catalog/ProductsController.php:54-71`) and `::update` (`:82-93`) call `Product::create/update(...except units,categories)`; no quantity handling. `::quickUpdate` (`:73-80`) likewise.
+- **Request has no quantity rule.** `app/Http/Requests/ProductRequest.php:24-39` validates `name, cost, price, currency, expire_date, alert_quantity, units, categories` only. (`alert_quantity` is the low-stock threshold, not on-hand.)
+- **The delta mechanic already exists.** `Storage::setStockTo(product, quantity, reason, movable, actor)` (`app/Models/Storage.php:173-196`) `insertOrIgnore`s the stock row, locks it, computes `delta = quantity − quantity_before`, updates the cache, and records a `StockMovement` for the delta — all in a transaction. `RecordAdjustmentAction` (`app/Actions/Stock/RecordAdjustmentAction.php:13-39`) wraps `setStockTo` with an `Adjustment` audit row (`reason:'adjustment'`, `movable:Adjustment`).
+- **On-hand is per-storage.** A product's balance is `SUM(stocks.quantity)` across storages (`Product::quantityOnHand()`, `app/Models/Product.php:263`); `setStockTo` operates on one `Storage`.
+
+## 4. Design & behavior
+
+Reuse the existing adjustment path — do not reinvent delta logic. The product form gains an optional quantity control:
+
+- **Single storage (common small-merchant case):** one quantity input, prefilled with the product's on-hand in that storage.
+- **Multiple storages:** a storage selector alongside the quantity input (edit one storage's on-hand at a time); default to the tenant's primary/sale-point storage. Bulk multi-storage editing is out of scope.
+
+On submit, the controller compares the submitted quantity against the current balance **for the chosen storage**. If unchanged, it does nothing (no zero-delta movement). If changed, it routes through `RecordAdjustmentAction` (preferred — see decision below) with the computed target quantity, which records both an `Adjustment` audit row and an `adjustment` `StockMovement`. The product's other attributes (name/cost/price/…) update as they do today; quantity is handled separately so a validation failure on one doesn't half-apply the other (wrap in a transaction).
+
+**Decision — Adjustment row vs. bare movement.** Route through `RecordAdjustmentAction` (create an `Adjustment` row), not a bare `setStockTo`. Rationale: it gives the change a first-class, reportable audit entity with `type`/`notes`/`created_by`, keeps product-edit deltas indistinguishable from modal adjustments in reports, and reuses gating added in M4. Tradeoff: a required `type` — default it to `manual` (or a dedicated `product_edit` type) and pass an auto-note like `__('Adjusted via product edit')`.
+
+**Strategy interaction (M3/M4).** The upward-delta case is a manual stock increase. Under `purchase_driven` it must be blocked or flagged with a reason exactly like a manual adjustment (same `InventoryStrategy::allowsManualStockIncrease()` gate used in M4.T4.4). Downward deltas (corrections/shrinkage) are always allowed. Under `free_form`, both directions are allowed freely. The quantity field should be hidden or read-only in the UI when the strategy forbids the edit, mirroring the adjustment modal's behavior.
+
+## 5. Data model / schema changes
+
+None. Reuses `stocks`, `stock_movements`, and `adjustments` as-is. No migration.
+
+## 6. Task specs
+
+### T5.1 — Quantity field on product form · **M**
+- **Behavior:** add an optional on-hand quantity input to `ProductForm.vue`, prefilled from the current balance; when the tenant has >1 storage, add a storage selector bound to the quantity. Field is hidden/read-only when the active strategy forbids the edit (upward under `purchase_driven`). Fully localized, RTL, dark-mode per `.ai/Design rules`.
+- **Files:** `resources/js/Components/Products/ProductForm.vue` (and the inline "Add New Product" form in `resources/js/Pages/Products/Index.vue:272-276` if quantity should be settable at create).
+- **Edge cases:** product with no `stocks` row yet (prefill 0); multiple storages (which one is shown/defaulted); tenant with a single storage (hide selector); strategy hides the field; non-integer/negative input.
+- **Acceptance criteria:** quantity field appears prefilled with current on-hand; changing it submits the new value with the chosen storage; hidden/disabled when strategy disallows; passes RTL + dark rendering.
+- **Test plan:** component/inertia render assertion that the field is present and prefilled; that it is absent when strategy forbids (covered jointly with backend via a feature test rendering the edit page).
+
+### T5.2 — Delta write path · **M**
+- **Behavior:** extend `ProductRequest` with an optional `quantity` (integer, `min:0`) and optional `storage_id` (exists, tenant-scoped, required when `quantity` present). In `ProductsController::store`/`::update`, after saving product attributes, if `quantity` is present and differs from the current balance for `storage_id`, call `RecordAdjustmentAction` to set the target quantity (records `Adjustment` + `adjustment` movement). Wrap product update + adjustment in a single `DB::transaction`. Never write `stocks.quantity` directly.
+- **Files:** `app/Http/Controllers/Catalog/ProductsController.php:54-93`, `app/Http/Requests/ProductRequest.php:24-39`; reuse `app/Actions/Stock/RecordAdjustmentAction.php`; consult the M3 `InventoryStrategy` for gating.
+- **Edge cases:** zero delta → no movement; upward delta under `purchase_driven` → blocked/flagged via strategy (surface a validation/authorization error, don't silently drop); `storage_id` omitted but `quantity` present → validation error; concurrent edits (rely on `setStockTo`'s row lock); create flow where no stock row exists yet.
+- **Acceptance criteria:** editing quantity produces exactly one `adjustment` `StockMovement` whose signed `quantity` equals `new − current`, plus an `Adjustment` row; no direct `stocks` write occurs; `SUM(movements) == stocks.quantity` holds after; `purchase_driven` upward edit is rejected/flagged; unchanged quantity produces no movement.
+- **Test plan:** feature test — edit product quantity up/down under `free_form` asserts movement sign/magnitude and `Adjustment` row; edit up under `purchase_driven` asserts rejection/flag; unchanged quantity asserts zero new movements; reconciliation invariant asserted post-edit.
+
+## 7. Edge cases (cross-task)
+
+- Multi-storage products: the form edits one storage's on-hand; the displayed "current" and the delta must both be scoped to the selected storage, not the product's total.
+- Strategy toggled between render and submit: the backend gate (T5.2) is authoritative; the UI hiding (T5.1) is advisory.
+- Newly created product with an initial quantity: treated as an adjustment delta from 0 (or an `opening_balance` — but for consistency with the edit path, use `adjustment`).
+
+## 8. Test plan (summary)
+
+- Feature: up/down delta under `free_form` → correct movement + Adjustment row (T5.2).
+- Feature: upward delta under `purchase_driven` → rejected/flagged (T5.2, depends on M4.T4.4 gate).
+- Feature: unchanged quantity → no movement (T5.2).
+- Invariant: `SUM(stock_movements.quantity) == stocks.quantity` per `(product,storage)` after edit.
+- Render: quantity field present/prefilled and correctly hidden under strict strategy (T5.1).
+
+## 9. Rollout & backwards compatibility
+
+Additive and behavior-preserving for existing flows — the product form simply gains an optional field; if a client submits no `quantity`, behavior is identical to today. No migration, no destructive change. Ships after M2 (balance helper) and alongside/after M4 (so the strategy gate exists); if M4 is not yet merged, gate defaults to `purchase_driven` blocking upward edits, matching current strict behavior. One PR.
+
+## 10. Open questions
+
+- Dedicated `MovementType`/adjustment `type` value `product_edit` vs. reusing `manual`? (Lean: reuse `manual` with an auto-note to avoid enum churn; revisit if reports need to distinguish source.)
+- For a brand-new product, should an initial quantity be recorded as `adjustment` or `opening_balance`? (Lean: `adjustment` for consistency with the edit path; `opening_balance` is reserved for the M9 migration.)
+- Should the multi-storage case eventually support editing several storages at once, or stay single-storage-per-save? (Lean: single-storage now; defer bulk.)

--- a/docs/inventory-ledger/M6-strategy-switch-audit.md
+++ b/docs/inventory-ledger/M6-strategy-switch-audit.md
@@ -1,0 +1,80 @@
+# PRD — M6: Strategy-switch flow + audit event
+
+**Status:** Draft · **Milestone:** M6 · **Depends on:** M3 · **PR grouping:** one PR
+
+## 1. Problem
+
+Tenants must be able to change their inventory strategy (`purchase_driven` ↔ `free_form`) or flip `allow_overselling` at any point in their operating life. Two things are missing today to make that safe and explainable. First, there is **no per-tenant record of when a setting changed** — so a report showing a period where sales suddenly stopped blocking (or a negative balance that appeared and then stopped growing) has no way to say "the rule changed here." Second, the switch must be unambiguously **forward-only**: flipping to a stricter mode must not retroactively rewrite history or force reconciliation of balances that are already negative. This milestone adds a durable, dated audit trail for strategy changes and pins down the forward-only semantics.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Persist a dated, per-tenant event every time `inventory_strategy` or `allow_overselling` changes (old value → new value, who, when).
+- Guarantee switches are forward-only: historical movements untouched, balances at switch time carry over as-is.
+- Make the events queryable so reports can annotate rule changes mid-history.
+
+**Non-goals**
+- The strategy setting itself and its enforcement (M3 defines the keys/policy; M4 enforces overselling). This milestone only records *changes* to those keys.
+- Reconciling or "fixing" negative balances that exist at switch time — they carry over by design.
+- A general-purpose settings-audit framework for all preferences (scope is the two inventory keys; the table is generic enough to extend later, but only these keys are wired now).
+- Building report UI that consumes the events (optional note in §4; the negative-stock report is M7).
+
+## 3. Current state (from audit)
+
+- Preferences are written by `app/Actions/UpdatePreferences.php:11-27` via `Preference::updateOrCreate(['key'=>$key], ['value'=>$value])` then `Cache::forget('preferences')`. There is **no history capture** — the old value is overwritten in place with no trace.
+- **There is no per-tenant settings audit trail.** `AdminAuditLog` (`app/Models/AdminAuditLog.php`) extends plain `Model`, has **no `tenant_id`**, and is written only via `app/Actions/Admin/LogAdminAction.php` for platform super-admin actions. It must **not** be reused for tenant setting history.
+- M3 introduces the `inventory_strategy` (default `purchase_driven`) and `allow_overselling` preference keys and the `InventoryStrategy` policy layer. This milestone hooks the write path that changes them.
+- Target-design semantics: switching applies **going forward only**; historical movements are untouched; negative balances existing at the time of a change (e.g. overselling turned off, or `free_form → purchase_driven`) **carry over as-is** — the stricter rules only prevent *new* negatives.
+
+## 4. Design & behavior
+
+Introduce a dedicated, tenant-scoped, append-only `tenant_settings_history` table and model. In `UpdatePreferences`, after computing each key's new value but before/around persisting it, compare against the current value; when the value actually changes **and** the key is one of the tracked inventory keys, insert a history row capturing `old_value`, `new_value`, `changed_by` (acting user), and `created_at`. The preference write itself is unchanged (still `updateOrCreate`), so enforcement and reads are unaffected — this milestone is purely additive observation.
+
+Forward-only is a property of the surrounding system, reaffirmed here: no code in this milestone touches `stock_movements` or `stocks.quantity`. Turning on a stricter mode simply changes what M4's `deductStock` allows from that moment on; balances already negative remain negative until an ordinary compensating movement (late purchase, write-off, correction) raises them. The history row is the durable marker that lets M7 and the P&L reports explain a rule boundary in the timeline.
+
+Optionally (noted, not required this milestone): reports may overlay these dated events as annotations so a reader can see "overselling disabled on 2026-08-01" against a balance chart.
+
+## 5. Data model / schema changes
+
+- **New table** `tenant_settings_history`: `id`, `tenant_id` (FK, indexed), `key` (string), `old_value` (text nullable), `new_value` (text nullable), `changed_by` (FK users, nullable), `created_at` (timestamp; no `updated_at` — rows are immutable). Index `['tenant_id', 'key']` for per-key history lookups.
+- **New model** `App\Models\TenantSettingsHistory` extending `BaseModel` (so it inherits `TenantScope` + auto-`tenant_id`), append-only (guard on `updating`/`deleting`, no `SoftDeletes`), `belongsTo(User::class, 'changed_by')`.
+- No existing table altered. Fully additive and reversible.
+
+## 6. Task specs
+
+### T6.1 — Tenant settings history table + model · **S**
+- **Behavior:** create the `tenant_settings_history` table and `TenantSettingsHistory` model. Tenant-scoped via `BaseModel`; append-only; `changer()` relation to `User`.
+- **Files:** *new* migration under `database/migrations/`; *new* `app/Models/TenantSettingsHistory.php`.
+- **Edge cases:** `old_value` is null on the very first time a key is set (no prior value). Values are stored as text to match the `preferences.value` text column and to survive booleans/enums stringified consistently. Do not reuse `AdminAuditLog` (global, no `tenant_id`).
+- **Acceptance criteria:** migration creates the table with `tenant_id` FK + `['tenant_id','key']` index; model auto-scopes to the current tenant, auto-fills `tenant_id`, and throws on update/delete; `down()` drops the table.
+- **Test plan:** unit test — creating a row auto-fills `tenant_id`; a second tenant cannot read the first tenant's rows (scope); update/delete throw.
+
+### T6.2 — Record strategy-switch events · **S**
+- **Behavior:** in `UpdatePreferences`, for the tracked keys (`inventory_strategy`, `allow_overselling`), detect a real change (current value ≠ new value) and write a `TenantSettingsHistory` row (`key`, `old_value`, `new_value`, `changed_by = auth()->id()`) within the same operation. Non-tracked keys and no-op writes record nothing.
+- **Files:** `app/Actions/UpdatePreferences.php:11-27`.
+- **Edge cases:** writing the same value again (no change) must **not** create a row; setting a key for the first time records `old_value = null`; the switch must not trigger any stock reconciliation or balance mutation — verify no `stock_movements`/`stocks` write occurs; keep the existing `Cache::forget('preferences')` behavior (and align with M3.T3.3's tenant-qualified cache key if landed).
+- **Acceptance criteria:** changing `inventory_strategy` from `purchase_driven` to `free_form` records one history row with correct old/new/actor/timestamp; flipping `allow_overselling` records one row; re-saving an unchanged value records none; a product with a negative balance at switch time still has that exact balance after the switch (no reconciliation).
+- **Test plan:** feature test toggling each tracked key asserting exactly one history row with expected fields; a no-op save asserts zero rows; a regression test asserting an existing negative `stocks.quantity` is unchanged across a `free_form → purchase_driven` switch and no new `stock_movements` row is created.
+
+## 7. Edge cases (cross-task)
+
+- First-ever set of a key → `old_value` null (not an error).
+- Idempotent saves (unchanged value) must never spam the history table.
+- A switch to a stricter mode is *not* a data-repair operation: negative balances persist and are only resolved by ordinary compensating movements; the history row exists precisely so reports can explain those pre-existing negatives.
+- Depends on M3 having introduced the two keys; if M3's `PreferenceRequest` whitelist is missing a key, that key never reaches `UpdatePreferences` and no event is recorded — covered by M3, called out here as a dependency.
+
+## 8. Test plan (summary)
+
+- Model scoping + immutability unit test (T6.1).
+- Change-detection feature tests for both tracked keys, including no-op and first-set cases (T6.2).
+- Forward-only regression: negative balance and ledger untouched across a strategy switch (T6.2).
+
+## 9. Rollout & backwards compatibility
+
+Fully additive and reversible — a new table plus an observation hook in `UpdatePreferences`. No behavior change to preferences, enforcement, or stock. Existing tenants have no history rows until they next change a tracked setting, which is correct (their standing default is `purchase_driven`, established in M3). Ship as one PR after M3.
+
+## 10. Open questions
+
+- Should we backfill a synthetic "initial `purchase_driven`" history row for every existing tenant at migration time, or leave history empty until the first real change? (Lean: leave empty; the M3 default already documents the starting state.)
+- Do we generalize this to record **all** preference changes (not just the two inventory keys) now, or keep it inventory-scoped and widen later? (Lean: keep scoped; table shape already supports widening.)
+- Should report annotations (overlaying switch events on balance/P&L charts) be part of M7, or a later enhancement? (Lean: later enhancement.)

--- a/docs/inventory-ledger/M7-negative-stock-report.md
+++ b/docs/inventory-ledger/M7-negative-stock-report.md
@@ -1,0 +1,102 @@
+# PRD — M7: Negative-stock reconciliation report
+
+**Status:** Draft · **Milestone:** M7 · **Depends on:** M2 (ledger balance helper) · **PR grouping:** one PR
+
+## 1. Problem
+
+Once `free_form` + `allow_overselling` is live (M4), balances can go negative, and a late purchase naturally lifts them back toward zero — no special balance-matching logic is needed. But a negative balance is a *signal a human must triage*: it is either a missed purchase entry, shrinkage/theft, or a counting error, and each resolves differently (enter the late purchase, post a write-off adjustment, or post a correction adjustment). Today there is **no negative-stock report at all** — the only inventory report, `InventoryValuationQuery`, explicitly filters `stocks.quantity > 0` (`app/Queries/Reports/InventoryValuationQuery.php:39`), so negatives are invisible everywhere. This milestone gives operators a dedicated surface listing every product/storage currently below zero, how long it has been negative, and the movements that drove it there, so they can decide the resolution per case.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A tenant-scoped report of every `(product, storage)` whose current balance is `< 0`.
+- For each row: current negative balance, **how long it has been negative** (since the movement that crossed zero downward), and a **drill-down of the driving movements**.
+- Export (Excel) parity with the other reports; localized/RTL/dark UI.
+
+**Non-goals**
+- Auto-reconciliation or auto-matching of late purchases to oversold units (the balance self-heals; resolution is a human decision).
+- Changing valuation math or the `quantity > 0` filter in `InventoryValuationQuery` (that is M10.T10.2).
+- Costing/margin restatement of oversold lines (that is M8, provisional costing + back-fill).
+- Blocking or preventing negatives (that is M4's enforcement).
+
+## 3. Current state (from audit)
+
+- **No negative-stock report exists.** The low-stock dashboard widget (`app/Queries/DashboardStatsQuery.php:206`) uses `SUM(quantity) <= alert_quantity`, which would incidentally include negatives but never surfaces "negative" as a distinct condition; it is a 5-row dashboard widget, not a report.
+- `InventoryValuationQuery` (`app/Queries/Reports/InventoryValuationQuery.php:34-47`) is the template to mirror: raw join `stocks → products → storages`, tenant-scoped via `products.tenant_id`, reads `stocks.quantity`, per-storage rows, summary sum. Its `:39` `where('stocks.quantity', '>', 0)` filter is exactly what this report must **invert** (`< 0`).
+- Report wiring pattern to copy: `app/Reports/InventoryValuationReport.php:24-29` (renders Inertia page `Reports/InventoryValuation`), `app/Exports/Reports/InventoryValuationExport.php:22` (reuses the query; columns Product/Storage/Quantity/Avg Cost/Total Value), Vue `resources/js/Pages/Reports/InventoryValuation.vue`, plus the reports index `resources/js/Pages/Reports/Index.vue`.
+- **Ledger is the source for age + driving movements:** `stock_movements` carries signed `quantity`, `quantity_before`, `quantity_after`, `created_at`, and (after M1) `movement_type` — everything needed to find the movement that crossed zero and to list contributors. `Storage::recordMovement` (`app/Models/Storage.php:198`) is where these rows originate.
+- Balance source: prefer M2's ledger balance helper (`app/Queries/StockBalanceQuery.php`) so the report and the ledger cannot disagree; `stocks.quantity` remains the O(1) cache and can seed the candidate set.
+
+## 4. Design & behavior
+
+The report answers three questions per negative `(product, storage)`:
+
+1. **What is negative and by how much** — current balance `< 0` (candidate set from `stocks.quantity`, confirmed against the M2 ledger balance).
+2. **How long has it been negative** — walk that pair's `stock_movements` ordered by `created_at, id` and find the **most recent** movement whose `quantity_after < 0` while the immediately preceding `quantity_before >= 0` (the downward zero-crossing that started the *current* negative streak). Its `created_at` gives the "negative since" date; age = `now − created_at`. If the balance has been continuously negative from the first movement, use the first movement's date.
+3. **What drove it there** — a drill-down listing the movements since that crossing (type via M1's `movement_type`, signed quantity, before/after, actor, `movable` source, timestamp), so the operator can see whether sales outran purchases (→ missed purchase), an adjustment/write-off is warranted (→ shrinkage), or a correction is needed (→ counting error).
+
+Main view: one row per negative `(product, storage)` with product name, storage name, current balance, "negative since" date + humanized age. Expandable/linked drill-down of driving movements. A summary line (count of negative lines, total negative units). Export mirrors the main rows.
+
+Zero special resolution logic: the report is read-only insight; resolution happens through the existing purchase/adjustment flows, and the balance self-corrects via their positive movements.
+
+## 5. Data model / schema changes
+
+**None.** Read-only over existing `stocks` and `stock_movements` (post-M1 `movement_type`). No migration. Depends on M2's balance helper existing.
+
+## 6. Task specs
+
+### T7.1 — Negative-stock report (query + report + export + page + route + nav) · **L**
+- **Behavior:** produce tenant-scoped rows for every `(product, storage)` with balance `< 0`, each with current negative quantity, "negative since" timestamp + humanized age (from the current-streak zero-crossing in `stock_movements`), and a drill-down of driving movements since that crossing. Summary aggregates (count of negative lines, total negative units). Export to Excel with the main-row columns.
+- **Files:**
+  - *new* `app/Queries/Reports/NegativeStockQuery.php` — mirror `InventoryValuationQuery` (raw join `stocks→products→storages`, tenant-scoped via `products.tenant_id`) but filter `stocks.quantity < 0`; compute the zero-crossing date + driving movements from `stock_movements`; reconcile balance against M2's helper.
+  - *new* `app/Reports/NegativeStockReport.php` — mirror `app/Reports/InventoryValuationReport.php`, render Inertia page `Reports/NegativeStock`.
+  - *new* `app/Exports/Reports/NegativeStockExport.php` — mirror `app/Exports/Reports/InventoryValuationExport.php`, reuse the query.
+  - *new* `resources/js/Pages/Reports/NegativeStock.vue` — mirror `Reports/InventoryValuation.vue`; table + expandable drill-down; localized (`__()`), RTL, dark mode per `.ai/Design rules`.
+  - `routes/tenant.php` — add the report route (next to the other report routes) + export route.
+  - `resources/js/Pages/Reports/Index.vue` (and any nav/menu) — add a "Negative stock" entry.
+- **Edge cases:**
+  - A pair currently negative that was negative from its very first movement → use the first movement's date as "negative since".
+  - A pair that dipped negative, recovered, and dipped again → age counts only the **current** streak (most recent downward zero-crossing), not the earliest.
+  - A negative `stocks.quantity` with **no** matching `stock_movements` (legacy/seeded drift before M9) → still list it, with "negative since" unknown/`created_at` of the stock row and a flag; do not crash on empty movement history.
+  - Soft-deleted products (`WithTrashScope`) and deleted storages must be excluded/handled like `InventoryValuationQuery` does.
+  - Multi-storage: a product negative in one storage but positive net across storages must still appear (report is per `(product, storage)`, matching valuation granularity).
+  - Pagination/performance for many negative lines; index usage on `stock_movements(storage_id, product_id)` (exists).
+- **Acceptance criteria:**
+  - Only `(product, storage)` pairs with balance `< 0` appear; positives/zeros excluded; `InventoryValuationQuery` remains unchanged.
+  - "Negative since"/age reflect the current-streak zero-crossing, verified against a crafted movement sequence (dip → recover → dip).
+  - Drill-down lists the driving movements since the crossing with type, signed qty, before/after, actor, source, timestamp.
+  - Report balance equals M2's ledger balance for each row (no divergence from the cache).
+  - Export produces the same rows as the page; tenant isolation holds (no cross-tenant rows).
+  - UI strings localized; RTL + dark verified.
+- **Test plan:**
+  - Feature test: seed sales exceeding stock under `free_form`+overselling → assert the pair appears with correct negative qty and "negative since".
+  - Streak test: movements dip → recover (late purchase) → dip again → assert age uses the second crossing.
+  - Isolation test: negative stock in tenant A not visible to tenant B.
+  - Empty-history test: negative `stocks` row with no movements listed without error, flagged.
+  - Export test: exported rows match the query.
+  - Regression: `InventoryValuationQuery`/valuation report unaffected.
+
+## 7. Edge cases (cross-task)
+
+- Depends on M2's balance helper; if run before M9's opening-balance backfill, ledger and `stocks.quantity` may diverge for legacy tenants — the report should reconcile to the cache and flag rows where ledger ≠ cache rather than hide them.
+- After M8 (provisional costing), oversold lines may carry provisional/zero cost — this report is quantity-only and must not depend on cost, but may optionally link to affected provisional sale lines for context.
+- M10.T10.2 revisits the `quantity > 0` valuation filter; keep this report's `< 0` logic independent so the two decisions don't couple.
+
+## 8. Test plan (summary)
+
+- Query correctness: negative-only filter, per-`(product,storage)` granularity, tenant scoping.
+- Zero-crossing/age logic incl. multi-streak and empty-history cases.
+- Drill-down contents (types/quantities/source).
+- Ledger-vs-cache reconciliation per row.
+- Export parity + tenant isolation.
+- Localization/RTL/dark smoke of the Vue page.
+
+## 9. Rollout & backwards compatibility
+
+Purely additive: a new read-only report, new routes, new page, no schema change, no write paths touched. Safe to ship anytime after M2. Most valuable once M4 (overselling) is enabled, since that is when negatives begin to occur; before then it simply renders an empty state. One PR.
+
+## 10. Open questions
+
+- Should "negative since" be computed on the fly from `stock_movements` each request, or denormalized/cached for large tenants? (Lean: on-the-fly first, using the `(storage_id, product_id)` index; optimize only if needed.)
+- Should the report offer inline quick-actions (e.g. "post correction adjustment", "record late purchase") or stay read-only with links to existing flows? (Lean: read-only + links for v1.)
+- Do we include products negative in one storage but net-positive overall as a separate "net negative" view, or only per-storage rows? (Lean: per-storage only, matching valuation granularity.)

--- a/docs/inventory-ledger/M8-provisional-costing.md
+++ b/docs/inventory-ledger/M8-provisional-costing.md
@@ -1,0 +1,91 @@
+# PRD — M8: Provisional costing + back-fill
+
+**Status:** Draft · **Milestone:** M8 · **Depends on:** M4 · **PR grouping:** one PR — **ship together with M4** (overselling makes zero/stale COGS frequent and visible)
+
+## 1. Problem
+
+A sale's cost of goods is captured as a one-time snapshot of the product's `average_cost` at the moment the sale line is written, and is never revisited. When a sale happens before any purchase exists — or once free-form/overselling drives stock negative — there is no real cost basis, so the line is booked with `unit_cost = 0` (or a stale value). That silently produces **0 COGS → inflated / 100% gross margin** in the P&L, and nothing ever corrects it once the real purchase arrives. Free-form mode (M4) turns this from a rare edge into an everyday occurrence, so M8 must ship alongside it: book such sales with an explicit **provisional** cost, flag them, and **back-fill** the true cost when the purchase lands. We accept that profit reports become **eventually consistent**, and we make that visible rather than misleading.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Flag sale lines booked without a real cost basis as provisional.
+- When the real purchase cost lands, restate `unit_cost` (and thus margin) for the flagged lines it covers, then clear the flag.
+- Make reports indicate when figures include provisional costs.
+
+**Non-goals**
+- Changing the costing method itself (moving weighted-average stays; see `Product::replayMovingAverageCost`).
+- Perfect lot-level matching of specific purchase units to specific sale units — we restate flagged lines against the newly-known cost, not a FIFO lot ledger.
+- Retroactively "locking" history: back-fill intentionally restates prior periods (eventual consistency is the accepted model).
+- Provisional costing for purchase lines (purchases set cost at delivery already).
+
+## 3. Current state (from audit)
+
+- **Sale `unit_cost` is a snapshot of `average_cost` at line creation**, never re-snapshotted: `app/Actions/Pos/ProcessPosCheckoutAction.php:126`, `app/Actions/StoreInvoiceAction.php:68`, `app/Actions/UpdateInvoiceAction.php:64` (all `?? 0`).
+- `average_cost` **defaults to `cost`** on product create (`app/Models/Product.php:41`); the moving-average replay **clamps on-hand to `max(qty,0)`** (`app/Models/Product.php:101`) and returns `null` → caller falls back to `cost` until a purchase is delivered.
+- **Only purchases** recompute the average: `app/Models/Transaction.php:180` (`recalculateAverageCost()` inside `add()` ~`:164-185`); `ReceiveGoodsAction` also recalculates on receipt (`app/Actions/Purchase/ReceiveGoodsAction.php`).
+- Net effect today: a zero-cost sale ⇒ `unit_cost = 0` ⇒ **0 COGS** ⇒ inflated margin, and it is **never back-filled**.
+- Single authoritative margin site: `app/Queries/Reports/ProfitAndLossQuery.php` — COGS = `SUM(base_quantity * COALESCE(unit_cost,0))` (`:48`, `:97`); gross/net margin derived from it. Dashboard mirror: `DashboardController::grossProfit` (`app/Http/Controllers/Core/DashboardController.php:19`).
+- No column, flag, or report currently distinguishes a provisional cost.
+
+## 4. Design & behavior
+
+When a sale line is created, determine whether a real cost basis exists (product `average_cost > 0` **and** on-hand not negative). If it does, behave exactly as today. If it does not, book the line with a **provisional** cost — the last known cost (`average_cost` or `cost`), or `0` if none exists — and set `cost_provisional = true`.
+
+When a purchase for that product is delivered (the point where `recalculateAverageCost()` already runs and a real cost becomes known), enqueue `BackfillProvisionalCostsJob` for the product. The job restates `unit_cost` on the covered flagged sale lines to the now-known cost and clears their flag. The job is **idempotent** and safe to run repeatedly (it only touches still-flagged lines). Because `ProfitAndLossQuery` reads `unit_cost` live, restatement automatically corrects past-period margins on the next report render.
+
+Reports surface a non-blocking indicator ("figures include provisional cost") for any period whose sale lines include a still-flagged row, so a reader knows the margin is not yet final.
+
+**Coverage policy (which flagged lines a purchase back-fills):** by default, all still-flagged sale lines for that product in the tenant (simplest, matches the "eventual consistency" framing). This is called out as an open question in §10 if a time-bounded or quantity-bounded policy is preferred.
+
+## 5. Data model / schema changes
+
+- **New migration:** `transactions.cost_provisional` boolean, default `false`, indexed (used to find lines to back-fill and to flag report periods). Additive, reversible.
+- No change to how `unit_cost` is stored; the job updates its value in place (a permitted mutation — `transactions` is not the append-only ledger).
+
+## 6. Task specs
+
+### T8.1 — Provisional flag on zero-basis sale lines · **M**
+- **Behavior:** add `cost_provisional`; at sale-line creation, set it `true` when no real cost basis exists (`average_cost = 0`, or on-hand negative for the product/storage), booking a provisional `unit_cost` (last known cost, else `0`). Normal sales set it `false`.
+- **Files:** *new* migration for `transactions.cost_provisional`; `app/Actions/Pos/ProcessPosCheckoutAction.php:126`; `app/Actions/StoreInvoiceAction.php:68`; `app/Actions/UpdateInvoiceAction.php:64`.
+- **Edge cases:** invoice edit (`UpdateInvoiceAction` deletes+recreates lines) must re-evaluate the flag; negative-on-hand detection must use the same balance source the strategy layer uses (M4); a product with a configured `cost` but no purchases is provisional against that `cost`, not a hard zero.
+- **Acceptance criteria:** a sale of a product with `average_cost = 0` (or into negative stock) is flagged `cost_provisional = true`; a sale with a real average is `false`.
+- **Test plan:** feature test — sale before any purchase → flagged + provisional unit_cost; sale after purchase → not flagged; edited invoice re-evaluates.
+
+### T8.2 — Back-fill job on purchase delivery · **L**
+- **Behavior:** `BackfillProvisionalCostsJob($productId, $tenantId)` restates `unit_cost` to the now-known cost for still-flagged sale lines it covers and clears their flag; recomputes/marks affected margins implicitly (P&L reads `unit_cost` live). Idempotent — no-op when nothing is flagged.
+- **Files:** *new* `app/Jobs/BackfillProvisionalCostsJob.php`; dispatch hooks in `app/Actions/Purchase/ReceiveGoodsAction.php` and `app/Models/Transaction.php` `add()` (~`:164-185`, right after `recalculateAverageCost()`).
+- **Edge cases:** must run **outside** the guarded ledger (it mutates `transactions`, not `stock_movements` — no immutability conflict); concurrent purchases → job idempotency + a row lock on the lines being restated; a later purchase at a different cost should not double-apply (flag already cleared); partial coverage policy (see §4 / §10); queue failure → retry-safe.
+- **Acceptance criteria:** after a late purchase, previously-flagged sale lines carry the real `unit_cost`, flags cleared; re-running the job changes nothing; P&L COGS/margin for the affected period reflects the restated cost.
+- **Test plan:** feature test — sell into zero/negative basis, deliver a purchase, assert flagged lines restated + unflagged and `ProfitAndLossQuery` margin corrected; idempotency test (run twice); concurrency test (two deliveries).
+
+### T8.3 — Reports indicate provisional figures · **M**
+- **Behavior:** `ProfitAndLossQuery` exposes whether the period includes any still-flagged lines (e.g. a `has_provisional_costs` flag / count); the P&L Vue page and dashboard render a subtle "includes provisional cost" indicator (localized, RTL, dark).
+- **Files:** `app/Queries/Reports/ProfitAndLossQuery.php:48,97`; its Vue page (`resources/js/Pages/Reports/…` P&L); `app/Http/Controllers/Core/DashboardController.php:19` + `Dashboard.vue` gross-profit tile.
+- **Edge cases:** period with zero flagged lines shows no indicator; export formats should carry the same caveat; indicator must not alter the numeric COGS, only annotate it.
+- **Acceptance criteria:** a period containing a flagged line renders the provisional indicator; once back-filled, the indicator disappears; numbers unchanged by the indicator itself.
+- **Test plan:** feature test asserting the query flag toggles with presence of flagged lines; Vue smoke test that the indicator renders when flagged.
+
+## 7. Edge cases (cross-task)
+
+- Invoice edit re-creating lines must not orphan or double-count flags.
+- A product with a nonzero configured `cost` but no purchase history is provisional against `cost`, not zero — back-fill still corrects it to the true purchased cost.
+- Back-fill mutates `transactions.unit_cost`; this is deliberately allowed (transactions are not the append-only `stock_movements` ledger from M1).
+- Overselling (M4) is the primary generator of provisional lines — this is why M8 ships with M4.
+
+## 8. Test plan (summary)
+
+- Flagging on zero/negative basis; not flagging on real basis (T8.1).
+- Back-fill restates + clears flags; idempotent; concurrency-safe (T8.2).
+- P&L/dashboard provisional indicator toggles correctly (T8.3).
+- Regression: existing `ProfitAndLossQuery` numbers unchanged for fully-costed periods.
+
+## 9. Rollout & backwards compatibility
+
+Additive column + a queued job; no destructive change. Existing (purchase_driven) tenants rarely hit the provisional path, so behavior is effectively unchanged for them; the value appears mainly once free-form/overselling (M4) is enabled — hence the joint release. Reversible: drop `cost_provisional` and remove the dispatch hooks; restated `unit_cost` values remain valid.
+
+## 10. Open questions
+
+- **Coverage policy:** should a purchase back-fill *all* still-flagged lines for the product, or only up to the purchased quantity / within a time window? (Lean: all still-flagged lines — simplest, matches eventual-consistency framing.)
+- **Provisional basis when none exists:** book `0`, or the product's configured `cost`? (Lean: last known cost = `average_cost ?: cost`, else `0`.)
+- Should back-fill run inline on delivery or strictly via the queue? (Lean: queue, for POS latency.)

--- a/docs/inventory-ledger/M9-opening-balance-migration.md
+++ b/docs/inventory-ledger/M9-opening-balance-migration.md
@@ -1,0 +1,105 @@
+# PRD — M9: Data migration — opening balances
+
+**Status:** Draft · **Milestone:** M9 · **Depends on:** M1 (`MovementType::OpeningBalance`, append-only guard), M2 (`stock:reconcile` command, balance helper) · **PR grouping:** one PR — **except T9.2, which is a separate hygiene PR**
+
+## 1. Problem
+
+The ledger (`stock_movements`) is complete for all *runtime* stock changes, but two conditions mean `SUM(movements)` does not necessarily equal the live `stocks.quantity` for existing data: (1) dev/demo **seeders bypass** the write choke point and set `stocks.quantity` directly with no matching movement, and (2) any historical drift between the cached quantity and the movement history. Before reads can be switched to a ledger-derived balance (M10), every `(tenant, product, storage)` row must satisfy the invariant `SUM(stock_movements.quantity) == stocks.quantity`. This milestone establishes that invariant for existing data by inserting a single **opening-balance movement** per row that absorbs whatever gap exists — regardless of *why* it exists.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Guarantee `SUM(movements) == stocks.quantity` for every `(tenant, product, storage)` after migration.
+- Do so idempotently, so a re-run is a no-op.
+- Surface pre-existing drift for review before it is folded into opening balances.
+- Close the non-production integrity holes (seeders/factory) so future seeded data stays reconciled.
+
+**Non-goals**
+- Switching any read path to the ledger (M10).
+- Changing runtime write behavior (M1/M3/M4).
+- "Explaining" historical drift — the opening balance intentionally absorbs it as a single reconciling entry; forensic attribution is out of scope.
+- Retiring `stocks.quantity` (it remains the cache; see M10).
+
+## 3. Current state (from audit)
+
+- **Runtime coverage is complete**: every runtime mutation funnels through `Storage::addStock` (`app/Models/Storage.php:108`), `deductStock` (`:144`), `setStockTo` (`:173`) → `recordMovement()` (`:198`), so for tenants created purely through the app, `SUM(movements)` already equals `stocks.quantity`.
+- **Bypasses (write `stocks.quantity` with NO movement), non-production only:** `database/seeders/DatabaseSeeder.php:58` (`$product->stock()->attach($storage->id, ['quantity' => rand(...)])`), `database/seeders/DashboardExampleSeeder.php:58` (`syncWithoutDetaching([$storage->id => ['quantity' => 60]])`), and `database/factories/StockFactory.php` (creates pivot rows directly). No production/app path bypasses.
+- **Balance shape:** on-hand is per `(product, storage)` — `stocks` pivot rows (`stocks.quantity`, `unsignedBigInteger`, `database/migrations/2023_01_07_162613_create_stocks_table.php`). Movements are per `(storage, product)` too (`stock_movements`, `database/migrations/2026_04_22_131838_create_stock_movements_table.php`).
+- **Prerequisites now available:** `MovementType::OpeningBalance = 'opening_balance'` (M1.T1.1) and the append-only guard (M1.T1.4, which the backfill must respect — it only *creates* rows); `stock:reconcile` (M2.T2.2) computes per-row drift.
+
+## 4. Design & behavior
+
+For each `(tenant_id, product_id, storage_id)` present in `stocks`:
+
+```
+opening = stocks.quantity − COALESCE(SUM(stock_movements.quantity for that product+storage), 0)
+if opening != 0:
+    insert ONE stock_movements row:
+        movement_type   = OpeningBalance
+        reason          = 'opening_balance'
+        quantity        = opening               (signed; may be negative if movements exceed cache)
+        quantity_before = stocks.quantity − opening   (== prior SUM(movements))
+        quantity_after  = stocks.quantity
+        movable_*       = null
+        user_id         = null   (system)
+        tenant_id/storage_id/product_id = the row's
+```
+
+After this runs, `SUM(movements) == stocks.quantity` holds **by construction** for every row — the opening entry is defined as exactly the residual. This is robust whether the gap came from a seeder bypass, a factory row, or historical drift; the migration does not need movement history to be complete or correct.
+
+**Idempotency:** the backfill is guarded so a row that already reconciles (`opening == 0`) gets nothing, and a re-run recomputes `opening` against the *now-reconciled* state → `0` → no-op. (Equivalently, skip any `(product, storage)` that already has an `OpeningBalance` movement.)
+
+**Ordering with the reconciliation gate:** T9.3 runs `stock:reconcile` first (dry-run) so an operator reviews the drift report *before* T9.1 folds it into opening balances. T9.1 is the write step; T9.3 is the read-only gate that precedes it.
+
+## 5. Data model / schema changes
+
+- **None.** No columns added or changed. This milestone only *inserts* `OpeningBalance` rows into `stock_movements` (schema from M1). Additive and reversible: `down()` deletes rows where `movement_type = 'opening_balance'` (the only creator of such rows).
+- Depends on M1's `movement_type` column and `OpeningBalance` case already existing.
+
+## 6. Task specs
+
+### T9.1 — Opening-balance backfill · **M**
+- **Behavior:** a migration (or a dedicated artisan command invoked by a migration) that, per `(tenant, product, storage)`, computes `opening = stocks.quantity − SUM(movements)` and inserts one `OpeningBalance` movement for a non-zero residual, with consistent `quantity_before`/`quantity_after`. Runs across all tenants (bypass `TenantScope` or iterate tenants explicitly, since this is a system migration). Chunked over `stocks` rows for scale.
+- **Files:** *new* `database/migrations/…_backfill_opening_balance_movements.php` (and optionally *new* `app/Console/Commands/BackfillOpeningBalancesCommand.php` if the logic is shared/re-runnable).
+- **Edge cases:** (a) residual already `0` → insert nothing; (b) re-run → no-op (idempotent via the `opening == 0` recompute or an existing-`OpeningBalance` skip); (c) `stocks` rows across many tenants — must not be silently filtered by the global `TenantScope`; (d) negative residual (movements exceed cache) → a negative `OpeningBalance` entry is valid and must not be blocked by any unsigned assumption (note: the signed-column change is M4; if M9 runs before M4, a negative *opening* is possible only where `stocks.quantity` already permits — in practice residuals here are ≥ 0 for seeded data, but the code must not assume sign); (e) the append-only guard (M1.T1.4) must permit these `create()`s.
+- **Acceptance criteria:** after running, for every `(tenant, product, storage)`, `SUM(stock_movements.quantity) == stocks.quantity`; a second run inserts zero additional rows; `down()` removes exactly the opening-balance rows.
+- **Test plan:** migration test with (i) a fully app-driven fixture (residual 0 → no opening rows), (ii) a seeded/bypassed fixture (residual > 0 → one opening row, invariant holds), (iii) re-run asserts no new rows; assert invariant `SUM(movements) == stocks.quantity` per row in all cases.
+
+### T9.2 — Fix seeder/factory bypasses · **S** · *(separate PR)*
+- **Behavior:** route seeded/factory stock creation through the choke point so seeding leaves the ledger reconciled — either call `Storage::addStock`/`setStockTo`, or emit an `OpeningBalance` movement alongside the pivot write.
+- **Files:** `database/seeders/DatabaseSeeder.php:58`, `database/seeders/DashboardExampleSeeder.php:58`, `database/factories/StockFactory.php`.
+- **Edge cases:** factory used in isolation (no `Storage`/tenant context) — ensure it still produces a reconciled pair, or document that the factory intentionally creates raw pivot rows for tests that don't assert the invariant; keep seeder performance acceptable (chunk/batch).
+- **Acceptance criteria:** after `db:seed`, `SUM(movements) == stocks.quantity` for every seeded `(product, storage)`; no seeder writes `stocks.quantity` without a corresponding movement.
+- **Test plan:** seeder test (or `RefreshDatabase` + seed) asserting the invariant post-seed; factory test documenting/asserting its chosen contract.
+
+### T9.3 — Pre-migration reconciliation gate · **S**
+- **Behavior:** reuse `stock:reconcile` (M2.T2.2) as a dry-run drift report to be run and reviewed *before* T9.1; document it as the required first step in the migration runbook. Optionally have T9.1 print the same drift summary before writing.
+- **Files:** reuses `app/Console/Commands/ReconcileStockCommand.php` (M2); optional runbook note in this PRD / deploy docs.
+- **Edge cases:** large drift or many affected rows → report must be reviewable (`--json`/summary counts); a tenant with zero `stocks` rows → empty report, not an error.
+- **Acceptance criteria:** a drift report (per-row and summary) is produced and reviewable before backfill; running it changes no data.
+- **Test plan:** command test asserting it reports the same residuals T9.1 would fold in, and writes nothing.
+
+## 7. Edge cases (cross-task)
+
+- **Seeded/demo tenants** (movements missing) and **historical drift** are handled identically — both absorbed by the opening entry; the migration is agnostic to the cause.
+- **Negative residuals** must be representable as a signed `OpeningBalance.quantity`; coordinate ordering with M4's signed-column change if a negative *opening balance itself* must persist (rare; seeded residuals are typically ≥ 0).
+- **Multi-tenant execution**: the system migration must cover all tenants, not just the resolved one — avoid `TenantScope` filtering.
+- **Append-only guard interaction**: backfill only creates; never updates existing movements.
+- **No orphaned-quantity risk** beyond (1) seeder rows and (2) drift rows — both enumerated and absorbed.
+
+## 8. Test plan (summary)
+
+- T9.1 migration test: invariant holds for app-driven, seeded/bypassed, and negative-residual fixtures; idempotent re-run; reversible `down()`.
+- T9.2 seeder/factory test: `SUM(movements) == stocks.quantity` after seeding.
+- T9.3 command test: dry-run drift report matches folded residuals; no writes.
+- Regression: existing stock feature tests green; `stock:reconcile` reports zero drift post-migration.
+
+## 9. Rollout & backwards compatibility
+
+Additive (insert-only) and reversible (`down()` deletes only `opening_balance` rows). Deploy order: **M1 and M2 first** (types + reconcile), then run T9.3 (review drift), then T9.1 (backfill). T9.2 ships as an independent hygiene PR and can land before or after T9.1 (once landed, freshly seeded environments are reconciled without needing the backfill). No runtime behavior changes for tenants; this only makes existing data satisfy the ledger invariant that M10 relies on.
+
+## 10. Open questions
+
+- Should T9.1 be a **migration** (auto-runs on deploy) or an **explicit command** gated behind the T9.3 review? (Lean: command invoked by a thin migration, so it's re-runnable and testable, with T9.3 as a documented pre-step.)
+- Timestamp for opening-balance rows: `now()` at migration time, or backdated to the tenant/stock `created_at`? (Lean: migration time, clearly labeled as an opening entry, to avoid implying false history.)
+- Do we run M9 before or after M4's signed-column change when negative residuals are possible? (Lean: M9 after M4 if any negative opening balances are expected; otherwise M9 can precede M4.)

--- a/docs/inventory-ledger/README.md
+++ b/docs/inventory-ledger/README.md
@@ -1,0 +1,50 @@
+# Inventory Ledger — PRDs
+
+Product requirements for migrating NamaIn's inventory from a mutable `stocks.quantity` source of truth to an **append-only, signed stock-movement ledger** with a **per-tenant inventory strategy** (`purchase_driven` vs `free_form` + nested `allow_overselling`).
+
+See the audit & verdict that motivate this work in the approved plan (Phase 1 findings + Phase 2 verdict). **Headline:** the ledger (`stock_movements`) already exists, is written through a single choke point (`Storage::addStock/deductStock/setStockTo`), is signed + polymorphic + append-only in practice, and is currently latent (no readers). `stocks.quantity` already behaves as an incrementally-updated, row-locked cached balance. The one unavoidable structural change is that `stocks.quantity` is **unsigned** today, so negatives are impossible. We therefore **extend, not replace**, and migrate incrementally (parallel-run), defaulting every existing tenant to `purchase_driven`.
+
+## Milestones
+
+| PRD | Milestone | One PR? | Depends on |
+|---|---|---|---|
+| [M1](M1-ledger-hardening.md) | Ledger hardening (movement type, append-only) | yes | — |
+| [M2](M2-balance-reconciliation.md) | Balance helper + reconciliation | yes | M1 |
+| [M3](M3-strategy-setting.md) | Strategy setting + policy layer | yes (+ M3.T3.3 separate) | M2 |
+| [M4](M4-free-form-mode.md) | Free-form mode + single-point enforcement | yes | M3 |
+| [M5](M5-product-edit-delta.md) | Product-edit-as-adjustment-delta | yes | M2 |
+| [M6](M6-strategy-switch-audit.md) | Strategy-switch flow + audit event | yes | M3 |
+| [M7](M7-negative-stock-report.md) | Negative-stock reconciliation report | yes | M2 |
+| [M8](M8-provisional-costing.md) | Provisional costing + back-fill | yes | M4 (ship together) |
+| [M9](M9-opening-balance-migration.md) | Data migration: opening balances | yes (+ M9.T9.2 separate) | M1, M2 |
+| [M10](M10-cutover.md) | Cutover: reads → ledger | yes | M9 |
+
+**Critical path:** M1 → M2 → M3 → M4; M8 ships with M4; M9 → M10. M3.T3.3 (tenant-qualify preferences cache) and M9.T9.2 (fix seeder bypasses) are independent hygiene PRs that unblock their milestones.
+
+## Cross-cutting conventions (apply to every task)
+
+- **TDD** — Pest feature/unit test written first (`php artisan make:test --pest`); run with `php artisan test --compact --filter=…`.
+- **Localization** — every user-facing string via `__()`; Arabic-first.
+- **RTL + dark mode** — every Vue element per `.ai/Design rules`.
+- **Pint** — `vendor/bin/pint --dirty` on touched PHP before finalizing.
+- **Additive & reversible migrations only** until M10; nothing destructive before cutover.
+- **Tenant scoping** — new tables carry `tenant_id` and extend `BaseModel` (except pivots).
+
+## PRD template
+
+Each milestone PRD follows this structure (standard depth, ~1 page + task specs):
+
+```
+# PRD — Mx: <Title>
+Status · Milestone · Depends on · PR grouping
+## 1. Problem
+## 2. Goals / Non-goals
+## 3. Current state (from audit, with file:line)
+## 4. Design & behavior
+## 5. Data model / schema changes
+## 6. Task specs   → per task: Behavior · Files · Edge cases · Acceptance criteria · Test plan · Size
+## 7. Edge cases (cross-task)
+## 8. Test plan (summary)
+## 9. Rollout & backwards compatibility
+## 10. Open questions
+```


### PR DESCRIPTION
## What

Root of the **inventory-ledger** stacked-PR series. Adds `docs/inventory-ledger/` — audit-backed PRDs for migrating inventory from a mutable \`stocks.quantity\` source of truth to an **append-only, signed stock-movement ledger** with a **per-tenant inventory strategy** (\`purchase_driven\` vs \`free_form\` + nested \`allow_overselling\`).

## Contents

- \`README.md\` — index, dependency graph, cross-cutting conventions, PRD template
- \`M1\`–\`M10\` — one PRD per milestone, each with per-task specs (Behavior · Files · Edge cases · Acceptance criteria · Test plan · Size)

## Why this shape

The ledger (\`stock_movements\`) already exists, is written through a single choke point (\`Storage::addStock/deductStock/setStockTo\`), is signed + polymorphic + append-only in practice, and is currently latent (no readers). \`stocks.quantity\` already behaves as an incrementally-updated, row-locked cached balance. So we **extend, not replace**, and migrate incrementally, defaulting every existing tenant to \`purchase_driven\`.

## Stack

Implementation PRs (M1 → M10) stack on top of this docs PR, each based on the previous.

Docs only — no code.