### PR TITLE
feat(inventory): M8 — provisional costing + back-fill

### DIFF
--- a/app/Actions/Pos/ProcessPosCheckoutAction.php
+++ b/app/Actions/Pos/ProcessPosCheckoutAction.php
@@ -127,6 +127,7 @@ class ProcessPosCheckoutAction
                     'base_quantity' => $quantity,
                     'price' => $item['price'],
                     'unit_cost' => $averageCosts[$item['product_id']]->average_cost ?? 0,
+                    'cost_provisional' => ($averageCosts[$item['product_id']]->average_cost ?? 0) <= 0,
                     'delivered' => false,
                 ]);
 

--- a/app/Actions/Purchase/ReceiveGoodsAction.php
+++ b/app/Actions/Purchase/ReceiveGoodsAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Purchase;
 
+use App\Jobs\BackfillProvisionalCostsJob;
 use App\Models\Storage;
 use App\Models\Transaction;
 use App\Models\TransactionReceipt;
@@ -41,6 +42,7 @@ class ReceiveGoodsAction
             );
 
             $transaction->product->recalculateAverageCost();
+            BackfillProvisionalCostsJob::dispatch($transaction->tenant_id, $transaction->product_id);
 
             if ($transaction->isFullyReceived()) {
                 $transaction->deliver($actor, $storage);

--- a/app/Actions/StoreInvoiceAction.php
+++ b/app/Actions/StoreInvoiceAction.php
@@ -68,6 +68,9 @@ class StoreInvoiceAction
                 'unit_cost' => $isSale
                     ? ($averageCosts[$product['product']]->average_cost ?? 0)
                     : null,
+                'cost_provisional' => $isSale
+                    ? (($averageCosts[$product['product']]->average_cost ?? 0) <= 0)
+                    : false,
                 'base_quantity' => isset($units[$product['unit'] ?? null])
                     ? $units[$product['unit']]->conversion_factor * $product['quantity']
                     : $product['quantity'],

--- a/app/Actions/UpdateInvoiceAction.php
+++ b/app/Actions/UpdateInvoiceAction.php
@@ -64,6 +64,9 @@ class UpdateInvoiceAction
             'unit_cost' => $isSale
                 ? ($averageCosts[$product['product']]->average_cost ?? 0)
                 : null,
+            'cost_provisional' => $isSale
+                ? (($averageCosts[$product['product']]->average_cost ?? 0) <= 0)
+                : false,
             'base_quantity' => isset($units[$product['unit'] ?? null])
                 ? $units[$product['unit']]->conversion_factor * $product['quantity']
                 : $product['quantity'],

--- a/app/Jobs/BackfillProvisionalCostsJob.php
+++ b/app/Jobs/BackfillProvisionalCostsJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * When a purchase establishes a real cost for a product, restate the cost of any
+ * sale lines that were booked provisionally (no cost basis) and clear the flag.
+ * Runs outside a tenant request, so it scopes by explicit tenant_id. Idempotent:
+ * once a line is cleared it is no longer selected.
+ */
+class BackfillProvisionalCostsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public int $tenantId, public int $productId) {}
+
+    public function handle(): void
+    {
+        $averageCost = DB::table('products')
+            ->where('id', $this->productId)
+            ->value('average_cost');
+
+        if ($averageCost === null || (int) $averageCost <= 0) {
+            return;
+        }
+
+        DB::table('transactions')
+            ->where('tenant_id', $this->tenantId)
+            ->where('product_id', $this->productId)
+            ->where('cost_provisional', true)
+            ->whereNull('deleted_at')
+            ->update([
+                'unit_cost' => (int) $averageCost,
+                'cost_provisional' => false,
+                'updated_at' => now(),
+            ]);
+    }
+}

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\MoneyCast;
+use App\Jobs\BackfillProvisionalCostsJob;
 use App\Traits\WithTrashScope;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -39,6 +40,7 @@ class Transaction extends BaseModel
     {
         return [
             'delivered' => 'boolean',
+            'cost_provisional' => 'boolean',
             'created_at' => 'datetime',
             'delivered_at' => 'datetime',
             'price' => MoneyCast::class,
@@ -179,6 +181,7 @@ class Transaction extends BaseModel
 
         if ($this->getTypeAttribute() === 'Purchases') {
             $this->product->recalculateAverageCost();
+            BackfillProvisionalCostsJob::dispatch($this->tenant_id, $this->product_id);
         }
 
         return $this;

--- a/app/Queries/Reports/ProfitAndLossQuery.php
+++ b/app/Queries/Reports/ProfitAndLossQuery.php
@@ -103,6 +103,12 @@ class ProfitAndLossQuery extends ReportQuery
         $grossProfit = $revenue - $cogs;
         $netProfit = $grossProfit - $expenses;
 
+        $hasProvisionalCosts = Transaction::delivered()
+            ->forCustomer()
+            ->whereBetween('transactions.created_at', [$from, $to])
+            ->where('transactions.cost_provisional', true)
+            ->exists();
+
         return [
             'revenue' => round($revenue, 2),
             'cogs' => round($cogs, 2),
@@ -111,6 +117,7 @@ class ProfitAndLossQuery extends ReportQuery
             'expenses' => round($expenses, 2),
             'net_profit' => round($netProfit, 2),
             'net_margin' => $revenue > 0 ? round(($netProfit / $revenue) * 100, 1) : 0,
+            'has_provisional_costs' => $hasProvisionalCosts,
         ];
     }
 }

