### PR TITLE
feat(inventory): M7 — negative-stock reconciliation report

### DIFF
--- a/app/Exports/Reports/NegativeStockExport.php
+++ b/app/Exports/Reports/NegativeStockExport.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Exports\Reports;
+
+use App\Exports\Concerns\WithExportStyles;
+use App\Queries\Reports\NegativeStockQuery;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+
+class NegativeStockExport implements FromArray, WithHeadings, WithStyles
+{
+    use WithExportStyles;
+
+    public function __construct(protected array $filters = []) {}
+
+    public function array(): array
+    {
+        $storageId = isset($this->filters['storage']) ? (int) $this->filters['storage'] : null;
+
+        return array_map(fn (array $row) => [
+            $row['product_id'],
+            $row['product_name'],
+            $row['storage_name'],
+            $row['quantity'],
+            $row['negative_since'],
+            $row['days_negative'],
+        ], (new NegativeStockQuery)->get($storageId));
+    }
+
+    public function headings(): array
+    {
+        return [__('Product ID'), __('Product'), __('Storage'), __('Quantity'), __('Negative Since'), __('Days Negative')];
+    }
+}

--- a/app/Queries/Reports/NegativeStockQuery.php
+++ b/app/Queries/Reports/NegativeStockQuery.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Queries\Reports;
+
+use App\Models\StockMovement;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Products currently below zero, how long they have been negative, and the
+ * movements that drove them there — so someone can decide per case (missed
+ * purchase entry, shrinkage, or counting error) and resolve it with the right
+ * movement. Unlike InventoryValuationQuery this intentionally surfaces
+ * negatives instead of filtering them out.
+ */
+class NegativeStockQuery extends ReportQuery
+{
+    public function get(?int $storageId = null): array
+    {
+        return $this->negativeRows($storageId)
+            ->map(fn ($row) => $this->describe($row))
+            ->all();
+    }
+
+    public function summary(?int $storageId = null): array
+    {
+        $rows = $this->negativeRows($storageId);
+
+        return [
+            'product_count' => $rows->pluck('product_id')->unique()->count(),
+            'line_count' => $rows->count(),
+            'units_short' => (int) $rows->sum(fn ($row) => abs((int) $row->quantity)),
+        ];
+    }
+
+    private function negativeRows(?int $storageId)
+    {
+        return DB::table('stocks')
+            ->join('products', 'stocks.product_id', '=', 'products.id')
+            ->join('storages', 'stocks.storage_id', '=', 'storages.id')
+            ->where('products.tenant_id', $this->tenantId())
+            ->whereNull('stocks.deleted_at')
+            ->where('stocks.quantity', '<', 0)
+            ->when($storageId, fn ($query) => $query->where('stocks.storage_id', $storageId))
+            ->orderBy('stocks.quantity')
+            ->get([
+                'products.id as product_id',
+                'products.name as product_name',
+                'storages.id as storage_id',
+                'storages.name as storage_name',
+                'stocks.quantity',
+            ]);
+    }
+
+    private function describe(object $row): array
+    {
+        // The current negative streak began at the last movement that crossed
+        // the balance from non-negative to negative.
+        $crossing = StockMovement::query()
+            ->where('product_id', $row->product_id)
+            ->where('storage_id', $row->storage_id)
+            ->where('quantity_before', '>=', 0)
+            ->where('quantity_after', '<', 0)
+            ->latest('created_at')
+            ->latest('id')
+            ->first();
+
+        $negativeSince = $crossing?->created_at;
+
+        return [
+            'product_id' => (int) $row->product_id,
+            'product_name' => $row->product_name,
+            'storage_id' => (int) $row->storage_id,
+            'storage_name' => $row->storage_name,
+            'quantity' => (int) $row->quantity,
+            'negative_since' => $negativeSince?->toDateString(),
+            'days_negative' => $negativeSince ? (int) $negativeSince->startOfDay()->diffInDays(Carbon::now()->startOfDay()) : null,
+            'movements' => $this->drivingMovements($row, $negativeSince),
+        ];
+    }
+
+    private function drivingMovements(object $row, ?Carbon $since): array
+    {
+        return StockMovement::query()
+            ->where('product_id', $row->product_id)
+            ->where('storage_id', $row->storage_id)
+            ->when($since, fn ($query) => $query->where('created_at', '>=', $since))
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->limit(20)
+            ->get()
+            ->map(fn (StockMovement $movement) => [
+                'type' => $movement->movement_type?->value,
+                'type_label' => $movement->movement_type ? __($movement->movement_type->label()) : $movement->reason,
+                'quantity' => (int) $movement->quantity,
+                'quantity_after' => (int) $movement->quantity_after,
+                'created_at' => $movement->created_at?->toDateTimeString(),
+            ])
+            ->all();
+    }
+}

