### PR TITLE
feat(inventory): M10 — cutover, ledger as source of truth (cache retained)

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\MoneyCast;
+use App\Queries\StockBalanceQuery;
 use App\Traits\WithTrashScope;
 use App\ValueObjects\Money;
 use Carbon\Carbon;
@@ -257,11 +258,26 @@ class Product extends BaseModel
     }
 
     /**
-     * Quantity on hand for this product
+     * Quantity on hand for this product, read from the `stocks` cache.
+     *
+     * Post-cutover the append-only `stock_movements` ledger is the source of
+     * truth; `stocks.quantity` is its incrementally-maintained, row-locked cache
+     * kept equal to SUM(movements) on every write. This is the O(1) hot-path
+     * read — use `ledgerBalance()` to read authoritatively from the ledger.
      */
     public function quantityOnHand(): int
     {
         return $this->stock->sum('pivot.quantity');
+    }
+
+    /**
+     * Authoritative on-hand derived from the movement ledger. Equal to
+     * quantityOnHand() whenever the cache is reconciled; prefer the cache for
+     * hot reads and reserve this for verification/reconciliation.
+     */
+    public function ledgerBalance(): int
+    {
+        return (new StockBalanceQuery)->forProduct($this->id);
     }
 
     /**

--- a/app/Queries/Reports/InventoryValuationQuery.php
+++ b/app/Queries/Reports/InventoryValuationQuery.php
@@ -36,7 +36,10 @@ class InventoryValuationQuery extends ReportQuery
             ->join('storages', 'stocks.storage_id', '=', 'storages.id')
             ->where('products.tenant_id', $tenantId)
             ->whereNull('stocks.deleted_at')
-            ->where('stocks.quantity', '>', 0)
+            // Include negative (oversold) balances so they are not silently
+            // dropped from valuation; they contribute negative value. Only true
+            // zeros (nothing on hand) are excluded.
+            ->where('stocks.quantity', '!=', 0)
             ->select(
                 'products.id as product_id',
                 'products.name as product_name',

--- a/docs/inventory-ledger/README.md
+++ b/docs/inventory-ledger/README.md
@@ -2,6 +2,8 @@
 
 Product requirements for migrating NamaIn's inventory from a mutable `stocks.quantity` source of truth to an **append-only, signed stock-movement ledger** with a **per-tenant inventory strategy** (`purchase_driven` vs `free_form` + nested `allow_overselling`).
 
+> **Cutover status (M10):** the append-only `stock_movements` ledger is the **source of truth** for stock. `stocks.quantity` is retained as its incrementally-maintained, row-locked **cache** (equal to `SUM(movements)` on every write) and remains the O(1) hot-path read — nothing was destructively dropped. Use `Product::ledgerBalance()` / `StockBalanceQuery` for authoritative reads and reconciliation; `stock:reconcile` runs daily as a drift guardrail. Valuation and stock views now include negative (oversold) balances.
+
 See the audit & verdict that motivate this work in the approved plan (Phase 1 findings + Phase 2 verdict). **Headline:** the ledger (`stock_movements`) already exists, is written through a single choke point (`Storage::addStock/deductStock/setStockTo`), is signed + polymorphic + append-only in practice, and is currently latent (no readers). `stocks.quantity` already behaves as an incrementally-updated, row-locked cached balance. The one unavoidable structural change is that `stocks.quantity` is **unsigned** today, so negatives are impossible. We therefore **extend, not replace**, and migrate incrementally (parallel-run), defaulting every existing tenant to `purchase_driven`.
 
 ## Milestones

--- a/routes/console.php
+++ b/routes/console.php
@@ -34,6 +34,9 @@ Schedule::call(fn () => DB::table('notifications')->where('created_at', '<', now
     ->daily()
     ->name('notifications:prune');
 Schedule::command('expenses:generate-recurring')->daily();
+// Post-cutover guardrail: surface any drift between the stocks cache and the
+// stock-movement ledger (source of truth). Read-only.
+Schedule::command('stock:reconcile')->daily();
 Schedule::command('exports:prune')->daily();
 Schedule::command('telescope:prune --hours=48')->daily();
 Schedule::command('horizon:snapshot')->everyFiveMinutes();

--- a/tests/Feature/Inventory/LedgerCutoverTest.php
+++ b/tests/Feature/Inventory/LedgerCutoverTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Actions\Stock\TransferStockAction;
+use App\Models\Preference;
+use App\Models\Product;
+use App\Models\StockTransfer;
+use App\Models\StockTransferLine;
+use App\Models\Storage;
+use App\Models\User;
+use App\Queries\Reports\InventoryValuationQuery;
+use App\Queries\StockBalanceQuery;
+
+test('the stocks cache equals the ledger through the full lifecycle including overselling', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '1']);
+
+    $a = Storage::factory()->create();
+    $b = Storage::factory()->create();
+    $product = Product::factory()->create();
+    $user = User::factory()->create();
+
+    $a->addStock($product, 50, 'purchase_receipt', actor: $user);
+    $a->deductStock($product, 20, 'sale_delivery', actor: $user);
+    $a->setStockTo($product, 40, 'adjustment', actor: $user);
+
+    $transfer = StockTransfer::factory()->create([
+        'from_storage_id' => $a->id, 'to_storage_id' => $b->id, 'created_by' => $user->id,
+    ]);
+    StockTransferLine::factory()->create([
+        'stock_transfer_id' => $transfer->id, 'product_id' => $product->id, 'quantity' => 10,
+    ]);
+    app(TransferStockAction::class)->handle($transfer, $user);
+
+    $b->deductStock($product, 25, 'sale_delivery', actor: $user); // b: 10 -> -15 (oversell)
+    $a->addStock($product, 5, 'sales_return', actor: $user);
+
+    $balance = new StockBalanceQuery;
+    foreach ([$a, $b] as $storage) {
+        expect($balance->forProductInStorage($product->id, $storage->id))->toBe($storage->quantityOf($product));
+    }
+
+    expect($product->ledgerBalance())->toBe($a->quantityOf($product) + $b->quantityOf($product));
+    expect($b->quantityOf($product))->toBe(-15);
+});
+
+test('inventory valuation includes negative (oversold) balances', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '1']);
+
+    $storage = Storage::factory()->create();
+    $product = Product::factory()->create(['name' => 'Oversold', 'average_cost' => 1000]);
+    $storage->deductStock($product, 4, 'sale_delivery'); // -4
+
+    $row = collect((new InventoryValuationQuery)->get())->firstWhere('product_name', 'Oversold');
+
+    expect($row)->not->toBeNull();
+    expect($row['quantity'])->toBe(-4);
+    expect($row['total_value'])->toBeLessThan(0);
+});


### PR DESCRIPTION
**Stacked on** #66 (M9 seeder-fix). PRD: `docs/inventory-ledger/M10-cutover.md`. Final milestone.

## What

Completes the migration. The append-only `stock_movements` ledger is now the **source of truth**; `stocks.quantity` is retained as its incrementally-maintained, row-locked **cache** and remains the O(1) hot-path read. **Nothing is destructively dropped** — per the PRD, the cache stays because it already equals `SUM(movements)` on every write (guaranteed by M1/M2/M9 + the seeder fix), so summing the ledger on hot reads would only regress performance.

- **T10.2 — negatives no longer dropped:** `InventoryValuationQuery` includes negative (oversold) balances (`!= 0` instead of `> 0`); they contribute negative value. `DashboardStatsQuery` already summed all rows.
- **T10.1 — canonical accessor:** `Product::ledgerBalance()` (→ `StockBalanceQuery`) is the authoritative read; `quantityOnHand()` is documented as the cache. The ~15 read surfaces keep using the cache, which is now formally a materialized view of the ledger.
- **T10.3 — guardrail + docs:** `stock:reconcile` scheduled daily to surface any drift; ledger README records the cutover.

## Tests

- **Invariant:** `stocks.quantity == SUM(movements)` per `(product, storage)` through purchase → sale → adjustment → transfer → oversell-into-negative → return; `ledgerBalance()` matches the summed cache.
- Inventory valuation includes negative balances.
- Reports / exports / dashboard / storage suites green (345 assertions).

## Acceptance criteria (from PRD)

- [x] Each report matches the ledger; POS balance reads stay O(1) (cache retained).
- [x] Negative balances visible where expected; valuation rule documented + tested.
- [x] Invariant green across the suite; no schema drop.

---

🏁 This completes the inventory-ledger stack (docs → M1 → … → M10).