### PR TITLE
feat(inventory): M1 — harden stock-movement ledger

### DIFF
--- a/app/Enums/MovementType.php
+++ b/app/Enums/MovementType.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Enums;
+
+enum MovementType: string
+{
+    case OpeningBalance = 'opening_balance';
+    case PurchaseReceipt = 'purchase_receipt';
+    case InvoiceAddition = 'invoice_addition';
+    case InvoiceDeduction = 'invoice_deduction';
+    case SaleDelivery = 'sale_delivery';
+    case Adjustment = 'adjustment';
+    case TransferIn = 'transfer_in';
+    case TransferOut = 'transfer_out';
+    case SalesReturn = 'sales_return';
+    case PurchaseReturn = 'purchase_return';
+
+    /**
+     * Resolve a movement type from a free-form `reason` string.
+     *
+     * The nine runtime reasons emitted by Storage's write paths are identical
+     * to this enum's backing values, so they resolve exactly. Unknown/legacy
+     * reasons (older data, ad-hoc strings) fall back to Adjustment rather than
+     * throwing, so the backfill migration never fails on surprise data.
+     */
+    public static function fromReason(string $reason): self
+    {
+        return self::tryFrom($reason) ?? self::Adjustment;
+    }
+
+    /**
+     * Whether this movement type increases stock on hand.
+     */
+    public function isIncrease(): bool
+    {
+        return match ($this) {
+            self::OpeningBalance,
+            self::PurchaseReceipt,
+            self::InvoiceAddition,
+            self::TransferIn,
+            self::SalesReturn => true,
+            self::InvoiceDeduction,
+            self::SaleDelivery,
+            self::TransferOut,
+            self::PurchaseReturn => false,
+            self::Adjustment => false,
+        };
+    }
+
+    /**
+     * Human-readable label (localize at the call site via __()).
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::OpeningBalance => 'Opening Balance',
+            self::PurchaseReceipt => 'Purchase Receipt',
+            self::InvoiceAddition => 'Invoice Addition',
+            self::InvoiceDeduction => 'Invoice Deduction',
+            self::SaleDelivery => 'Sale Delivery',
+            self::Adjustment => 'Adjustment',
+            self::TransferIn => 'Transfer In',
+            self::TransferOut => 'Transfer Out',
+            self::SalesReturn => 'Sales Return',
+            self::PurchaseReturn => 'Purchase Return',
+        };
+    }
+}

--- a/app/Exceptions/StockMovementIsImmutableException.php
+++ b/app/Exceptions/StockMovementIsImmutableException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class StockMovementIsImmutableException extends RuntimeException
+{
+    public function __construct(string $operation)
+    {
+        parent::__construct("Stock movements are append-only and cannot be {$operation}. Record a compensating movement instead.");
+    }
+}

--- a/app/Models/StockMovement.php
+++ b/app/Models/StockMovement.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Enums\MovementType;
+use App\Exceptions\StockMovementIsImmutableException;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -9,6 +11,33 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class StockMovement extends BaseModel
 {
     use HasFactory;
+
+    /**
+     * Enforce the append-only ledger invariant: movements are never updated or
+     * deleted to change stock; corrections are new compensating rows.
+     */
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        static::updating(function () {
+            throw new StockMovementIsImmutableException('updated');
+        });
+
+        static::deleting(function () {
+            throw new StockMovementIsImmutableException('deleted');
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'movement_type' => MovementType::class,
+        ];
+    }
 
     public function storage(): BelongsTo
     {

--- a/app/Models/Storage.php
+++ b/app/Models/Storage.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\MovementType;
 use App\Enums\StorageType;
 use App\Exceptions\InsufficientStockException;
 use App\Traits\WithTrashScope;
@@ -204,6 +205,7 @@ class Storage extends BaseModel
             'movable_type' => $movable?->getMorphClass(),
             'movable_id' => $movable?->getKey(),
             'reason' => $reason,
+            'movement_type' => MovementType::fromReason($reason),
             'quantity' => $quantity,
             'quantity_before' => $before,
             'quantity_after' => $after,

--- a/database/factories/StockMovementFactory.php
+++ b/database/factories/StockMovementFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\MovementType;
 use App\Models\Product;
 use App\Models\StockMovement;
 use App\Models\Storage;
@@ -17,12 +18,14 @@ class StockMovementFactory extends Factory
     {
         $quantityBefore = $this->faker->numberBetween(0, 500);
         $quantity = $this->faker->numberBetween(-100, 100);
+        $reason = $this->faker->randomElement(['invoice_deduction', 'invoice_addition', 'adjustment', 'transfer_in', 'sales_return', 'purchase_return']);
 
         return [
             'storage_id' => Storage::factory(),
             'product_id' => Product::factory(),
             'user_id' => User::factory(),
-            'reason' => $this->faker->randomElement(['invoice_deduction', 'invoice_addition', 'manual_adjustment', 'transfer', 'sales_return', 'purchase_return']),
+            'reason' => $reason,
+            'movement_type' => MovementType::fromReason($reason),
             'quantity' => $quantity,
             'quantity_before' => $quantityBefore,
             'quantity_after' => $quantityBefore + $quantity,

--- a/database/migrations/2026_07_13_090000_add_movement_type_to_stock_movements_table.php
+++ b/database/migrations/2026_07_13_090000_add_movement_type_to_stock_movements_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Enums\MovementType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stock_movements', function (Blueprint $table) {
+            $table->string('movement_type')->nullable()->after('reason')->index();
+        });
+
+        DB::table('stock_movements')
+            ->select('id', 'reason')
+            ->orderBy('id')
+            ->chunkById(1000, function ($rows) {
+                foreach ($rows as $row) {
+                    DB::table('stock_movements')
+                        ->where('id', $row->id)
+                        ->update(['movement_type' => MovementType::fromReason($row->reason)->value]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stock_movements', function (Blueprint $table) {
+            $table->dropIndex(['movement_type']);
+            $table->dropColumn('movement_type');
+        });
+    }
+};

--- a/tests/Feature/StockMovementLedgerHardeningTest.php
+++ b/tests/Feature/StockMovementLedgerHardeningTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Actions\Stock\RecordAdjustmentAction;
+use App\Enums\MovementType;
+use App\Exceptions\StockMovementIsImmutableException;
+use App\Models\Product;
+use App\Models\StockMovement;
+use App\Models\Storage;
+use App\Models\User;
+
+test('recordMovement persists the typed movement_type for each write path', function (string $reason, string $direction, MovementType $expected) {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 100, 'purchase_receipt');
+
+    match ($direction) {
+        'add' => $storage->addStock($product, 5, $reason),
+        'deduct' => $storage->deductStock($product, 5, $reason),
+        'set' => $storage->setStockTo($product, 42, $reason),
+    };
+
+    $movement = StockMovement::where('product_id', $product->id)
+        ->where('reason', $reason)
+        ->latest('id')
+        ->first();
+
+    expect($movement->movement_type)->toBe($expected);
+})->with([
+    ['purchase_receipt', 'add', MovementType::PurchaseReceipt],
+    ['invoice_addition', 'add', MovementType::InvoiceAddition],
+    ['transfer_in', 'add', MovementType::TransferIn],
+    ['sales_return', 'add', MovementType::SalesReturn],
+    ['invoice_deduction', 'deduct', MovementType::InvoiceDeduction],
+    ['sale_delivery', 'deduct', MovementType::SaleDelivery],
+    ['transfer_out', 'deduct', MovementType::TransferOut],
+    ['purchase_return', 'deduct', MovementType::PurchaseReturn],
+    ['adjustment', 'set', MovementType::Adjustment],
+]);
+
+test('the adjustment action records a typed adjustment movement', function () {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $actor = User::factory()->create();
+
+    app(RecordAdjustmentAction::class)
+        ->handle($storage, $product, 30, 'manual', $actor);
+
+    $movement = StockMovement::where('reason', 'adjustment')->latest('id')->first();
+
+    expect($movement->movement_type)->toBe(MovementType::Adjustment);
+});
+
+test('stock movements are append-only: updates and deletes are rejected', function () {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 10, 'purchase_receipt');
+
+    $movement = StockMovement::firstOrFail();
+
+    expect(fn () => $movement->update(['quantity' => 999]))
+        ->toThrow(StockMovementIsImmutableException::class);
+    expect(fn () => $movement->delete())
+        ->toThrow(StockMovementIsImmutableException::class);
+
+    // Creating a new (compensating) movement is still allowed.
+    $storage->addStock($product, 5, 'purchase_receipt');
+    expect(StockMovement::count())->toBe(2);
+});

