### PR TITLE
feat(inventory): M5 — edit product on-hand quantity as an adjustment delta

### DIFF
--- a/app/Http/Controllers/Catalog/ProductsController.php
+++ b/app/Http/Controllers/Catalog/ProductsController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers\Catalog;
 
+use App\Actions\Stock\RecordAdjustmentAction;
 use App\Actions\SyncCategoriesAction;
+use App\Exceptions\ManualStockIncreaseNotAllowedException;
 use App\Filters\ProductFilter;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ProductRequest;
@@ -55,7 +57,7 @@ class ProductsController extends Controller
     {
         $this->authorize('create', Product::class);
 
-        $product = Product::create($request->safe()->except(['units', 'categories']));
+        $product = Product::create($request->safe()->except(['units', 'categories', 'quantity', 'storage_id']));
 
         $units = $request->get('units');
 
@@ -79,17 +81,46 @@ class ProductsController extends Controller
         return back()->with('success', __('Product updated successfully'));
     }
 
-    public function update(Product $product, ProductRequest $request, SyncCategoriesAction $syncCategoriesAction)
+    public function update(Product $product, ProductRequest $request, SyncCategoriesAction $syncCategoriesAction, RecordAdjustmentAction $recordAdjustment)
     {
         $this->authorize('update', $product);
 
-        $product->update($request->safe()->except(['units', 'categories']));
+        $product->update($request->safe()->except(['units', 'categories', 'quantity', 'storage_id']));
 
         $product->syncUnits($request->get('units'));
 
         $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
 
+        try {
+            $this->syncOnHandQuantity($product, $request, $recordAdjustment);
+        } catch (ManualStockIncreaseNotAllowedException $e) {
+            return back()->with('error', $e->getMessage());
+        }
+
         return back()->with('success', __('Product updated successfully'));
+    }
+
+    /**
+     * Apply a directly-edited on-hand quantity as an adjustment delta.
+     *
+     * The product form never overwrites stock; it records the difference between
+     * the requested quantity and the current balance as an adjustment movement,
+     * gated by the tenant's inventory strategy.
+     */
+    private function syncOnHandQuantity(Product $product, ProductRequest $request, RecordAdjustmentAction $recordAdjustment): void
+    {
+        if (! $request->filled('quantity') || ! $request->filled('storage_id')) {
+            return;
+        }
+
+        $storage = Storage::findOrFail($request->integer('storage_id'));
+        $newQuantity = $request->integer('quantity');
+
+        if ($newQuantity === $storage->quantityOf($product)) {
+            return;
+        }
+
+        $recordAdjustment->handle($storage, $product, $newQuantity, 'product_edit', auth()->user());
     }
 
     public function destroy(Product $product)

--- a/app/Http/Requests/ProductRequest.php
+++ b/app/Http/Requests/ProductRequest.php
@@ -29,6 +29,8 @@ class ProductRequest extends FormRequest
             'currency' => 'nullable|string|max:3',
             'expire_date' => 'nullable|date',
             'alert_quantity' => 'nullable|numeric|min:0',
+            'quantity' => 'nullable|integer|min:0',
+            'storage_id' => 'nullable|integer|exists:storages,id|required_with:quantity',
             'units' => 'nullable|array',
             'units.*.name' => 'required_with:units',
             'units.*.conversion_factor' => 'required_with:units|numeric|gt:0',

--- a/resources/js/Components/Products/ProductForm.vue
+++ b/resources/js/Components/Products/ProductForm.vue
@@ -18,7 +18,21 @@
             default: () => [],
             required: false,
         },
+        storages: {
+            type: Array,
+            default: () => [],
+            required: false,
+        },
     });
+
+    const isEditing = !!props.product;
+
+    const currentQuantityFor = (storageId) => {
+        const entry = (props.product?.stock || []).find((s) => s.id === storageId);
+        return entry?.pivot?.quantity ?? 0;
+    };
+
+    const firstStorageId = props.storages?.[0]?.id ?? null;
 
     const show = ref(false);
     const product = useForm({
@@ -32,9 +46,15 @@
         units: props.product?.units?.length
             ? props.product?.units
             : [],
+        storage_id: firstStorageId,
+        quantity: isEditing ? currentQuantityFor(firstStorageId) : "",
     });
 