--- a/app/Reports/NegativeStockReport.php
+++ b/app/Reports/NegativeStockReport.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Reports;
+
+use App\Models\Storage;
+use App\Queries\Reports\NegativeStockQuery;
+use Illuminate\Http\Request;
+
+class NegativeStockReport implements Report
+{
+    public function __construct(private NegativeStockQuery $query) {}
+
+    public function page(): string
+    {
+        return 'Reports/NegativeStock';
+    }
+
+    public function props(Request $request): array
+    {
+        $storageId = $request->input('storage') ? (int) $request->input('storage') : null;
+
+        return [
+            'data' => $this->query->get($storageId),
+            'summary' => $this->query->summary($storageId),
+            'filters' => $request->only(['storage']),
+            'storages' => fn () => Storage::pluck('name', 'id'),
+        ];
+    }
+}

--- a/app/Reports/ReportRegistry.php
+++ b/app/Reports/ReportRegistry.php
@@ -16,6 +16,7 @@ class ReportRegistry
         'purchases' => PurchaseReport::class,
         'pos-sessions' => PosSessionReport::class,
         'inventory-valuation' => InventoryValuationReport::class,
+        'negative-stock' => NegativeStockReport::class,
         'customer-aging' => CustomerAgingReport::class,
         'supplier-aging' => SupplierAgingReport::class,
         'treasury-reconciliation' => TreasuryReconciliationReport::class,

--- a/app/Services/Utils/ExportRegistry.php
+++ b/app/Services/Utils/ExportRegistry.php
@@ -8,6 +8,7 @@ use App\Exports\ProductExport;
 use App\Exports\Reports\CustomerAgingExport;
 use App\Exports\Reports\ExpenseSummaryExport;
 use App\Exports\Reports\InventoryValuationExport;
+use App\Exports\Reports\NegativeStockExport;
 use App\Exports\Reports\PosSessionExport;
 use App\Exports\Reports\ProfitAndLossExport;
 use App\Exports\Reports\PurchaseReportExport;
@@ -30,6 +31,7 @@ class ExportRegistry
             'report-purchases' => PurchaseReportExport::class,
             'report-pos-sessions' => PosSessionExport::class,
             'report-inventory-valuation' => InventoryValuationExport::class,
+            'report-negative-stock' => NegativeStockExport::class,
             'report-customer-aging' => CustomerAgingExport::class,
             'report-supplier-aging' => SupplierAgingExport::class,
             'report-treasury' => TreasuryReconciliationExport::class,

