### PR TITLE
feat(inventory): M9 — opening-balance backfill

### DIFF
--- a/app/Console/Commands/BackfillOpeningBalancesCommand.php
+++ b/app/Console/Commands/BackfillOpeningBalancesCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\MovementType;
+use App\Models\StockMovement;
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds an opening-balance movement per (tenant, product, storage) so the
+ * ledger reconstructs the current cache exactly:
+ *
+ *     opening = stocks.quantity - SUM(stock_movements.quantity)
+ *
+ * The delta absorbs both historical drift and seeder bypasses. Idempotent:
+ * once the ledger equals the cache, a re-run finds nothing to do. Run
+ * `stock:reconcile` (or this command's --dry-run) first as a pre-flight gate.
+ */
+class BackfillOpeningBalancesCommand extends Command
+{
+    protected $signature = 'stock:backfill-opening-balances {--dry-run : Report what would be created without writing} {--tenant= : Limit to a single tenant (id or slug)}';
+
+    protected $description = 'Insert opening-balance movements so the ledger reconstructs the current stock cache.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $previousTenant = app()->has('currentTenant') ? app('currentTenant') : null;
+        $created = 0;
+
+        try {
+            foreach ($this->tenants() as $tenant) {
+                app()->instance('currentTenant', $tenant);
+                $created += $this->backfillTenant($tenant, $dryRun);
+            }
+        } finally {
+            if ($previousTenant) {
+                app()->instance('currentTenant', $previousTenant);
+            } else {
+                app()->forgetInstance('currentTenant');
+            }
+        }
+
+        $verb = $dryRun ? 'would be created' : 'created';
+        $this->info("{$created} opening-balance movement(s) {$verb}.");
+
+        return self::SUCCESS;
+    }
+
+    private function tenants()
+    {
+        $filter = $this->option('tenant');
+
+        return Tenant::withoutGlobalScopes()
+            ->when($filter, fn ($query) => $query->where('id', $filter)->orWhere('slug', $filter))
+            ->get();
+    }
+
+    private function backfillTenant(Tenant $tenant, bool $dryRun): int
+    {
+        $cache = DB::table('stocks')
+            ->where('tenant_id', $tenant->id)
+            ->whereNull('deleted_at')
+            ->get(['product_id', 'storage_id', 'quantity'])
+            ->keyBy(fn ($row) => "{$row->product_id}:{$row->storage_id}");
+
+        $ledger = DB::table('stock_movements')
+            ->where('tenant_id', $tenant->id)
+            ->selectRaw('product_id, storage_id, SUM(quantity) as balance')
+            ->groupBy('product_id', 'storage_id')
+            ->get()
+            ->keyBy(fn ($row) => "{$row->product_id}:{$row->storage_id}");
+
+        $created = 0;
+
+        foreach ($cache->keys()->merge($ledger->keys())->unique() as $key) {
+            [$productId, $storageId] = array_map('intval', explode(':', $key));
+            $cacheQty = (int) ($cache[$key]->quantity ?? 0);
+            $ledgerQty = (int) ($ledger[$key]->balance ?? 0);
+            $opening = $cacheQty - $ledgerQty;
+
+            if ($opening === 0) {
+                continue;
+            }
+
+            $created++;
+
+            if ($dryRun) {
+                $this->line("[{$tenant->slug}] product {$productId} / storage {$storageId}: opening {$opening} (cache {$cacheQty}, ledger {$ledgerQty})");
+
+                continue;
+            }
+
+            StockMovement::create([
+                'tenant_id' => $tenant->id,
+                'storage_id' => $storageId,
+                'product_id' => $productId,
+                'user_id' => null,
+                'reason' => 'opening_balance',
+                'movement_type' => MovementType::OpeningBalance,
+                'quantity' => $opening,
+                'quantity_before' => $ledgerQty,
+                'quantity_after' => $cacheQty,
+            ]);
+        }
+
+        return $created;
+    }
+}

