### PR TITLE
feat(inventory): M2 — ledger balance helper + stock:reconcile

### DIFF
--- a/app/Console/Commands/ReconcileStockCommand.php
+++ b/app/Console/Commands/ReconcileStockCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class ReconcileStockCommand extends Command
+{
+    protected $signature = 'stock:reconcile {--json : Emit machine-readable JSON} {--tenant= : Limit to a single tenant (id or slug)}';
+
+    protected $description = 'Report drift between the stocks.quantity cache and the stock-movement ledger. Read-only.';
+
+    public function handle(): int
+    {
+        $previousTenant = app()->has('currentTenant') ? app('currentTenant') : null;
+
+        $drifts = [];
+
+        try {
+            foreach ($this->tenants() as $tenant) {
+                app()->instance('currentTenant', $tenant);
+
+                foreach ($this->driftsForTenant($tenant) as $drift) {
+                    $drifts[] = $drift;
+                }
+            }
+        } finally {
+            if ($previousTenant) {
+                app()->instance('currentTenant', $previousTenant);
+            } else {
+                app()->forgetInstance('currentTenant');
+            }
+        }
+
+        $this->option('json')
+            ? $this->line(json_encode($drifts, JSON_PRETTY_PRINT))
+            : $this->renderTable($drifts);
+
+        return empty($drifts) ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return Collection<int, Tenant>
+     */
+    private function tenants()
+    {
+        $filter = $this->option('tenant');
+
+        return Tenant::withoutGlobalScopes()
+            ->when($filter, fn ($query) => $query->where('id', $filter)->orWhere('slug', $filter))
+            ->get();
+    }
+
+    /**
+     * Compare the cache against the ledger for one tenant.
+     *
+     * @return array<int, array{tenant: string, product_id: int, storage_id: int, cache: int, ledger: int, drift: int}>
+     */
+    private function driftsForTenant(Tenant $tenant): array
+    {
+        $cache = DB::table('stocks')
+            ->where('tenant_id', $tenant->id)
+            ->whereNull('deleted_at')
+            ->get(['product_id', 'storage_id', 'quantity'])
+            ->keyBy(fn ($row) => "{$row->product_id}:{$row->storage_id}");
+
+        $ledger = DB::table('stock_movements')
+            ->where('tenant_id', $tenant->id)
+            ->selectRaw('product_id, storage_id, SUM(quantity) as balance')
+            ->groupBy('product_id', 'storage_id')
+            ->get()
+            ->keyBy(fn ($row) => "{$row->product_id}:{$row->storage_id}");
+
+        $drifts = [];
+
+        foreach ($cache->keys()->merge($ledger->keys())->unique() as $key) {
+            [$productId, $storageId] = array_map('intval', explode(':', $key));
+            $cacheQty = (int) ($cache[$key]->quantity ?? 0);
+            $ledgerQty = (int) ($ledger[$key]->balance ?? 0);
+
+            if ($cacheQty === $ledgerQty) {
+                continue;
+            }
+
+            $drifts[] = [
+                'tenant' => $tenant->slug,
+                'product_id' => $productId,
+                'storage_id' => $storageId,
+                'cache' => $cacheQty,
+                'ledger' => $ledgerQty,
+                'drift' => $cacheQty - $ledgerQty,
+            ];
+        }
+
+        return $drifts;
+    }
+
+    /**
+     * @param  array<int, array{tenant: string, product_id: int, storage_id: int, cache: int, ledger: int, drift: int}>  $drifts
+     */
+    private function renderTable(array $drifts): void
+    {
+        if (empty($drifts)) {
+            $this->info('No drift: the cache and the ledger agree for every product and storage.');
+
+            return;
+        }
+
+        $this->warn(count($drifts).' drifting (product, storage) pair(s) found:');
+        $this->table(
+            ['Tenant', 'Product', 'Storage', 'Cache', 'Ledger', 'Drift'],
+            array_map(fn ($d) => [$d['tenant'], $d['product_id'], $d['storage_id'], $d['cache'], $d['ledger'], $d['drift']], $drifts),
+        );
+    }
+}

--- a/app/Queries/StockBalanceQuery.php
+++ b/app/Queries/StockBalanceQuery.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Queries;
+
+use App\Models\StockMovement;
+use Illuminate\Support\Collection;
+
+/**
+ * Derives stock balances from the append-only ledger (`stock_movements`).
+ *
+ * This is the authoritative balance per the target design. It is NOT a hot-path
+ * read — `stocks.quantity` remains the O(1) cache used at POS speed. This query
+ * exists for reconciliation (M2), opening balances (M9), and the eventual read
+ * cutover (M10). All reads are tenant-scoped via StockMovement's global scope.
+ */
+class StockBalanceQuery
+{
+    /**
+     * Ledger balance for a product across all its storages.
+     */
+    public function forProduct(int $productId): int
+    {
+        return (int) StockMovement::query()
+            ->where('product_id', $productId)
+            ->sum('quantity');
+    }
+
+    /**
+     * Ledger balance for a product within a single storage.
+     */
+    public function forProductInStorage(int $productId, int $storageId): int
+    {
+        return (int) StockMovement::query()
+            ->where('product_id', $productId)
+            ->where('storage_id', $storageId)
+            ->sum('quantity');
+    }
+
+    /**
+     * Ledger balances grouped per (product, storage) for the current tenant.
+     *
+     * @return Collection<int, object{product_id: int, storage_id: int, balance: int}>
+     */
+    public function perProductStorage(): Collection
+    {
+        return StockMovement::query()
+            ->selectRaw('product_id, storage_id, SUM(quantity) as balance')
+            ->groupBy('product_id', 'storage_id')
+            ->get()
+            ->map(fn ($row) => (object) [
+                'product_id' => (int) $row->product_id,
+                'storage_id' => (int) $row->storage_id,
+                'balance' => (int) $row->balance,
+            ]);
+    }
+}

--- a/tests/Feature/Inventory/ReconcileStockCommandTest.php
+++ b/tests/Feature/Inventory/ReconcileStockCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\Product;
+use App\Models\Storage;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+test('reconcile reports no drift and exits zero on clean data', function () {
+    $tenant = app('currentTenant');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 50, 'purchase_receipt');
+    $storage->deductStock($product, 20, 'sale_delivery');
+
+    $this->artisan('stock:reconcile', ['--tenant' => $tenant->slug])
+        ->assertExitCode(0);
+});
+
+test('reconcile detects a bypassed stocks row as drift and exits non-zero', function () {
+    $tenant = app('currentTenant');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+
+    // Simulate a seeder-style bypass: write the cache without a movement.
+    DB::table('stocks')->insert([
+        'tenant_id' => $tenant->id,
+        'storage_id' => $storage->id,
+        'product_id' => $product->id,
+        'quantity' => 60,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->artisan('stock:reconcile', ['--tenant' => $tenant->slug])
+        ->assertExitCode(1);
+});
+
+test('reconcile --json emits the exact drift for a bypassed row', function () {
+    $tenant = app('currentTenant');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+
+    DB::table('stocks')->insert([
+        'tenant_id' => $tenant->id,
+        'storage_id' => $storage->id,
+        'product_id' => $product->id,
+        'quantity' => 60,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    Artisan::call('stock:reconcile', ['--json' => true, '--tenant' => $tenant->slug]);
+    $payload = json_decode(Artisan::output(), true);
+
+    expect($payload)->toHaveCount(1);
+    expect($payload[0])->toMatchArray([
+        'product_id' => $product->id,
+        'storage_id' => $storage->id,
+        'cache' => 60,
+        'ledger' => 0,
+        'drift' => 60,
+    ]);
+});

--- a/tests/Feature/Inventory/StockBalanceQueryTest.php
+++ b/tests/Feature/Inventory/StockBalanceQueryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Actions\Stock\TransferStockAction;
+use App\Models\Product;
+use App\Models\StockMovement;
+use App\Models\StockTransfer;
+use App\Models\StockTransferLine;
+use App\Models\Storage;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Queries\StockBalanceQuery;
+
+test('ledger balance equals the cache for every product and storage on clean data', function () {
+    $query = new StockBalanceQuery;
+    $storageA = Storage::factory()->create();
+    $storageB = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $user = User::factory()->create();
+
+    // A mixed sequence through the write choke point.
+    $storageA->addStock($product, 100, 'purchase_receipt', actor: $user);
+    $storageA->deductStock($product, 30, 'sale_delivery', actor: $user);
+    $storageA->setStockTo($product, 80, 'adjustment', actor: $user);
+
+    // A real transfer: net-zero across two storages.
+    $transfer = StockTransfer::factory()->create([
+        'from_storage_id' => $storageA->id,
+        'to_storage_id' => $storageB->id,
+        'created_by' => $user->id,
+    ]);
+    StockTransferLine::factory()->create([
+        'stock_transfer_id' => $transfer->id,
+        'product_id' => $product->id,
+        'quantity' => 20,
+    ]);
+    app(TransferStockAction::class)->handle($transfer, $user);
+
+    // A return raises stock back.
+    $storageA->addStock($product, 5, 'sales_return', actor: $user);
+
+    // Invariant: ledger sum == cache, per (product, storage).
+    foreach ([$storageA, $storageB] as $storage) {
+        $cache = $storage->quantityOf($product);
+        expect($query->forProductInStorage($product->id, $storage->id))->toBe($cache);
+    }
+
+    // And the whole-product ledger balance matches the summed cache.
+    $totalCache = $storageA->quantityOf($product) + $storageB->quantityOf($product);
+    expect($query->forProduct($product->id))->toBe($totalCache);
+    expect($totalCache)->toBe(85); // 100 -30 +10 (-20 +20 net) +5
+});
+
+test('the balance helper is tenant scoped', function () {
+    $query = new StockBalanceQuery;
+    $currentTenant = app('currentTenant');
+
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 40, 'purchase_receipt');
+
+    // Another tenant with its own movements for a product of the SAME id space.
+    $other = Tenant::create(['name' => 'Other Org', 'slug' => 'other-org', 'is_active' => true]);
+    app()->instance('currentTenant', $other);
+    $otherStorage = Storage::factory()->create();
+    $otherProduct = Product::factory()->create();
+    $otherStorage->addStock($otherProduct, 999, 'purchase_receipt');
+
+    // Back to the original tenant: its balance excludes the other tenant's rows.
+    app()->instance('currentTenant', $currentTenant);
+    expect($query->forProduct($product->id))->toBe(40);
+    expect(StockMovement::count())->toBe(1);
+});
+
+test('a product with no movements has a zero ledger balance', function () {
+    $product = Product::factory()->create();
+
+    expect((new StockBalanceQuery)->forProduct($product->id))->toBe(0);
+});


### PR DESCRIPTION
**Stacked on** #57 (M1). PRD: `docs/inventory-ledger/M2-balance-reconciliation.md`.

## What

The safety net that lets M9/M10 trust the ledger. **No read-path or write-behavior change** — pure additive tooling.

- **`StockBalanceQuery`** (`app/Queries/StockBalanceQuery.php`) — derives `SUM(stock_movements.quantity)` per product and per product+storage, tenant-scoped. This is the *authoritative* balance; `stocks.quantity` stays the O(1) row-locked cache and is never summed at POS speed.
- **`stock:reconcile`** command — reports drift between the cache and the ledger per `(tenant, product, storage)`; `--json` for CI; `--tenant=` filter; non-zero exit when drift exists. Read-only — correction is deferred to M9's opening-balance backfill (single reconciliation code path).

## Tests

- `StockBalanceQueryTest` — cache == ledger invariant across purchase → sale → adjustment → transfer (net-zero) → return, per (product, storage); tenant isolation; zero-movement balance = 0.
- `ReconcileStockCommandTest` — clean tenant (exit 0), seeder-style bypassed `stocks` row surfaced as exact drift (exit 1), `--json` shape.

## Acceptance criteria (from PRD)

- [x] Helper equals `stocks.quantity` for every (product, storage) on clean data; tenant isolation holds.
- [x] Clean data → zero drift, exit 0; bypassed row → exact gap, exit non-zero; `--json` well-formed.
- [x] `SUM(movements) == stocks.quantity` per (product, storage) after a mixed op sequence.