### PR TITLE
feat(inventory): M3 — per-tenant inventory strategy + policy layer

### DIFF
--- a/app/Enums/InventoryStrategyType.php
+++ b/app/Enums/InventoryStrategyType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Enums;
+
+enum InventoryStrategyType: string
+{
+    case PurchaseDriven = 'purchase_driven';
+    case FreeForm = 'free_form';
+
+    /**
+     * Human-readable label (localize at the call site via __()).
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::PurchaseDriven => 'Purchase-driven',
+            self::FreeForm => 'Free-form',
+        };
+    }
+}

--- a/app/Http/Requests/PreferenceRequest.php
+++ b/app/Http/Requests/PreferenceRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\InventoryStrategyType;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class PreferenceRequest extends FormRequest
 {
@@ -22,6 +24,8 @@ class PreferenceRequest extends FormRequest
             'alerts' => 'nullable',
             'currency' => 'nullable|string|max:10',
             'pecentage' => 'nullable|numeric|min:0|max:100',
+            'inventory_strategy' => ['nullable', Rule::enum(InventoryStrategyType::class)],
+            'allow_overselling' => 'nullable|boolean',
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,8 @@ use App\Models\User;
 use App\Observers\InvoiceObserver;
 use App\Observers\QuoteObserver;
 use App\Services\Core\Cache as TenantCacheService;
+use App\Services\Inventory\InventoryStrategy;
+use App\Services\Inventory\InventoryStrategyResolver;
 use Illuminate\Auth\Events\Logout;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -27,6 +29,13 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton('tenant-cache', fn () => new TenantCacheService);
+
+        // Resolve the acting tenant's inventory strategy fresh each time it is
+        // injected (not a singleton — it depends on per-tenant preferences).
+        $this->app->bind(
+            InventoryStrategy::class,
+            fn ($app) => $app->make(InventoryStrategyResolver::class)->resolve(),
+        );
     }
 
     public function boot(): void

--- a/app/Services/Inventory/FreeFormStrategy.php
+++ b/app/Services/Inventory/FreeFormStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\Inventory;
+
+use App\Enums\InventoryStrategyType;
+
+/**
+ * Flexible management: stock can be adjusted freely without a purchase invoice.
+ * The nested allow_overselling sub-setting decides whether sales may drive the
+ * balance negative (on) or still block at zero (off).
+ */
+class FreeFormStrategy implements InventoryStrategy
+{
+    public function __construct(private bool $allowOverselling) {}
+
+    public function type(): InventoryStrategyType
+    {
+        return InventoryStrategyType::FreeForm;
+    }
+
+    public function allowsManualStockIncrease(): bool
+    {
+        return true;
+    }
+
+    public function allowsOverselling(): bool
+    {
+        return $this->allowOverselling;
+    }
+
+    public function permitsDeduction(int $available, int $requested): bool
+    {
+        return $this->allowOverselling || $available >= $requested;
+    }
+}

--- a/app/Services/Inventory/InventoryStrategy.php
+++ b/app/Services/Inventory/InventoryStrategy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Inventory;
+
+use App\Enums\InventoryStrategyType;
+
+/**
+ * A tenant's inventory strategy: the single place that answers "how does this
+ * tenant want to manage stock?". Strategy changes only which validation rules
+ * and entry paths are permitted — the ledger schema is identical in every mode.
+ */
+interface InventoryStrategy
+{
+    public function type(): InventoryStrategyType;
+
+    /**
+     * May stock be raised manually (adjustments / product-edit) without a
+     * purchase invoice? False under purchase_driven.
+     */
+    public function allowsManualStockIncrease(): bool;
+
+    /**
+     * May a sale drive the balance negative? Only free_form with the nested
+     * allow_overselling sub-setting turned on.
+     */
+    public function allowsOverselling(): bool;
+
+    /**
+     * Whether a deduction of $requested is permitted given $available on hand.
+     * The caller owns the InsufficientStockException (it holds product/storage).
+     */
+    public function permitsDeduction(int $available, int $requested): bool;
+}

--- a/app/Services/Inventory/InventoryStrategyResolver.php
+++ b/app/Services/Inventory/InventoryStrategyResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Inventory;
+
+use App\Enums\InventoryStrategyType;
+
+/**
+ * Resolves the current tenant's inventory strategy from its preferences.
+ *
+ * Existing tenants have no preference set, so they resolve to purchase_driven,
+ * which matches NamaIn's historical behaviour exactly.
+ */
+class InventoryStrategyResolver
+{
+    public function resolve(): InventoryStrategy
+    {
+        return match ($this->type()) {
+            InventoryStrategyType::FreeForm => new FreeFormStrategy($this->allowsOverselling()),
+            InventoryStrategyType::PurchaseDriven => new PurchaseDrivenStrategy,
+        };
+    }
+
+    public function type(): InventoryStrategyType
+    {
+        return InventoryStrategyType::tryFrom((string) preference('inventory_strategy', InventoryStrategyType::PurchaseDriven->value))
+            ?? InventoryStrategyType::PurchaseDriven;
+    }
+
+    private function allowsOverselling(): bool
+    {
+        return filter_var(preference('allow_overselling', false), FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/app/Services/Inventory/PurchaseDrivenStrategy.php
+++ b/app/Services/Inventory/PurchaseDrivenStrategy.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services\Inventory;
+
+use App\Enums\InventoryStrategyType;
+
+/**
+ * Strict discipline: positive stock enters only via purchase invoices, and
+ * sales are blocked at zero. Manual upward adjustments are not allowed.
+ */
+class PurchaseDrivenStrategy implements InventoryStrategy
+{
+    public function type(): InventoryStrategyType
+    {
+        return InventoryStrategyType::PurchaseDriven;
+    }
+
+    public function allowsManualStockIncrease(): bool
+    {
+        return false;
+    }
+
+    public function allowsOverselling(): bool
+    {
+        return false;
+    }
+
+    public function permitsDeduction(int $available, int $requested): bool
+    {
+        return $available >= $requested;
+    }
+}

--- a/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
+++ b/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
@@ -10,12 +10,17 @@
     import TextInput from "@/Components/TextInput.vue";
     const alertsToggle = ref(preferences('alerts', true));
 
+    const truthy = (value) => [true, 1, "1", "true"].includes(value);
+    const oversellingToggle = ref(truthy(preferences('allow_overselling', false)));
+
     const form = useForm({
         logo: preferences('logo'),
         invoicesHeadline: preferences('invoicesHeadline'),
         alerts: alertsToggle.value,
         currency: preferences('currency', 'SDG'),
         pecentage: preferences('pecentage', 60),
+        inventory_strategy: preferences('inventory_strategy', 'purchase_driven'),
+        allow_overselling: oversellingToggle.value,
     });
 
     const logoPreview = ref(null);
@@ -23,6 +28,9 @@
 
     const updateApplicationInformation = () => {
         form.alerts = alertsToggle.value;
+        // allow_overselling only applies under free-form; purchase-driven always blocks.
+        form.allow_overselling =
+            form.inventory_strategy === "free_form" ? oversellingToggle.value : false;
         if (logoInput.value && logoInput.value.files[0]) {
             form.logo = logoInput.value.files[0];
         }
@@ -214,6 +222,89 @@
                 </div>
                 <InputError
                     :message="form.errors.currency"
+                    class="mt-2"
+                />
+            </div>
+
+            <!-- Inventory strategy -->
+            <div class="col-span-6 sm:col-span-4">
+                <InputLabel :value="__('Inventory Management')" />
+                <p class="mt-1 text-sm text-secondary">
+                    {{ __("Choose how you want to manage your inventory.") }}
+                </p>
+
+                <div class="mt-3 space-y-3">
+                    <label
+                        class="flex items-start gap-x-3 p-3 border border-line rounded-lg cursor-pointer bg-surface"
+                        :class="{ 'ring-1 ring-emerald-500/40 border-emerald-400': form.inventory_strategy === 'purchase_driven' }"
+                    >
+                        <input
+                            v-model="form.inventory_strategy"
+                            type="radio"
+                            value="purchase_driven"
+                            class="mt-0.5 text-emerald-600 border-line focus:ring-emerald-200"
+                        />
+                        <span>
+                            <span class="block text-sm font-medium text-primary">
+                                {{ __("Purchase-driven (strict)") }}
+                            </span>
+                            <span class="block text-xs text-secondary">
+                                {{ __("Stock enters only through purchase invoices. Sales are blocked when stock runs out.") }}
+                            </span>
+                        </span>
+                    </label>
+
+                    <label
+                        class="flex items-start gap-x-3 p-3 border border-line rounded-lg cursor-pointer bg-surface"
+                        :class="{ 'ring-1 ring-emerald-500/40 border-emerald-400': form.inventory_strategy === 'free_form' }"
+                    >
+                        <input
+                            v-model="form.inventory_strategy"
+                            type="radio"
+                            value="free_form"
+                            class="mt-0.5 text-emerald-600 border-line focus:ring-emerald-200"
+                        />
+                        <span>
+                            <span class="block text-sm font-medium text-primary">
+                                {{ __("Free-form (flexible)") }}
+                            </span>
+                            <span class="block text-xs text-secondary">
+                                {{ __("Adjust quantities freely without purchase invoices.") }}
+                            </span>
+                        </span>
+                    </label>
+                </div>
+
+                <!-- Overselling toggle: only meaningful under free-form -->
+                <div
+                    v-if="form.inventory_strategy === 'free_form'"
+                    class="flex items-center mt-4 cursor-pointer"
+                    @click="oversellingToggle = !oversellingToggle"
+                >
+                    <div
+                        class="relative w-10 h-5 transition duration-200 ease-linear rounded-full"
+                        :class="[oversellingToggle ? 'bg-emerald-500' : 'bg-gray-300']"
+                    >
+                        <label
+                            class="absolute left-0 w-5 h-5 mb-2 transition duration-100 ease-linear transform bg-white border-2 rounded-full cursor-pointer"
+                            :class="[
+                                oversellingToggle
+                                    ? 'translate-x-full border-emerald-500'
+                                    : 'translate-x-0 border-gray-300',
+                            ]"
+                        ></label>
+                    </div>
+                    <p class="mx-3 text-sm text-secondary">
+                        {{ __("Allow selling below zero (overselling). Negative balances are surfaced for later reconciliation.") }}
+                    </p>
+                </div>
+
+                <InputError
+                    :message="form.errors.inventory_strategy"
+                    class="mt-2"
+                />
+                <InputError
+                    :message="form.errors.allow_overselling"
                     class="mt-2"
                 />
             </div>

--- a/tests/Feature/Inventory/InventoryStrategyResolverTest.php
+++ b/tests/Feature/Inventory/InventoryStrategyResolverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Enums\InventoryStrategyType;
+use App\Models\Preference;
+use App\Models\User;
+use App\Services\Inventory\InventoryStrategy;
+use App\Services\Inventory\InventoryStrategyResolver;
+
+test('existing tenants with no preference resolve to purchase-driven', function () {
+    $strategy = app(InventoryStrategyResolver::class)->resolve();
+
+    expect($strategy->type())->toBe(InventoryStrategyType::PurchaseDriven);
+    expect($strategy->allowsOverselling())->toBeFalse();
+});
+
+test('resolves free-form with overselling on from preferences', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '1']);
+
+    $strategy = app(InventoryStrategyResolver::class)->resolve();
+
+    expect($strategy->type())->toBe(InventoryStrategyType::FreeForm);
+    expect($strategy->allowsManualStockIncrease())->toBeTrue();
+    expect($strategy->allowsOverselling())->toBeTrue();
+});
+
+test('free-form with overselling off still guards deductions', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '0']);
+
+    $strategy = app(InventoryStrategyResolver::class)->resolve();
+
+    expect($strategy->allowsOverselling())->toBeFalse();
+    expect($strategy->permitsDeduction(2, 5))->toBeFalse();
+});
+
+test('the container binds InventoryStrategy to the resolved strategy', function () {
+    expect(app(InventoryStrategy::class))->toBeInstanceOf(InventoryStrategy::class)
+        ->and(app(InventoryStrategy::class)->type())->toBe(InventoryStrategyType::PurchaseDriven);
+});
+
+test('the settings form persists the strategy and overselling preferences', function () {
+    $this->actingAs(User::factory()->create());
+
+    $this->post(route('preferences.update'), [
+        'inventory_strategy' => 'free_form',
+        'allow_overselling' => true,
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('preferences', ['key' => 'inventory_strategy', 'value' => 'free_form']);
+    $this->assertDatabaseHas('preferences', ['key' => 'allow_overselling', 'value' => '1']);
+});

--- a/tests/Unit/InventoryStrategyTest.php
+++ b/tests/Unit/InventoryStrategyTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Enums\InventoryStrategyType;
+use App\Services\Inventory\FreeFormStrategy;
+use App\Services\Inventory\PurchaseDrivenStrategy;
+
+test('purchase-driven blocks manual increases and overselling', function () {
+    $strategy = new PurchaseDrivenStrategy;
+
+    expect($strategy->type())->toBe(InventoryStrategyType::PurchaseDriven);
+    expect($strategy->allowsManualStockIncrease())->toBeFalse();
+    expect($strategy->allowsOverselling())->toBeFalse();
+    expect($strategy->permitsDeduction(10, 5))->toBeTrue();
+    expect($strategy->permitsDeduction(5, 10))->toBeFalse();
+});
+
+test('free-form allows manual increases; overselling follows the sub-setting', function () {
+    $off = new FreeFormStrategy(allowOverselling: false);
+
+    expect($off->type())->toBe(InventoryStrategyType::FreeForm);
+    expect($off->allowsManualStockIncrease())->toBeTrue();
+    expect($off->allowsOverselling())->toBeFalse();
+    expect($off->permitsDeduction(5, 10))->toBeFalse(); // still guards at zero
+
+    $on = new FreeFormStrategy(allowOverselling: true);
+
+    expect($on->allowsOverselling())->toBeTrue();
+    expect($on->permitsDeduction(5, 10))->toBeTrue(); // oversell permitted
+    expect($on->permitsDeduction(0, 3))->toBeTrue();
+});


### PR DESCRIPTION
**Stacked on** #58 (M2). PRD: `docs/inventory-ledger/M3-strategy-setting.md`.

## What

The single place that answers *"how does this tenant want to manage stock?"*. **Default `purchase_driven`** → existing tenants behave exactly as today. **No enforcement is wired yet** (that's M4) — this ships the resolvable strategy, the setting, and the UI.

- **`InventoryStrategy`** contract + `PurchaseDrivenStrategy` / `FreeFormStrategy(allowOverselling)` (`app/Services/Inventory/`). Methods: `allowsManualStockIncrease()`, `allowsOverselling()`, `permitsDeduction($available, $requested)`.
- **`InventoryStrategyResolver`** reads `preference('inventory_strategy')` + `preference('allow_overselling')`; defaults to `purchase_driven`. Bound in the container (transient — depends on per-tenant prefs).
- `InventoryStrategyType` enum; preference keys added to `PreferenceRequest`.
- **Settings UI** — strategy radio + a nested overselling toggle shown only under free-form (localized, RTL/dark via the semantic design tokens).

## Design note (deviation from PRD)

- The contract exposes `permitsDeduction()` rather than `assertCanDeduct()`; the caller (M4's `Storage::deductStock`) owns the `InsufficientStockException` since it holds the product/storage context.
- **T3.3 dropped.** The PRD flagged the `preferences` cache key as not tenant-qualified, but every usage goes through the custom **tenant-aware `App\Facades\Cache`** (`app/Services/Core/Cache.php`), which already prefixes `tenant_{id}_`. No bug → no separate PR.

## Tests

- `InventoryStrategyTest` (unit) — both strategies' behaviors incl. overselling on/off.
- `InventoryStrategyResolverTest` — default = purchase_driven, free-form on/off, container binding, settings-form persistence.
- Frontend builds clean.

## Acceptance criteria (from PRD)

- [x] Resolver defaults to `purchase_driven`; each method covered for both strategies.
- [x] Keys persist via `UpdatePreferences`.
- [x] Overselling toggle hidden under purchase_driven; saves round-trip.