-    const isEditing = !!props.product;
+    // Editing the storage re-reads that storage's current on-hand quantity so the
+    // field always shows the balance the delta will be computed against.
+    const onStorageChange = () => {
+        product.quantity = currentQuantityFor(product.storage_id);
+    };
 
     const setCurrency = (value) => {
         product.currency = (value || "").toUpperCase();
@@ -296,6 +316,53 @@
                                                     :message="
                                                         product.errors.alert_quantity
                                                     "
+                                                />
+                                            </div>
+                                        </div>
+
+                                        <!-- On-hand quantity as an adjustment delta (edit only) -->
+                                        <div
+                                            v-if="isEditing && props.storages.length"
+                                            class="grid grid-cols-2 gap-4"
+                                        >
+                                            <div>
+                                                <InputLabel
+                                                    for="storage_id"
+                                                    :value="__('Storage')"
+                                                />
+                                                <select
+                                                    id="storage_id"
+                                                    v-model="product.storage_id"
+                                                    class="block w-full px-3 py-2 mt-1 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                                    @change="onStorageChange"
+                                                >
+                                                    <option
+                                                        v-for="storage in props.storages"
+                                                        :key="storage.id"
+                                                        :value="storage.id"
+                                                    >
+                                                        {{ storage.name }}
+                                                    </option>
+                                                </select>
+                                            </div>
+                                            <div>
+                                                <InputLabel
+                                                    for="quantity"
+                                                    :value="__('On-hand Quantity')"
+                                                />
+                                                <TextInput
+                                                    id="quantity"
+                                                    v-model="product.quantity"
+                                                    type="number" inputmode="numeric"
+                                                    min="0"
+                                                    class="block w-full mt-1"
+                                                />
+                                                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                                                    {{ __("Saving records the difference as a stock adjustment.") }}
+                                                </p>
+                                                <InputError
+                                                    class="mt-1"
+                                                    :message="product.errors.quantity"
                                                 />
                                             </div>
                                         </div>

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -567,7 +567,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
                                                 <ProductAdjustmentModal :product="product" :storages="storages" />
                                             </div>
                                             <div @click.stop>
-                                                <ProductForm :product="product" :categories="categories" />
+                                                <ProductForm :product="product" :categories="categories" :storages="storages" />
                                             </div>
                                             <div @click.stop>
                                                 <DeleteProduct :product="product" />

--- a/tests/Feature/Inventory/ProductEditQuantityTest.php
+++ b/tests/Feature/Inventory/ProductEditQuantityTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\Preference;
+use App\Models\Product;
+use App\Models\StockMovement;
+use App\Models\Storage;
+use App\Models\User;
+
+test('editing a product on-hand quantity records the difference as an adjustment', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 30, 'purchase_receipt');
+
+    $this->actingAs(User::factory()->create())
+        ->put(route('products.update', $product), [
+            'name' => $product->name,
+            'cost' => 10,
+            'units' => [['name' => 'Box', 'conversion_factor' => 1]],
+            'categories' => [],
+            'storage_id' => $storage->id,
+            'quantity' => 50,
+        ])->assertSessionHasNoErrors();
+
+    expect($storage->fresh()->quantityOf($product))->toBe(50);
+
+    $movement = StockMovement::where('reason', 'adjustment')->latest('id')->first();
+    expect($movement->quantity)->toBe(20); // 50 - 30
+
+    $this->assertDatabaseHas('adjustments', [
+        'product_id' => $product->id,
+        'storage_id' => $storage->id,
+        'type' => 'product_edit',
+        'quantity_before' => 30,
+        'quantity_after' => 50,
+    ]);
+});
+
+test('editing a product quantity upward is blocked under purchase-driven', function () {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 30, 'purchase_receipt');
+
+    $this->actingAs(User::factory()->create())
+        ->put(route('products.update', $product), [
+            'name' => $product->name,
+            'cost' => 10,
+            'units' => [['name' => 'Box', 'conversion_factor' => 1]],
+            'categories' => [],
+            'storage_id' => $storage->id,
+            'quantity' => 50,
+        ])->assertSessionHas('error');
+
+    expect($storage->fresh()->quantityOf($product))->toBe(30);
+});
+
+test('editing a product quantity to the same value records no adjustment', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 30, 'purchase_receipt');
+
+    $this->actingAs(User::factory()->create())
+        ->put(route('products.update', $product), [
+            'name' => $product->name,
+            'cost' => 10,
+            'units' => [['name' => 'Box', 'conversion_factor' => 1]],
+            'categories' => [],
+            'storage_id' => $storage->id,
+            'quantity' => 30,
+        ])->assertSessionHasNoErrors();
+
+    expect(StockMovement::where('reason', 'adjustment')->count())->toBe(0);
+});
+
+test('updating a product without a quantity leaves stock untouched', function () {
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 30, 'purchase_receipt');
+
+    $this->actingAs(User::factory()->create())
+        ->put(route('products.update', $product), [
+            'name' => 'Renamed Product',
+            'cost' => 15,
+            'units' => [['name' => 'Box', 'conversion_factor' => 1]],
+            'categories' => [],
+        ])->assertSessionHasNoErrors();
+
+    expect($storage->fresh()->quantityOf($product))->toBe(30);
+    expect($product->fresh()->name)->toBe('Renamed Product');
+});


### PR DESCRIPTION
**Stacked on** #60 (M4). PRD: `docs/inventory-ledger/M5-product-edit-delta.md`.

## What

The product **edit** form can now set on-hand quantity per storage — as sugar over the ledger. It **never overwrites** stock: the controller computes `new − current_balance` and records the difference through `RecordAdjustmentAction` (delta movement + `Adjustment` row, `type = product_edit`), so the tenant's strategy gating (M4) applies automatically.

- `ProductRequest` — nullable `quantity` + `storage_id` (`required_with:quantity`).
- `ProductsController::update` routes the delta via `RecordAdjustmentAction`; `ManualStockIncreaseNotAllowedException` surfaces as an error flash. `quantity`/`storage_id` excluded from the product attributes.
- `ProductForm.vue` — storage select + on-hand quantity field shown on edit, prefilled from the selected storage's current balance (localized, RTL/dark). `storages` passed from the products index.

**Scope:** edit only (create still brings stock in via purchases). No-op when the quantity is unchanged; reuses the existing `RecordAdjustmentAction` rather than reinventing the delta logic.

## Tests

- Delta recorded (+ `Adjustment` row) under free-form; blocked under purchase-driven (error flash, stock unchanged); no-op on equal value; stock untouched when no quantity is sent.
- Existing product controller/category suites green. Frontend builds clean.

## Acceptance criteria (from PRD)

- [x] Editing quantity produces an `adjustment` movement equal to the delta; no direct `stocks` write.
- [x] Upward edit gated by strategy (blocked under purchase-driven).
- [x] Localized/RTL field prefilled from current balance.