--- a/tests/Feature/Inventory/OpeningBalanceBackfillTest.php
+++ b/tests/Feature/Inventory/OpeningBalanceBackfillTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Enums\MovementType;
+use App\Models\Product;
+use App\Models\StockMovement;
+use App\Models\Storage;
+use App\Queries\StockBalanceQuery;
+use Illuminate\Support\Facades\DB;
+
+function seedBypassedStock(Storage $storage, Product $product, int $quantity): void
+{
+    DB::table('stocks')->insert([
+        'tenant_id' => $storage->tenant_id,
+        'storage_id' => $storage->id,
+        'product_id' => $product->id,
+        'quantity' => $quantity,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+test('backfill creates an opening-balance movement for a bypassed stocks row', function () {
+    $tenant = app('currentTenant');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    seedBypassedStock($storage, $product, 60);
+
+    $this->artisan('stock:backfill-opening-balances', ['--tenant' => $tenant->slug])->assertExitCode(0);
+
+    $movement = StockMovement::where('reason', 'opening_balance')->where('product_id', $product->id)->first();
+    expect($movement)->not->toBeNull();
+    expect($movement->quantity)->toBe(60);
+    expect($movement->quantity_before)->toBe(0);
+    expect($movement->quantity_after)->toBe(60);
+    expect($movement->movement_type)->toBe(MovementType::OpeningBalance);
+
+    // Ledger now reconstructs the cache exactly.
+    expect((new StockBalanceQuery)->forProductInStorage($product->id, $storage->id))->toBe(60);
+
+    // Idempotent: a second run inserts nothing.
+    $this->artisan('stock:backfill-opening-balances', ['--tenant' => $tenant->slug])->assertExitCode(0);
+    expect(StockMovement::where('reason', 'opening_balance')->count())->toBe(1);
+});
+
+test('backfill is a no-op when the ledger already matches the cache', function () {
+    $tenant = app('currentTenant');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $storage->addStock($product, 40, 'purchase_receipt');
+
+    $this->artisan('stock:backfill-opening-balances', ['--tenant' => $tenant->slug])->assertExitCode(0);
+
+    expect(StockMovement::where('reason', 'opening_balance')->count())->toBe(0);
+});
+
+test('dry-run reports the gap without writing a movement', function () {
+    $tenant = app('currentTenant');
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create();
+    seedBypassedStock($storage, $product, 60);
+
+    $this->artisan('stock:backfill-opening-balances', ['--dry-run' => true, '--tenant' => $tenant->slug])->assertExitCode(0);
+
+    expect(StockMovement::where('reason', 'opening_balance')->count())->toBe(0);
+});


### PR DESCRIPTION
**Stacked on** #64 (M8). PRD: `docs/inventory-ledger/M9-opening-balance-migration.md`. (T9.2 seeder-bypass fix follows as its own PR.)

## What

`stock:backfill-opening-balances` seeds an opening-balance movement per `(tenant, product, storage)` so the ledger reconstructs the current cache exactly:

```
opening = stocks.quantity − SUM(stock_movements.quantity)
```

The delta absorbs **both** historical drift **and** non-production seeder bypasses, so the ledger becomes self-consistent regardless of movement completeness. Movement type `OpeningBalance` (from M1), `movable` null.

- **Idempotent** — once `ledger == cache`, a re-run inserts nothing.
- **Tenant-scoped**, runs off-request (`--tenant=` filter).
- **`--dry-run`** reports the gaps without writing — the pre-flight gate (T9.3), alongside `stock:reconcile` (M2).

## Tests

- A bypassed `stocks` row gets an `OpeningBalance` movement making `SUM(movements) == stocks.quantity`; re-run is idempotent.
- No-op when the ledger already matches.
- `--dry-run` writes nothing.

## Acceptance criteria (from PRD)

- [x] Post-run `SUM(movements) == stocks.quantity` for every row incl. seeded/drifted; re-run inserts nothing.
- [x] Drift report available before backfill (`--dry-run` / `stock:reconcile`).

## Follow-up

- **T9.2** (separate PR): route seeder/factory bypasses through `Storage::addStock` so fresh seeds also satisfy the invariant.