### PR TITLE
feat(inventory): M4 — free-form mode + single-point enforcement

### DIFF
--- a/app/Actions/Pos/PosPreflightAction.php
+++ b/app/Actions/Pos/PosPreflightAction.php
@@ -5,6 +5,7 @@ namespace App\Actions\Pos;
 use App\Models\PosSession;
 use App\Models\Product;
 use App\Models\Unit;
+use App\Services\Inventory\InventoryStrategy;
 
 class PosPreflightAction
 {
@@ -49,7 +50,8 @@ class PosPreflightAction
         $quantityRequested = $item['quantity'] * ($unit->conversion_factor ?? 1);
         $quantityAtSalePoint = $session->storage->quantityOf($product);
 
-        if ($quantityAtSalePoint >= $quantityRequested) {
+        // Overselling tenants are never blocked, so nothing needs confirming.
+        if ($quantityAtSalePoint >= $quantityRequested || app(InventoryStrategy::class)->allowsOverselling()) {
             return [];
         }
 

--- a/app/Actions/Pos/ProcessPosCheckoutAction.php
+++ b/app/Actions/Pos/ProcessPosCheckoutAction.php
@@ -21,6 +21,7 @@ use App\Models\Storage;
 use App\Models\TreasuryAccount;
 use App\Models\Unit;
 use App\Models\User;
+use App\Services\Inventory\InventoryStrategy;
 use DomainException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -71,7 +72,9 @@ class ProcessPosCheckoutAction
                 $available = $session->storage->quantityOf($item['product_id']);
                 $needed = $quantity;
 
-                if ($available < $needed) {
+                // Overselling tenants never block on stock; the sale drives the
+                // sale-point balance negative and is surfaced for reconciliation.
+                if ($available < $needed && ! app(InventoryStrategy::class)->allowsOverselling()) {
                     if (! $acknowledgeTransfers) {
                         throw new InsufficientStockException(Product::findOrFail($item['product_id']), $session->storage);
                     }

--- a/app/Actions/Stock/RecordAdjustmentAction.php
+++ b/app/Actions/Stock/RecordAdjustmentAction.php
@@ -2,10 +2,12 @@
 
 namespace App\Actions\Stock;
 
+use App\Exceptions\ManualStockIncreaseNotAllowedException;
 use App\Models\Adjustment;
 use App\Models\Product;
 use App\Models\Storage;
 use App\Models\User;
+use App\Services\Inventory\InventoryStrategy;
 use Illuminate\Support\Facades\DB;
 
 class RecordAdjustmentAction
@@ -14,6 +16,11 @@ class RecordAdjustmentAction
     {
         return DB::transaction(function () use ($storage, $product, $newQuantity, $type, $actor, $notes) {
             $quantityBefore = $storage->quantityOf($product);
+
+            // Under purchase-driven, stock may only rise via purchase invoices.
+            if ($newQuantity > $quantityBefore && ! app(InventoryStrategy::class)->allowsManualStockIncrease()) {
+                throw new ManualStockIncreaseNotAllowedException($product);
+            }
 
             $adjustment = Adjustment::create([
                 'tenant_id' => $storage->tenant_id,

--- a/app/Exceptions/ManualStockIncreaseNotAllowedException.php
+++ b/app/Exceptions/ManualStockIncreaseNotAllowedException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Models\Product;
+use RuntimeException;
+
+class ManualStockIncreaseNotAllowedException extends RuntimeException
+{
+    public function __construct(public Product $product)
+    {
+        parent::__construct("Manual stock increases are not allowed for [{$product->name}] under the purchase-driven strategy. Add stock through a purchase invoice.");
+    }
+}

--- a/app/Http/Controllers/Inventory/StockAdjustmentController.php
+++ b/app/Http/Controllers/Inventory/StockAdjustmentController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Inventory;
 
 use App\Actions\Stock\RecordAdjustmentAction;
 use App\Exceptions\InsufficientStockException;
+use App\Exceptions\ManualStockIncreaseNotAllowedException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StockAdjustmentRequest;
 use App\Models\Product;
@@ -24,7 +25,7 @@ class StockAdjustmentController extends Controller
                 auth()->user(),
                 $request->validated('notes')
             );
-        } catch (InsufficientStockException $e) {
+        } catch (InsufficientStockException|ManualStockIncreaseNotAllowedException $e) {
             return back()->with('error', $e->getMessage());
         }
 

--- a/app/Models/Storage.php
+++ b/app/Models/Storage.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\MovementType;
 use App\Enums\StorageType;
 use App\Exceptions\InsufficientStockException;
+use App\Services\Inventory\InventoryStrategy;
 use App\Traits\WithTrashScope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -154,17 +155,33 @@ class Storage extends BaseModel
                 ->lockForUpdate()
                 ->first();
 
-            if (! $stockData || $stockData->quantity < $quantity) {
+            $available = (int) ($stockData->quantity ?? 0);
+            $overselling = app(InventoryStrategy::class)->allowsOverselling();
+
+            // Without overselling, keep the original guard exactly: a missing row
+            // or an insufficient balance blocks the sale. Overselling bypasses it
+            // and drives the balance negative.
+            if (! $overselling && (! $stockData || $available < $quantity)) {
                 throw new InsufficientStockException($productModel, $this);
             }
 
+            if (! $stockData) {
+                DB::table('stocks')->insert([
+                    'tenant_id' => $this->tenant_id,
+                    'storage_id' => $this->id,
+                    'product_id' => $productId,
+                    'quantity' => 0,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
             DB::table('stocks')
-                ->where('id', $stockData->id)
+                ->where('storage_id', $this->id)
+                ->where('product_id', $productId)
                 ->decrement('quantity', $quantity, ['updated_at' => now()]);
 
-            $quantityBefore = $stockData->quantity;
-
-            $this->recordMovement($productModel, -$quantity, $quantityBefore, $quantityBefore - $quantity, $reason, $movable, $actor);
+            $this->recordMovement($productModel, -$quantity, $available, $available - $quantity, $reason, $movable, $actor);
         });
     }
 

--- a/database/migrations/2026_07_13_093000_make_stocks_quantity_signed.php
+++ b/database/migrations/2026_07_13_093000_make_stocks_quantity_signed.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Allow negative stock balances so free-form tenants can oversell.
+ *
+ * Only MySQL/MariaDB enforce the UNSIGNED constraint. Postgres maps
+ * unsignedBigInteger to a (signed) bigint already, and SQLite is dynamically
+ * typed, so both already permit negatives — this migration is a no-op there.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            return;
+        }
+
+        Schema::table('stocks', function (Blueprint $table) {
+            $table->bigInteger('quantity')->default(0)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        if (! in_array(DB::getDriverName(), ['mysql', 'mariadb'], true)) {
+            return;
+        }
+
+        Schema::table('stocks', function (Blueprint $table) {
+            $table->unsignedBigInteger('quantity')->default(0)->change();
+        });
+    }
+};

--- a/tests/Feature/Inventory/FreeFormModeTest.php
+++ b/tests/Feature/Inventory/FreeFormModeTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Actions\Stock\RecordAdjustmentAction;
+use App\Exceptions\InsufficientStockException;
+use App\Exceptions\ManualStockIncreaseNotAllowedException;
+use App\Models\Preference;
+use App\Models\Product;
+use App\Models\StockMovement;
+use App\Models\Storage;
+use App\Models\User;
+
+function useStrategy(string $strategy, bool $allowOverselling = false): void
+{
+    Preference::updateOrCreate(['key' => 'inventory_strategy'], ['value' => $strategy]);
+    Preference::updateOrCreate(['key' => 'allow_overselling'], ['value' => $allowOverselling ? '1' : '0']);
+}
+
+test('purchase-driven blocks a sale that would drive stock negative', function () {
+    // No preference set → purchase_driven (matches current behaviour).
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 5, 'purchase_receipt');
+
+    expect(fn () => $storage->deductStock($product, 8, 'sale_delivery'))
+        ->toThrow(InsufficientStockException::class);
+
+    expect($storage->quantityOf($product))->toBe(5); // rolled back, untouched
+});
+
+test('free-form with overselling on drives the balance negative and ledgers it', function () {
+    useStrategy('free_form', allowOverselling: true);
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 5, 'purchase_receipt');
+
+    $storage->deductStock($product, 8, 'sale_delivery');
+
+    expect($storage->quantityOf($product))->toBe(-3);
+
+    $movement = StockMovement::where('reason', 'sale_delivery')->latest('id')->first();
+    expect($movement->quantity)->toBe(-8);
+    expect($movement->quantity_before)->toBe(5);
+    expect($movement->quantity_after)->toBe(-3);
+});
+
+test('free-form with overselling off still blocks at zero', function () {
+    useStrategy('free_form', allowOverselling: false);
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 5, 'purchase_receipt');
+
+    expect(fn () => $storage->deductStock($product, 8, 'sale_delivery'))
+        ->toThrow(InsufficientStockException::class);
+
+    expect($storage->quantityOf($product))->toBe(5);
+});
+
+test('overselling can sell a product that has no stock row at all', function () {
+    useStrategy('free_form', allowOverselling: true);
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+
+    $storage->deductStock($product, 4, 'sale_delivery');
+
+    expect($storage->quantityOf($product))->toBe(-4);
+});
+
+test('purchase-driven blocks a manual upward adjustment', function () {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $actor = User::factory()->create();
+    $storage->addStock($product, 10, 'purchase_receipt');
+
+    expect(fn () => app(RecordAdjustmentAction::class)->handle($storage, $product, 25, 'manual', $actor))
+        ->toThrow(ManualStockIncreaseNotAllowedException::class);
+
+    expect($storage->quantityOf($product))->toBe(10);
+});
+
+test('purchase-driven still allows a downward adjustment for loss or damage', function () {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $actor = User::factory()->create();
+    $storage->addStock($product, 10, 'purchase_receipt');
+
+    app(RecordAdjustmentAction::class)->handle($storage, $product, 4, 'loss', $actor);
+
+    expect($storage->quantityOf($product))->toBe(4);
+});
+
+test('free-form allows a manual upward adjustment', function () {
+    useStrategy('free_form');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $actor = User::factory()->create();
+    $storage->addStock($product, 10, 'purchase_receipt');
+
+    app(RecordAdjustmentAction::class)->handle($storage, $product, 25, 'manual', $actor);
+
+    expect($storage->quantityOf($product))->toBe(25);
+});

--- a/tests/Feature/StockAdjustmentTest.php
+++ b/tests/Feature/StockAdjustmentTest.php
@@ -2,6 +2,7 @@
 
 use App\Actions\Stock\RecordAdjustmentAction;
 use App\Models\Adjustment;
+use App\Models\Preference;
 use App\Models\Product;
 use App\Models\Storage;
 use App\Models\Tenant;
@@ -13,6 +14,10 @@ uses(RefreshDatabase::class);
 beforeEach(function () {
     $this->tenant = Tenant::factory()->create();
     app()->instance('currentTenant', $this->tenant);
+
+    // Free upward/downward adjustments are a free-form capability; under the
+    // purchase-driven strategy upward adjustments are blocked (see FreeFormModeTest).
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
 
     $this->owner = User::factory()->create(['current_tenant_id' => $this->tenant->id]);
     $this->tenant->users()->attach($this->owner, ['role' => 'owner']);


### PR DESCRIPTION
**Stacked on** #59 (M3). PRD: `docs/inventory-ledger/M4-free-form-mode.md`. Ships with M8 (provisional costing) conceptually.

## What

Wires the M3 strategy layer into the stock write paths. **`purchase_driven` behaviour is byte-for-byte unchanged.**

- **Signed `stocks.quantity`** — migration flips MySQL/MariaDB's UNSIGNED to signed (Postgres `bigint` and SQLite already allow negatives → no-op there). Reversible.
- **`Storage::deductStock`** consults the strategy **inside the locked transaction**: overselling drives the balance negative; otherwise the original guard (missing row *or* insufficient balance) still blocks. This is the single enforcement authority.
- **POS** checkout precheck + preflight consult `allowsOverselling()` (advisory); `deductStock` remains the authority.
- **Adjustments** — `RecordAdjustmentAction` blocks manual **upward** adjustments under `purchase_driven` (`ManualStockIncreaseNotAllowedException`, surfaced as an error flash); free-form allows them. Downward always allowed.

## Behaviours

| Strategy | Sale beyond stock |
|---|---|
| `purchase_driven` | blocked at zero |
| `free_form` + overselling **on** | proceeds, balance goes negative, ledgered |
| `free_form` + overselling **off** | blocked at zero |

## Tests

- `FreeFormModeTest` — the three deduction behaviours, overselling with no stock row at all, and adjustment gating (up blocked strict / allowed free-form / down always allowed).
- `StockAdjustmentTest` updated to `free_form` for its upward-adjustment happy path (the block path is covered by `FreeFormModeTest`).
- Full sales / purchase / invoice / POS / treasury / returns suites green (518 assertions). *(Unrelated: a pre-existing Excel-export test hits a zipstream memory limit when the whole suite runs in one process — untouched by this PR.)*

## Acceptance criteria (from PRD)

- [x] Negative balances insertable; existing values unchanged; `down()` restores.
- [x] Overselling on → negative + movement; off → blocks at zero; both under the row lock.
- [x] Free-form+oversell checkout succeeds into negative; purchase_driven unchanged.
- [x] Upward adjustment blocked in strict, allowed in free-form.