### PR TITLE
fix(inventory): M9.T9.2 — route seeder stock through the ledger

### DIFF
--- a/database/seeders/DashboardExampleSeeder.php
+++ b/database/seeders/DashboardExampleSeeder.php
@@ -55,9 +55,10 @@ class DashboardExampleSeeder extends Seeder
             ['cost' => 125, 'expire_date' => now()->addYear()],
         );
 
-        $product->stock()->syncWithoutDetaching([
-            $storage->id => ['quantity' => 60],
-        ]);
+        // setStockTo keeps the seed idempotent while recording a ledger movement.
+        if ($storage->quantityOf($product) !== 60) {
+            $storage->setStockTo($product, 60, 'opening_balance');
+        }
 
         $customer = Customer::firstOrCreate(
             ['name' => 'Demo Customer', 'tenant_id' => $tenant->id],

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -54,11 +54,9 @@ class DatabaseSeeder extends Seeder
         });
 
         $products->each(function ($product) use ($storages) {
-            // Attach stock to storages
-            $product->stock()->attach(
-                $storages->random()->id,
-                ['quantity' => fake()->numberBetween(10, 1000)]
-            );
+            // Route through addStock so the movement ledger stays consistent
+            // with the cache (SUM(movements) == stocks.quantity).
+            $storages->random()->addStock($product, fake()->numberBetween(10, 1000), 'opening_balance');
         });
 
         // 4. Customers & Sales

--- a/tests/Feature/Inventory/SeederLedgerConsistencyTest.php
+++ b/tests/Feature/Inventory/SeederLedgerConsistencyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\StockMovement;
+use App\Models\Tenant;
+use Database\Seeders\DashboardExampleSeeder;
+use Illuminate\Support\Facades\DB;
+
+test('the demo seeder leaves the ledger consistent with the stocks cache', function () {
+    $this->seed(DashboardExampleSeeder::class);
+
+    $tenant = Tenant::withoutGlobalScopes()->where('slug', 'demo')->firstOrFail();
+
+    $cache = DB::table('stocks')->where('tenant_id', $tenant->id)->whereNull('deleted_at')
+        ->get(['product_id', 'storage_id', 'quantity'])
+        ->keyBy(fn ($r) => "{$r->product_id}:{$r->storage_id}");
+
+    $ledger = StockMovement::withoutGlobalScopes()->where('tenant_id', $tenant->id)
+        ->selectRaw('product_id, storage_id, SUM(quantity) as balance')
+        ->groupBy('product_id', 'storage_id')
+        ->get()
+        ->keyBy(fn ($r) => "{$r->product_id}:{$r->storage_id}");
+
+    expect($cache)->not->toBeEmpty();
+
+    foreach ($cache as $key => $row) {
+        expect((int) ($ledger[$key]->balance ?? 0))->toBe((int) $row->quantity);
+    }
+});


### PR DESCRIPTION
**Stacked on** #65 (M9). PRD: `docs/inventory-ledger/M9-opening-balance-migration.md` (T9.2 — the separate hygiene PR).

## What

The dev (`DatabaseSeeder`) and demo (`DashboardExampleSeeder`) seeders wrote `stocks.quantity` directly (`attach` / `syncWithoutDetaching`), bypassing the movement ledger and leaving `SUM(movements) != stocks.quantity` for seeded tenants. This routes them through `Storage::addStock` / `setStockTo` so fresh seeds satisfy the reconciliation invariant without needing the opening-balance backfill.

- `DatabaseSeeder` → `addStock(..., 'opening_balance')`.
- `DashboardExampleSeeder` → `setStockTo(..., 'opening_balance')`, guarded to stay idempotent.
- `StockFactory` left as-is — it sets no `quantity` (defaults to 0), so it is already consistent (`0 == 0`).

## Tests

- The demo seeder leaves `SUM(movements) == stocks.quantity` for every `(product, storage)`.

## Acceptance criteria (from PRD)

- [x] Seeding leaves `SUM(movements) == stocks.quantity`.