--- a/database/migrations/2026_07_13_101000_add_cost_provisional_to_transactions_table.php
+++ b/database/migrations/2026_07_13_101000_add_cost_provisional_to_transactions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Flags a sale line whose cost was booked without a real cost basis (the
+ * product had no known average cost at sale time). A later purchase back-fills
+ * the real cost and clears the flag; profit reports are eventually consistent.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->boolean('cost_provisional')->default(false)->after('unit_cost');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $table->dropColumn('cost_provisional');
+        });
+    }
+};

--- a/resources/js/Pages/Reports/ProfitAndLoss.vue
+++ b/resources/js/Pages/Reports/ProfitAndLoss.vue
@@ -68,6 +68,17 @@ function requestExport() {
                 </div>
             </div>
 
+            <!-- Provisional-cost notice: figures may be restated when late purchases land -->
+            <div
+                v-if="summary?.has_provisional_costs"
+                class="flex items-start gap-x-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-400"
+            >
+                <svg class="h-5 w-5 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+                </svg>
+                <p class="text-sm">{{ __('Some figures include provisional costs and may be restated when the related purchases are recorded.') }}</p>
+            </div>
+
             <!-- Summary Cards -->
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-5">
                 <div class="px-4 py-5 bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 sm:p-6">

--- a/tests/Feature/Inventory/ProvisionalCostingTest.php
+++ b/tests/Feature/Inventory/ProvisionalCostingTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Actions\Purchase\ReceiveGoodsAction;
+use App\Jobs\BackfillProvisionalCostsJob;
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Product;
+use App\Models\Storage;
+use App\Models\Supplier;
+use App\Models\Transaction;
+use App\Models\Unit;
+use App\Models\User;
+use App\Queries\Reports\ProfitAndLossQuery;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+
+test('a sale of a product with no cost basis is flagged provisional', function () {
+    $customer = Customer::factory()->create();
+    $product = Product::factory()->create(['cost' => 0, 'average_cost' => 0]);
+    $unit = Unit::factory()->create(['product_id' => $product->id]);
+    $storage = Storage::factory()->create();
+
+    $this->actingAs(User::factory()->create())->post(route('sales.store'), [
+        'total' => 1000,
+        'invocable' => ['id' => $customer->id, 'name' => $customer->name, 'type' => Customer::class],
+        'products' => [[
+            'product' => $product->id, 'quantity' => 2, 'unit' => $unit->id, 'price' => 500, 'storage' => $storage->id,
+        ]],
+        'payment_method' => 'cash',
+    ])->assertRedirect(route('sales.index'));
+
+    expect(Transaction::where('product_id', $product->id)->first()->cost_provisional)->toBeTrue();
+});
+
+test('a sale of a product with a known cost is not provisional', function () {
+    $customer = Customer::factory()->create();
+    $product = Product::factory()->create(); // factory sets average_cost = cost > 0
+    $unit = Unit::factory()->create(['product_id' => $product->id]);
+    $storage = Storage::factory()->create();
+
+    $this->actingAs(User::factory()->create())->post(route('sales.store'), [
+        'total' => 1000,
+        'invocable' => ['id' => $customer->id, 'name' => $customer->name, 'type' => Customer::class],
+        'products' => [[
+            'product' => $product->id, 'quantity' => 2, 'unit' => $unit->id, 'price' => 500, 'storage' => $storage->id,
+        ]],
+        'payment_method' => 'cash',
+    ])->assertRedirect(route('sales.index'));
+
+    expect(Transaction::where('product_id', $product->id)->first()->cost_provisional)->toBeFalse();
+});
+
+test('the back-fill job restates provisional lines and clears the flag idempotently', function () {
+    $tenant = app('currentTenant');
+    $product = Product::factory()->create(['cost' => 0, 'average_cost' => 0]);
+    $customer = Customer::factory()->create();
+    $invoice = Invoice::factory()->create(['invocable_id' => $customer->id, 'invocable_type' => Customer::class]);
+    $transaction = Transaction::factory()->create([
+        'invoice_id' => $invoice->id,
+        'product_id' => $product->id,
+        'base_quantity' => 5,
+        'quantity' => 5,
+        'unit_cost' => 0,
+        'cost_provisional' => true,
+        'delivered' => true,
+    ]);
+
+    // A purchase later establishes the real cost (minor units).
+    DB::table('products')->where('id', $product->id)->update(['average_cost' => 700]);
+
+    (new BackfillProvisionalCostsJob($tenant->id, $product->id))->handle();
+
+    $transaction->refresh();
+    expect($transaction->cost_provisional)->toBeFalse();
+    expect($transaction->getRawOriginal('unit_cost'))->toBe(700);
+
+    // Idempotent: nothing left to restate.
+    (new BackfillProvisionalCostsJob($tenant->id, $product->id))->handle();
+    expect(Transaction::where('cost_provisional', true)->count())->toBe(0);
+});
+
+test('receiving a purchase dispatches the provisional back-fill', function () {
+    Queue::fake();
+    $supplier = Supplier::factory()->create();
+    $invoice = Invoice::factory()->create(['invocable_id' => $supplier->id, 'invocable_type' => Supplier::class]);
+    $product = Product::factory()->create();
+    $storage = Storage::factory()->create();
+    $transaction = Transaction::factory()->create([
+        'invoice_id' => $invoice->id, 'product_id' => $product->id, 'base_quantity' => 5, 'quantity' => 5, 'delivered' => false,
+    ]);
+
+    app(ReceiveGoodsAction::class)->handle($transaction, $storage, 5, User::factory()->create());
+
+    Queue::assertPushed(BackfillProvisionalCostsJob::class);
+});
+
+test('profit and loss flags periods that include provisional costs', function () {
+    $customer = Customer::factory()->create();
+    $invoice = Invoice::factory()->create(['invocable_id' => $customer->id, 'invocable_type' => Customer::class]);
+    Transaction::factory()->create([
+        'invoice_id' => $invoice->id,
+        'delivered' => true,
+        'cost_provisional' => true,
+        'base_quantity' => 1,
+        'quantity' => 1,
+        'price' => 100,
+        'unit_cost' => 0,
+        'created_at' => now(),
+    ]);
+
+    $summary = (new ProfitAndLossQuery)->summary(now()->startOfMonth(), now()->endOfMonth());
+
+    expect($summary['has_provisional_costs'])->toBeTrue();
+});


### PR DESCRIPTION
**Stacked on** #63 (M7). PRD: `docs/inventory-ledger/M8-provisional-costing.md`. Pairs with M4 (overselling makes no-basis sales common).

## What

Margins become **eventually consistent** when sales precede purchases.

- **`transactions.cost_provisional`** flags a sale line booked with no cost basis (`average_cost <= 0`) at the three sale-creation sites: POS checkout, `StoreInvoiceAction`, `UpdateInvoiceAction`. Purchases are never flagged.
- **`BackfillProvisionalCostsJob`** restates `unit_cost` to the now-known average and clears the flag for a product's flagged sale lines. Dispatched after purchase cost recalculation (`Transaction::add`, `ReceiveGoodsAction`). **Idempotent** and tenant-scoped (runs off-request → explicit `tenant_id`).
- **`ProfitAndLossQuery`** exposes `has_provisional_costs`; the P&L page shows an amber notice that figures may be restated.

## Tests

- Flag set on a no-basis sale; **not** set on a known-cost sale.
- Back-fill restates `unit_cost` + clears the flag; idempotent on re-run.
- Receiving a purchase dispatches the job (`Queue::fake`).
- P&L summary flags periods containing provisional lines.
- Sales / P&L / purchase-receiving / POS suites green (415 assertions).

## Acceptance criteria (from PRD)

- [x] Zero-basis sale flagged; normal sale not.
- [x] Late purchase restates prior provisional COGS and clears the flag; idempotent.
- [x] P&L flags periods containing provisional lines.