--- a/tests/Unit/MovementTypeTest.php
+++ b/tests/Unit/MovementTypeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Enums\MovementType;
+
+test('fromReason resolves each runtime reason to its exact type', function (string $reason, MovementType $expected) {
+    expect(MovementType::fromReason($reason))->toBe($expected);
+})->with([
+    ['opening_balance', MovementType::OpeningBalance],
+    ['purchase_receipt', MovementType::PurchaseReceipt],
+    ['invoice_addition', MovementType::InvoiceAddition],
+    ['invoice_deduction', MovementType::InvoiceDeduction],
+    ['sale_delivery', MovementType::SaleDelivery],
+    ['adjustment', MovementType::Adjustment],
+    ['transfer_in', MovementType::TransferIn],
+    ['transfer_out', MovementType::TransferOut],
+    ['sales_return', MovementType::SalesReturn],
+    ['purchase_return', MovementType::PurchaseReturn],
+]);
+
+test('fromReason falls back to Adjustment for unknown or legacy reasons', function (string $reason) {
+    expect(MovementType::fromReason($reason))->toBe(MovementType::Adjustment);
+})->with(['restock', 'initial_stock', 'sale', 'manual_adjustment', 'transfer', '']);
+
+test('isIncrease reflects the direction of the movement type', function () {
+    expect(MovementType::PurchaseReceipt->isIncrease())->toBeTrue();
+    expect(MovementType::OpeningBalance->isIncrease())->toBeTrue();
+    expect(MovementType::TransferIn->isIncrease())->toBeTrue();
+    expect(MovementType::SaleDelivery->isIncrease())->toBeFalse();
+    expect(MovementType::TransferOut->isIncrease())->toBeFalse();
+    expect(MovementType::PurchaseReturn->isIncrease())->toBeFalse();
+});


