### PR TITLE
feat(inventory): M6 — strategy-switch flow + audit event

### DIFF
--- a/app/Actions/UpdatePreferences.php
+++ b/app/Actions/UpdatePreferences.php
@@ -2,12 +2,21 @@
 
 namespace App\Actions;
 
+use App\Facades\Cache;
 use App\Http\Requests\PreferenceRequest;
 use App\Models\Preference;
-use App\Facades\Cache;
+use App\Models\TenantSettingHistory;
 
 class UpdatePreferences
 {
+    /**
+     * Preference keys whose changes are recorded to the tenant settings history
+     * so reports can explain rule changes that happened mid-history.
+     *
+     * @var array<int, string>
+     */
+    private const AUDITED_KEYS = ['inventory_strategy', 'allow_overselling'];
+
     public function handle(PreferenceRequest $request): void
     {
         foreach ($request->validated() as $key => $value) {
@@ -17,13 +26,27 @@ class UpdatePreferences
                 continue;
             }
 
-            Preference::updateOrCreate(
-                ['key' => $key],
-                ['value' => $value]
-            );
+            $this->persist($key, $value);
         }
 
         Cache::forget('preferences');
+    }
+
+    private function persist(string $key, mixed $value): void
+    {
+        $audited = in_array($key, self::AUDITED_KEYS, true);
+        $oldValue = $audited ? Preference::where('key', $key)->value('value') : null;
+
+        Preference::updateOrCreate(['key' => $key], ['value' => $value]);
+
+        if ($audited && (string) $oldValue !== (string) $value) {
+            TenantSettingHistory::create([
+                'key' => $key,
+                'old_value' => $oldValue,
+                'new_value' => $value,
+                'changed_by' => auth()->id(),
+            ]);
+        }
     }
 
     private function resolveValue(string $key, mixed $value, PreferenceRequest $request): mixed

--- a/app/Exceptions/ImmutableRecordException.php
+++ b/app/Exceptions/ImmutableRecordException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class ImmutableRecordException extends RuntimeException
+{
+    public function __construct(string $record, string $operation)
+    {
+        parent::__construct("{$record} records are append-only and cannot be {$operation}.");
+    }
+}

--- a/app/Models/TenantSettingHistory.php
+++ b/app/Models/TenantSettingHistory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use App\Exceptions\ImmutableRecordException;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * An append-only record of a change to a tenant setting (e.g. inventory
+ * strategy). Reports read this to explain rule changes that happened
+ * mid-history. Rows are never updated or deleted.
+ */
+class TenantSettingHistory extends BaseModel
+{
+    protected $table = 'tenant_settings_history';
+
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        static::updating(function () {
+            throw new ImmutableRecordException('Tenant setting history', 'updated');
+        });
+
+        static::deleting(function () {
+            throw new ImmutableRecordException('Tenant setting history', 'deleted');
+        });
+    }
+
+    public function changedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'changed_by');
+    }
+}

--- a/database/migrations/2026_07_13_095000_create_tenant_settings_history_table.php
+++ b/database/migrations/2026_07_13_095000_create_tenant_settings_history_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tenant_settings_history', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->string('key');
+            $table->text('old_value')->nullable();
+            $table->text('new_value')->nullable();
+            $table->foreignId('changed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->index(['tenant_id', 'key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tenant_settings_history');
+    }
+};

--- a/tests/Feature/Inventory/StrategySwitchAuditTest.php
+++ b/tests/Feature/Inventory/StrategySwitchAuditTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Exceptions\ImmutableRecordException;
+use App\Models\Preference;
+use App\Models\Product;
+use App\Models\Storage;
+use App\Models\TenantSettingHistory;
+use App\Models\User;
+
+test('changing the inventory strategy records a dated history event', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'purchase_driven']);
+    $user = User::factory()->create();
+
+    $this->actingAs($user)->post(route('preferences.update'), [
+        'inventory_strategy' => 'free_form',
+        'allow_overselling' => true,
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('tenant_settings_history', [
+        'key' => 'inventory_strategy',
+        'old_value' => 'purchase_driven',
+        'new_value' => 'free_form',
+        'changed_by' => $user->id,
+    ]);
+    $this->assertDatabaseHas('tenant_settings_history', [
+        'key' => 'allow_overselling',
+        'new_value' => '1',
+    ]);
+});
+
+test('re-saving the same strategy records no new history event', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+
+    $this->actingAs(User::factory()->create())->post(route('preferences.update'), [
+        'inventory_strategy' => 'free_form',
+    ])->assertRedirect();
+
+    expect(TenantSettingHistory::where('key', 'inventory_strategy')->count())->toBe(0);
+});
+
+test('existing negative balances carry over unchanged when switching to purchase-driven', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '1']);
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 2, 'purchase_receipt');
+    $storage->deductStock($product, 5, 'sale_delivery');
+    expect($storage->quantityOf($product))->toBe(-3);
+
+    $this->actingAs(User::factory()->create())->post(route('preferences.update'), [
+        'inventory_strategy' => 'purchase_driven',
+        'allow_overselling' => false,
+    ])->assertRedirect();
+
+    // Switching only prevents NEW negatives; the existing one is untouched.
+    expect($storage->quantityOf($product))->toBe(-3);
+});
+
+test('tenant setting history is append-only', function () {
+    $history = TenantSettingHistory::create([
+        'key' => 'inventory_strategy',
+        'old_value' => 'purchase_driven',
+        'new_value' => 'free_form',
+        'changed_by' => null,
+    ]);
+
+    expect(fn () => $history->update(['new_value' => 'x']))->toThrow(ImmutableRecordException::class);
+    expect(fn () => $history->delete())->toThrow(ImmutableRecordException::class);
+});


### PR DESCRIPTION
**Stacked on** #61 (M5). PRD: `docs/inventory-ledger/M6-strategy-switch-audit.md`.

## What

Tenants can switch strategy or flip overselling at any time. The change applies **going forward only**, and existing negative balances **carry over untouched** (the stricter rules only prevent *new* negatives). Each change is now a dated, append-only event so reports can explain rule changes mid-history.

- **`tenant_settings_history`** table + model (`tenant_id, key, old_value, new_value, changed_by, created_at`). Tenant-scoped and **append-only** — updates/deletes throw `ImmutableRecordException`. (`AdminAuditLog` is a global super-admin log, so this is a new per-tenant trail as the PRD notes.)
- **`UpdatePreferences`** records `old → new` (with `changed_by`) for `inventory_strategy` and `allow_overselling`, only when the value actually changes.

## Tests

- Switching strategy records the dated event (old/new/actor); re-saving the same value records nothing.
- An existing negative balance survives a switch to `purchase_driven` (carry-over).
- History rows are immutable.

## Acceptance criteria (from PRD)

- [x] Switching records old→new with actor + timestamp.
- [x] Balances unchanged at switch (forward-only).
- [x] History table tenant-scoped and append-only.