### PR TITLE
test: fix suite failures under isolated/parallel runs

### DIFF
--- a/tests/Feature/PosSessionTest.php
+++ b/tests/Feature/PosSessionTest.php
@@ -32,15 +32,6 @@ beforeEach(function () {
     $this->storage = Storage::factory()->create(['tenant_id' => $this->tenant->id]);
 });
 
-function createSalePoint(string $name): Storage
-{
-    return Storage::factory()->create([
-        'tenant_id' => app('currentTenant')->id,
-        'type' => StorageType::SALE_POINT,
-        'name' => $name,
-    ]);
-}
-
 function recordDeliveredSale(Storage $storage, Product $product, int $quantity): void
 {
     $invoice = Invoice::factory()->create();

--- a/tests/Feature/StockMovementLedgerHardeningTest.php
+++ b/tests/Feature/StockMovementLedgerHardeningTest.php
@@ -3,6 +3,7 @@
 use App\Actions\Stock\RecordAdjustmentAction;
 use App\Enums\MovementType;
 use App\Exceptions\StockMovementIsImmutableException;
+use App\Models\Preference;
 use App\Models\Product;
 use App\Models\StockMovement;
 use App\Models\Storage;
@@ -38,6 +39,8 @@ test('recordMovement persists the typed movement_type for each write path', func
 ]);
 
 test('the adjustment action records a typed adjustment movement', function () {
+    // Free-form allows the manual upward adjustment (purchase-driven blocks it).
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
     $storage = Storage::factory()->create();
     $product = Product::factory()->create();
     $actor = User::factory()->create();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Enums\StorageType;
 use App\Models\Role;
+use App\Models\Storage;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Services\OnBoarding\DefaultRolesService;
@@ -112,4 +114,18 @@ function actingAsTenantUser(?User $user = null, string $role = 'owner'): TestCas
     app()->instance('currentTenant', $tenant);
 
     return test()->actingAs($user);
+}
+
+/**
+ * Shared POS helper: create a sale-point storage for the current tenant.
+ * Lives here (not in a single test file) so every test process has it,
+ * including isolated/parallel runs.
+ */
+function createSalePoint(string $name): Storage
+{
+    return Storage::factory()->create([
+        'tenant_id' => app('currentTenant')->id,
+        'type' => StorageType::SALE_POINT,
+        'name' => $name,
+    ]);
 }


### PR DESCRIPTION
Two **pre-existing** failures on `master` that only surface when tests run in separate processes (`--parallel`) or in isolation — both unrelated to any feature work, hence their own PR.

## 1. `createSalePoint()` cross-file helper
Defined in `PosSessionTest.php` but used by `PosFavoritesTest.php`. It resolved only when both files happened to load in the same process, so `PosFavoritesTest` failed with *"Call to undefined function createSalePoint()"* under parallel/isolated runs. **Fix:** moved the helper to `tests/Pest.php` (where the other global helpers live) and removed the duplicate definition.

## 2. `StockMovementLedgerHardeningTest` adjustment gate
Its *"adjustment action records a typed adjustment movement"* test performs an **upward** adjustment (0→30) under the default `purchase_driven` strategy — which M4's `ManualStockIncreaseNotAllowedException` gate now blocks. The test predates the gate and was never re-run against it (the milestone regression runs didn't include this file, and the full suite OOMs single-process). **Fix:** set `free_form` for that case, mirroring the same fix already applied to `StockAdjustmentTest` in M4.

## Verification
`php artisan test --parallel` → **3520 assertions, 0 failed** (previously 2 failing). Both tests also pass in isolation now. Pint clean.

> Note: running the suite single-process (`php artisan test` without `--parallel`) still OOMs at the 128M limit on export/MIME tests — a separate pre-existing environmental issue; use `--parallel` (as CI does).