--- a/resources/js/Pages/Reports/Index.vue
+++ b/resources/js/Pages/Reports/Index.vue
@@ -34,6 +34,12 @@ const reports = [
         icon: 'M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z',
     },
     {
+        name: 'Negative Stock',
+        description: 'Products below zero, how long, and the movements that drove them there.',
+        route: 'reports.negative-stock',
+        icon: 'M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z',
+    },
+    {
         name: 'Expense Summary',
         description: 'Expenses by category with budget comparison.',
         route: 'reports.expenses',

--- a/resources/js/Pages/Reports/NegativeStock.vue
+++ b/resources/js/Pages/Reports/NegativeStock.vue
@@ -1,0 +1,152 @@
+<script setup>
+import AppLayout from "@/Layouts/AppLayout.vue";
+import { Link, router } from "@inertiajs/vue3";
+import { ref, watch } from "vue";
+
+const props = defineProps(['data', 'summary', 'filters', 'storages']);
+
+const localFilters = ref({
+    storage: props.filters?.storage || '',
+});
+
+const expanded = ref(null);
+const toggle = (key) => {
+    expanded.value = expanded.value === key ? null : key;
+};
+
+let debounceTimer;
+watch(localFilters, (val) => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+        const params = Object.fromEntries(Object.entries(val).filter(([, v]) => v !== '' && v != null));
+        router.get(route('reports.negative-stock'), params, { preserveState: true, preserveScroll: true });
+    }, 400);
+}, { deep: true });
+
+function requestExport() {
+    router.post(route('exports.store'), {
+        export_key: 'report-negative-stock',
+        format: 'xlsx',
+        filters: { ...localFilters.value },
+    }, { preserveState: true, preserveScroll: true });
+}
+</script>
+
+<template>
+    <AppLayout :title="__('Negative Stock')">
+        <div class="space-y-6">
+            <!-- Header -->
+            <div class="w-full lg:flex lg:items-center lg:justify-between">
+                <div>
+                    <div class="flex items-center gap-x-3">
+                        <Link :href="route('reports.index')" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
+                            <svg class="h-5 w-5 rtl:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                            </svg>
+                        </Link>
+                        <h2 class="text-xl font-semibold text-gray-800 dark:text-white">{{ __('Negative Stock') }}</h2>
+                    </div>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __('Products currently below zero, and the movements that drove them there.') }}</p>
+                </div>
+                <div class="mt-4 flex items-center gap-x-4 lg:mt-0">
+                    <button
+                        @click="requestExport"
+                        :disabled="!data?.length"
+                        class="inline-flex items-center justify-center px-4 py-2 text-sm font-normal text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-200"
+                    >
+                        <svg class="h-4 w-4 ltr:mr-2 rtl:ml-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                        </svg>
+                        {{ __('Export') }}
+                    </button>
+                </div>
+            </div>
+
+            <!-- Summary Cards -->
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-5">
+                <div class="px-4 py-5 bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 sm:p-6">
+                    <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{{ __('Negative Products') }}</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1">{{ summary?.product_count ?? 0 }}</p>
+                </div>
+                <div class="px-4 py-5 bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 sm:p-6">
+                    <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{{ __('Negative Lines') }}</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white mt-1">{{ summary?.line_count ?? 0 }}</p>
+                </div>
+                <div class="px-4 py-5 bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 sm:p-6">
+                    <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-widest">{{ __('Units Short') }}</p>
+                    <p class="text-2xl font-bold text-red-600 dark:text-red-400 mt-1">{{ summary?.units_short ?? 0 }}</p>
+                </div>
+            </div>
+
+            <!-- Filters + Table -->
+            <div class="flex flex-col lg:flex-row gap-6">
+                <aside class="w-full lg:w-72 shrink-0">
+                    <div class="sticky top-4 space-y-4">
+                        <div class="p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl space-y-6">
+                            <div v-if="storages">
+                                <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">{{ __('Storage') }}</p>
+                                <select v-model="localFilters.storage"
+                                    class="w-full px-3 py-2 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50">
+                                    <option value="">{{ __('All') }}</option>
+                                    <option v-for="(name, id) in storages" :key="id" :value="id">{{ name }}</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </aside>
+
+                <div class="flex-1 min-w-0">
+                    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead class="bg-gray-50/50 dark:bg-gray-800/40">
+                                    <tr>
+                                        <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Product') }}</th>
+                                        <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Storage') }}</th>
+                                        <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Quantity') }}</th>
+                                        <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Negative Since') }}</th>
+                                        <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __('Days') }}</th>
+                                        <th class="px-6 py-4"></th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60">
+                                    <template v-for="row in data" :key="row.product_id + '-' + row.storage_id">
+                                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200 cursor-pointer" @click="toggle(row.product_id + '-' + row.storage_id)">
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ row.product_name }}</td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ row.storage_name }}</td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold text-red-600 dark:text-red-400">{{ row.quantity }}</td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ row.negative_since ?? '—' }}</td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ row.days_negative ?? '—' }}</td>
+                                            <td class="px-6 py-4 text-end">
+                                                <svg class="h-4 w-4 inline text-gray-400 transition-transform" :class="{ 'rotate-180': expanded === row.product_id + '-' + row.storage_id }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                                                </svg>
+                                            </td>
+                                        </tr>
+                                        <tr v-if="expanded === row.product_id + '-' + row.storage_id">
+                                            <td colspan="6" class="px-6 py-4 bg-gray-50/60 dark:bg-gray-800/40">
+                                                <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">{{ __('Driving Movements') }}</p>
+                                                <div class="space-y-1">
+                                                    <div v-for="(m, i) in row.movements" :key="i" class="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300">
+                                                        <span>{{ m.type_label }}</span>
+                                                        <span :class="m.quantity < 0 ? 'text-red-600 dark:text-red-400' : 'text-emerald-600 dark:text-emerald-400'">{{ m.quantity > 0 ? '+' : '' }}{{ m.quantity }}</span>
+                                                        <span class="text-gray-400 dark:text-gray-500">{{ __('balance') }}: {{ m.quantity_after }}</span>
+                                                        <span class="text-xs text-gray-400 dark:text-gray-500">{{ m.created_at }}</span>
+                                                    </div>
+                                                    <p v-if="!row.movements?.length" class="text-sm text-gray-400 dark:text-gray-500">{{ __('No movements recorded.') }}</p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </template>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div v-if="!data?.length" class="py-12 text-center text-sm text-gray-400 dark:text-gray-500">
+                            {{ __('No products are below zero. ') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -378,6 +378,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
                 'purchases' => 'reports.purchases',
                 'pos-sessions' => 'reports.pos-sessions',
                 'inventory-valuation' => 'reports.inventory-valuation',
+                'negative-stock' => 'reports.negative-stock',
                 'customer-aging' => 'reports.customer-aging',
                 'supplier-aging' => 'reports.supplier-aging',
                 'treasury-reconciliation' => 'reports.treasury',

--- a/tests/Feature/Inventory/NegativeStockReportTest.php
+++ b/tests/Feature/Inventory/NegativeStockReportTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Preference;
+use App\Models\Product;
+use App\Models\Storage;
+use App\Queries\Reports\NegativeStockQuery;
+
+function makeNegative(): array
+{
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '1']);
+
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create(['name' => 'Widget']);
+    $storage->addStock($product, 2, 'purchase_receipt');
+    $storage->deductStock($product, 6, 'sale_delivery'); // balance -4
+
+    return [$storage, $product];
+}
+
+test('the query surfaces only products below zero with driving movements', function () {
+    [$storage, $product] = makeNegative();
+
+    // A healthy product must not appear.
+    $healthy = Product::factory()->create();
+    $storage->addStock($healthy, 10, 'purchase_receipt');
+
+    $rows = (new NegativeStockQuery)->get();
+
+    expect($rows)->toHaveCount(1);
+    expect($rows[0]['product_name'])->toBe('Widget');
+    expect($rows[0]['quantity'])->toBe(-4);
+    expect($rows[0]['days_negative'])->toBe(0);
+    expect(collect($rows[0]['movements'])->pluck('quantity'))->toContain(-6);
+
+    $summary = (new NegativeStockQuery)->summary();
+    expect($summary['product_count'])->toBe(1);
+    expect($summary['units_short'])->toBe(4);
+});
+
+test('the negative stock report page renders for an authorised user', function () {
+    makeNegative();
+
+    actingAsTenantUser(role: 'owner')
+        ->get(route('reports.negative-stock'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Reports/NegativeStock')
+            ->has('data', 1)
+            ->where('data.0.quantity', -4)
+            ->where('summary.units_short', 4)
+        );
+});


### PR DESCRIPTION
**Stacked on** #62 (M6). PRD: `docs/inventory-ledger/M7-negative-stock-report.md`.

## What

A report of products currently **below zero**, so someone can reconcile each case (missed purchase entry, shrinkage/theft, or counting error) with the right movement.

- **`NegativeStockQuery`** — `stocks.quantity < 0`, tenant-scoped; per row: how long negative (the last movement that crossed from non-negative to negative), days negative, and the driving movements since that crossing. **Intentionally includes negatives** (unlike `InventoryValuationQuery`, which filters `> 0`).
- **`NegativeStockReport`** + registry slug + route `reports.negative-stock`; **`NegativeStockExport`** + export-registry key; card on the Reports index.
- **`Reports/NegativeStock.vue`** — summary tiles, storage filter, expandable driving-movements drill-down, xlsx export (localized, RTL/dark, mirrors the Inventory Valuation page).

## Tests

- Query lists only negatives, with `days_negative` + driving movements, and correct summary (`product_count`, `units_short`).
- Report page renders for an authorised (owner) user with the expected Inertia props.
- Existing Reports/Exports suites green (246 assertions).

## Acceptance criteria (from PRD)

- [x] Shows only negative balances with age + drill-down; negatives included here though excluded from valuation.