### PR DESCRIPTION
**Stacked on** #56 (docs). PRD: `docs/inventory-ledger/M1-ledger-hardening.md`.

## What

Promotes the existing `stock_movements` recording toward an authoritative, append-only ledger — **no stock behavior changes** (fully additive, dual-write with `stocks.quantity` retained).

- **`MovementType` enum** (`app/Enums/MovementType.php`) — the nine runtime reasons plus `opening_balance` (for M9). `fromReason()` resolves exactly for known reasons and falls back to `Adjustment` for unknown/legacy strings.
- **Typed recording** — `Storage::recordMovement()` (the single write choke point) now derives + persists `movement_type` from `reason`. Because the production reasons equal the enum values, all nine write paths get the correct type with zero caller churn.
- **Migration** — adds `movement_type` to `stock_movements` (indexed, nullable) and backfills from `reason`. Additive + reversible; `reason` retained.
- **Append-only enforcement** — `StockMovement` rejects `update`/`delete` (`StockMovementIsImmutableException`); corrections must be new compensating rows.
- Factory kept consistent.

## Tests

- `tests/Unit/MovementTypeTest.php` — mapping (exact + fallback + `isIncrease`).
- `tests/Feature/StockMovementLedgerHardeningTest.php` — typed `movement_type` per write path (parametrized over all nine), adjustment-action integration, append-only immutability.
- Existing stock/POS/transfer/dashboard suites remain green.

## Acceptance criteria (from PRD)

- [x] Every runtime reason maps to exactly one type; `fromReason` fallback covered.
- [x] No `stock_movements` row lacks `movement_type` after migrate; reversible.
- [x] Each write path persists the correct `movement_type`.
- [x] Update/delete on a movement throws; create still works.