### PR TITLE
refactor(inventory): overselling/redesign follow-up (arch + naming review)

### DIFF
--- a/app/Http/Controllers/Catalog/ProductsController.php
+++ b/app/Http/Controllers/Catalog/ProductsController.php
@@ -13,6 +13,7 @@ use App\Models\Category;
 use App\Models\Product;
 use App\Models\Storage;
 use App\Queries\ProductShowQuery;
+use Illuminate\Support\Facades\DB;
 
 class ProductsController extends Controller
 {
@@ -57,20 +58,22 @@ class ProductsController extends Controller
     {
         $this->authorize('create', Product::class);
 
-        $product = Product::create($request->safe()->except(['units', 'categories', 'quantities']));
-
-        $units = $request->get('units');
-
-        if (empty($units)) {
-            $product->units()->create(['name' => __('Base Unit'), 'conversion_factor' => 1]);
-        } else {
-            $product->syncUnits($units);
-        }
-
-        $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
-
         try {
-            $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+            DB::transaction(function () use ($request, $syncCategoriesAction, $recordAdjustment) {
+                $product = Product::create($request->safe()->except(['units', 'categories', 'quantities']));
+
+                $units = $request->get('units');
+
+                if (empty($units)) {
+                    $product->units()->create(['name' => __('Base Unit'), 'conversion_factor' => 1]);
+                } else {
+                    $product->syncUnits($units);
+                }
+
+                $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
+
+                $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+            });
         } catch (ManualStockIncreaseNotAllowedException $e) {
             return redirect()->route('products.index')->with('error', $e->getMessage());
         }
@@ -91,14 +94,16 @@ class ProductsController extends Controller
     {
         $this->authorize('update', $product);
 
-        $product->update($request->safe()->except(['units', 'categories', 'quantities']));
-
-        $product->syncUnits($request->get('units'));
-
-        $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
-
         try {
-            $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+            DB::transaction(function () use ($product, $request, $syncCategoriesAction, $recordAdjustment) {
+                $product->update($request->safe()->except(['units', 'categories', 'quantities']));
+
+                $product->syncUnits($request->get('units'));
+
+                $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
+
+                $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+            });
         } catch (ManualStockIncreaseNotAllowedException $e) {
             return back()->with('error', $e->getMessage());
         }

--- a/resources/js/Components/Pos/PosFavorites.vue
+++ b/resources/js/Components/Pos/PosFavorites.vue
@@ -1,5 +1,6 @@
 <script setup>
 import FavoriteStar from "@/Components/Pos/FavoriteStar.vue";
+import { useInventoryStrategy } from "@/Composables/useInventoryStrategy";
 
 const props = defineProps({
     favorites: {
@@ -14,7 +15,7 @@ const emit = defineEmits(['add-to-cart', 'toggle-favorite']);
 const fmt = (val) => `${Number(val).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${props.currency}`;
 
 // Overselling tenants never block on stock; favourites stay addable.
-const oversellingEnabled = [true, 1, '1', 'true'].includes(window.preferences?.('allow_overselling', false));
+const { oversellingEnabled } = useInventoryStrategy();
 const isAvailable = (product) => oversellingEnabled || product.sale_point_qty > 0;
 </script>
 
@@ -58,7 +59,7 @@ const isAvailable = (product) => oversellingEnabled || product.sale_point_qty > 
                     <h4 class="text-sm font-semibold text-gray-900 dark:text-white group-hover:text-emerald-600 truncate leading-snug ltr:pr-8 rtl:pl-8">{{ product.name }}</h4>
 
                     <div class="flex items-center justify-between mt-2">
-                        <span class="text-sm font-bold text-emerald-600">{{ fmt(product.price || 0) }}</span>
+                        <span class="text-sm font-bold text-emerald-600"><Ltr>{{ fmt(product.price || 0) }}</Ltr></span>
                         <span v-if="isAvailable(product)" class="text-[10px] font-medium text-gray-400">{{ product.sale_point_qty }}</span>
                         <span v-else class="text-[10px] font-bold uppercase tracking-wider text-red-500 dark:text-red-400">{{ __('Out of Stock') }}</span>
                     </div>

--- a/resources/js/Components/Pos/PosProductGrid.vue
+++ b/resources/js/Components/Pos/PosProductGrid.vue
@@ -5,6 +5,7 @@ import debounce from "lodash/debounce";
 import TextInput from "@/Components/TextInput.vue";
 import PosFavorites from "@/Components/Pos/PosFavorites.vue";
 import FavoriteStar from "@/Components/Pos/FavoriteStar.vue";
+import { useInventoryStrategy } from "@/Composables/useInventoryStrategy";
 
 const props = defineProps({
     initialProducts: Object,
@@ -24,7 +25,7 @@ const emit = defineEmits(['add-to-cart', 'toggle-favorite']);
 const fmt = (val) => `${Number(val).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${props.currency}`;
 
 // Overselling tenants never block on stock; every product stays addable.
-const oversellingEnabled = [true, 1, '1', 'true'].includes(window.preferences?.('allow_overselling', false));
+const { oversellingEnabled } = useInventoryStrategy();
 
 const search = ref('');
 const products = ref(props.initialProducts.data);
@@ -122,7 +123,7 @@ onUnmounted(() => {
                 >
                     <h4 class="text-sm font-semibold text-gray-900 dark:text-white group-hover:text-emerald-600 truncate leading-snug">{{ product.name }}</h4>
                     <div class="flex items-center justify-between mt-2">
-                        <span class="text-sm font-bold text-emerald-600">{{ fmt(product.price || 0) }}</span>
+                        <span class="text-sm font-bold text-emerald-600"><Ltr>{{ fmt(product.price || 0) }}</Ltr></span>
                         <span v-if="product.sale_point_qty > 0" class="text-[10px] font-medium text-gray-400">{{ product.sale_point_qty }}</span>
                         <span v-else-if="product.replenishment" class="text-[10px] font-medium text-amber-500">{{ __('via warehouse') }}</span>
                     </div>
@@ -166,7 +167,7 @@ onUnmounted(() => {
                     </div>
                     <h3 class="text-sm font-semibold text-gray-900 dark:text-white group-hover:text-emerald-600 truncate leading-snug ltr:pr-8 rtl:pl-8">{{ product.name }}</h3>
                     <div class="flex items-center justify-between mt-2 pt-2 border-t border-gray-100 dark:border-gray-800">
-                        <span class="text-sm font-bold text-emerald-600">{{ fmt(product.price || 0) }}</span>
+                        <span class="text-sm font-bold text-emerald-600"><Ltr>{{ fmt(product.price || 0) }}</Ltr></span>
                         <span v-if="product.sale_point_qty > 0" class="text-[10px] font-medium text-gray-400">{{ product.sale_point_qty }}</span>
                         <span v-else-if="product.replenishment" class="text-[10px] font-medium text-amber-500">{{ __('via warehouse') }}</span>
                     </div>

--- a/resources/js/Components/Products/ProductForm.vue
+++ b/resources/js/Components/Products/ProductForm.vue
@@ -6,6 +6,7 @@
     import PrimaryButton from "@/Components/PrimaryButton.vue";
     import TextInput from "@/Components/TextInput.vue";
     import CustomSelect from "../CustomSelect.vue";
+    import { useInventoryStrategy } from "@/Composables/useInventoryStrategy";
 
     const props = defineProps({
         product: {
@@ -39,8 +40,7 @@
 
     // Under purchase-driven, stock only enters via purchase invoices, so the
     // per-location quantities are shown read-only. Free-form allows editing them.
-    const manualStockAllowed =
-        preferences("inventory_strategy", "purchase_driven") === "free_form";
+    const { manualStockAllowed } = useInventoryStrategy();
 
     const show = ref(false);
     const product = useForm({
@@ -59,10 +59,6 @@
             quantity: currentQuantityFor(storage.id),
         })),
     });
-
-    const setCurrency = (value) => {
-        product.currency = (value || "").toUpperCase();
-    };
 
     const addUnit = () => {
         product.units.push({ name: "", conversion_factor: null });
@@ -114,17 +110,17 @@
         const price = parseFloat(product.price);
         if (!product.cost || !product.price || isNaN(cost) || isNaN(price)) return null;
         const profit = price - cost;
-        return { profit, pct: cost > 0 ? (profit / cost) * 100 : 0, belowCost: price < cost };
+        return { profit, percent: cost > 0 ? (profit / cost) * 100 : 0, belowCost: price < cost };
     });
 
     // Units are demoted to a collapsible section; expand it when units exist.
     const showUnits = ref((props.product?.units?.length || 0) > 0);
 
     // Esc closes the dialog (with the dirty guard).
-    const onKeydown = (e) => { if (e.key === "Escape") cancel(); };
+    const closeOnEscape = (e) => { if (e.key === "Escape") cancel(); };
     watch(show, (open) => {
-        if (open) window.addEventListener("keydown", onKeydown);
-        else window.removeEventListener("keydown", onKeydown);
+        if (open) window.addEventListener("keydown", closeOnEscape);
+        else window.removeEventListener("keydown", closeOnEscape);
     });
 </script>
 
@@ -305,7 +301,7 @@
                                                 <span class="font-medium">
                                                     {{ margin.belowCost ? __("Priced below cost") : __("Profit") }}
                                                 </span>
-                                                <Ltr class="font-semibold">{{ margin.profit.toFixed(2) }} {{ product.currency }} ({{ margin.pct.toFixed(0) }}%)</Ltr>
+                                                <Ltr class="font-semibold">{{ margin.profit.toFixed(2) }} {{ product.currency }} ({{ margin.percent.toFixed(0) }}%)</Ltr>
                                             </div>
 
                                             <div>

--- a/resources/js/Composables/useCurrency.js
+++ b/resources/js/Composables/useCurrency.js
@@ -22,7 +22,15 @@ export function useCurrency() {
         }
     };
 
+    // A bare Latin-digit amount (no currency symbol) for tables that put the
+    // currency in the column header. Zero/null renders as an em dash so a
+    // column of zeros isn't noise. Wrap the output in <Ltr> at render.
+    const formatAmount = (value) => value
+        ? new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(value)
+        : '—';
+
     return {
-        formatCurrency
+        formatCurrency,
+        formatAmount,
     };
 }

--- a/resources/js/Composables/useInventoryStrategy.js
+++ b/resources/js/Composables/useInventoryStrategy.js
@@ -1,0 +1,14 @@
+// Reads the tenant's inventory strategy from shared preferences, in one place,
+// so the "stored as '1'/'0'" coercion isn't duplicated across components.
+export function useInventoryStrategy() {
+    const truthy = (value) => [true, 1, "1", "true"].includes(value);
+    const strategy = window.preferences?.("inventory_strategy", "purchase_driven");
+
+    return {
+        strategy,
+        // Sales may drive the balance negative (free-form + overselling on).
+        oversellingEnabled: truthy(window.preferences?.("allow_overselling", false)),
+        // Stock may be raised manually (adjustments / product-edit) — free-form only.
+        manualStockAllowed: strategy === "free_form",
+    };
+}

--- a/resources/js/Pages/Pos/Session.vue
+++ b/resources/js/Pages/Pos/Session.vue
@@ -8,6 +8,7 @@ import PrimaryButton from "@/Components/PrimaryButton.vue";
 import CustomSelect from "@/Components/CustomSelect.vue";
 import QuickAddPartyModal from "@/Components/QuickAddPartyModal.vue";
 import { useAsyncOptions } from "@/Composables/useAsyncOptions";
+import { useInventoryStrategy } from "@/Composables/useInventoryStrategy";
 
 import PosProductGrid from "@/Components/Pos/PosProductGrid.vue";
 import PosCheckoutModal from "@/Components/Pos/PosCheckoutModal.vue";
@@ -41,7 +42,7 @@ const fmt = (val) => `${Number(val).toLocaleString('en-US', { minimumFractionDig
 
 // When the tenant allows overselling, the POS never blocks on stock — sales
 // drive the sale-point balance negative and are reconciled later.
-const oversellingEnabled = [true, 1, '1', 'true'].includes(window.preferences?.('allow_overselling', false));
+const { oversellingEnabled } = useInventoryStrategy();
 
 // ── Customer ─────────────────────────────────────────────────────────────────
 const {
@@ -309,7 +310,7 @@ const paymentMethodLabels = [
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4" /></svg>
                                 </button>
                             </div>
-                            <span class="text-sm font-bold text-gray-900 dark:text-white">{{ fmt(item.quantity * item.price) }}</span>
+                            <span class="text-sm font-bold text-gray-900 dark:text-white"><Ltr>{{ fmt(item.quantity * item.price) }}</Ltr></span>
                         </div>
                         <div v-if="!oversellingEnabled && item.sale_point_qty < item.quantity && item.replenishment" class="flex items-center gap-x-1 mt-2 px-2 py-1.5 bg-amber-100 dark:bg-amber-900/20 rounded-lg">
                             <svg class="h-3 w-3 text-amber-600 shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" /></svg>
@@ -346,7 +347,7 @@ const paymentMethodLabels = [
                         <span class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('Total') }}</span>
                         <div class="text-end">
                             <span v-if="discountAmount > 0" class="block text-xs line-through text-gray-400 dark:text-gray-600 ltr:text-right rtl:text-left">{{ fmt(cartSubtotal) }}</span>
-                            <span class="text-2xl font-bold text-emerald-600">{{ fmt(total) }}</span>
+                            <span class="text-2xl font-bold text-emerald-600"><Ltr>{{ fmt(total) }}</Ltr></span>
                         </div>
                     </div>
                     <button type="button" class="w-full py-4 text-base font-semibold rounded-xl transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed" :class="!oversellingEnabled && cart.some(i => i.sale_point_qty < i.quantity) ? 'bg-amber-500 hover:bg-amber-600 text-white focus:ring-amber-500' : 'bg-emerald-600 hover:bg-emerald-700 text-white focus:ring-emerald-500'" :disabled="cart.length === 0 || checkoutForm.processing || (!oversellingEnabled && cart.some(i => i.sale_point_qty < i.quantity && !i.replenishment))" @click="openCheckoutModal">
@@ -371,7 +372,7 @@ const paymentMethodLabels = [
                     {{ __('Cart') }}
                     <span v-if="cart.length > 0" class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[10px] font-bold rounded-full bg-white/20">{{ cart.length }}</span>
                 </span>
-                <span class="text-base font-bold">{{ fmt(total) }}</span>
+                <span class="text-base font-bold"><Ltr>{{ fmt(total) }}</Ltr></span>
             </button>
         </div>
 

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -17,6 +17,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     import { useFilterChips } from "@/Composables/useFilterChips";
     import Tooltip from "@/Components/Tooltip.vue";
     import Dropdown from "@/Components/Dropdown.vue";
+    import { useCurrency } from "@/Composables/useCurrency";
 
     const props = defineProps({
         products: Object,
@@ -123,20 +124,11 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
         };
     };
 
-    const formatCurrency = (amount, currency = 'SDG') => {
-        const validCurrency = (currency && /^[A-Z]{3}$/.test(currency)) ? currency : (preferences('currency') && /^[A-Z]{3}$/.test(preferences('currency')) ? preferences('currency') : 'SDG');
-        // Latin digits regardless of locale; wrap the output in <Ltr> at render.
-        return new Intl.NumberFormat('en-US', {
-            style: 'currency',
-            currency: validCurrency,
-        }).format(amount);
-    };
-
     // ── Table numbers ────────────────────────────────────────────────────────
     // The currency symbol lives in the column header; cells render bare Latin
-    // numbers (em dash for zero/null so a column of zeros isn't noise).
+    // numbers via the shared useCurrency() formatter (em dash for zero/null).
+    const { formatCurrency, formatAmount } = useCurrency();
     const currencyCode = (preferences('currency') && /^[A-Z]{3}$/.test(preferences('currency'))) ? preferences('currency') : 'SDG';
-    const money = (amount) => amount ? new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 }).format(amount) : '—';
     const onHandOf = (product) => product.stock.reduce((sum, s) => sum + s.pivot.quantity, 0);
     const availableClass = (product) => {
         if (product.available_qty <= 0) return 'text-red-600 dark:text-red-400';
@@ -541,9 +533,9 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
                                             </span>
                                         </div>
                                     </td>
-                                    <td class="w-28 px-3 py-2.5 text-end text-sm text-gray-700 dark:text-gray-300"><Ltr>{{ money(product.cost) }}</Ltr></td>
-                                    <td class="w-28 px-3 py-2.5 text-end text-sm text-gray-700 dark:text-gray-300"><Ltr>{{ money(product.average_cost) }}</Ltr></td>
-                                    <td class="w-28 px-3 py-2.5 text-end text-sm font-semibold text-gray-900 dark:text-white"><Ltr>{{ money(product.price) }}</Ltr></td>
+                                    <td class="w-28 px-3 py-2.5 text-end text-sm text-gray-700 dark:text-gray-300"><Ltr>{{ formatAmount(product.cost) }}</Ltr></td>
+                                    <td class="w-28 px-3 py-2.5 text-end text-sm text-gray-700 dark:text-gray-300"><Ltr>{{ formatAmount(product.average_cost) }}</Ltr></td>
+                                    <td class="w-28 px-3 py-2.5 text-end text-sm font-semibold text-gray-900 dark:text-white"><Ltr>{{ formatAmount(product.price) }}</Ltr></td>
                                     <td class="w-24 px-3 py-2.5 text-end" @click.stop>
                                         <div class="flex items-center justify-end gap-x-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-within:opacity-100 transition-opacity">
                                             <ProductForm :product="product" :categories="categories" :storages="storages" />

--- a/tests/Feature/Inventory/ProductEditQuantityTest.php
+++ b/tests/Feature/Inventory/ProductEditQuantityTest.php
@@ -65,6 +65,26 @@ test('creating a product with per-storage quantities sets stock via adjustments'
     ]);
 });
 
+test('creating a product rolls back entirely when the stock step is rejected', function () {
+    // purchase_driven (default) blocks the upward manual increase mid-transaction.
+    $storage = Storage::factory()->create();
+
+    $this->actingAs(User::factory()->create())
+        ->post(route('products.index'), [
+            'name' => 'Should Not Persist',
+            'cost' => 10,
+            'units' => [['name' => 'Box', 'conversion_factor' => 1]],
+            'categories' => [],
+            'quantities' => [
+                ['storage_id' => $storage->id, 'quantity' => 40],
+            ],
+        ])->assertSessionHas('error');
+
+    // The whole create is atomic: no product, no units, no stock movement.
+    expect(Product::where('name', 'Should Not Persist')->exists())->toBeFalse();
+    expect(StockMovement::count())->toBe(0);
+});
+
 test('editing quantities upward is blocked under purchase-driven', function () {
     $storage = Storage::factory()->create();
     $product = Product::factory()->create();


### PR DESCRIPTION
> **Note:** the main feature (POS overselling, per-location quantities, table + modal redesign, bidi foundation) already merged to `master` via **#70**. This branch was reopened after that merge, so it re-conflicted (squash-merge artifact). It's now **rebased onto master** and contains **only the post-merge follow-up** — the `/arch` and `/jeff` review fixes.

## What's in this PR (9 files, +88/−50)

- **Atomic writes** — `ProductsController::store()/update()` + the per-storage adjustments are wrapped in one `DB::transaction`, so a rejected stock step (e.g. an upward edit under `purchase_driven`) rolls the whole write back. Test added: *"creating a product rolls back entirely when the stock step is rejected"*.
- **`useInventoryStrategy()` composable** — centralizes the `'1'/'0'` preference coercion that was duplicated across POS `Session`/`Grid`/`Favorites` and `ProductForm`.
- **Money formatting consolidated** onto `useCurrency()` (adds `formatAmount()`); `Index.vue` drops its local copies.
- **Naming** — `money()`→`formatAmount`, `onKeydown`→`closeOnEscape`, `pct`→`percent`; removed dead `setCurrency()`.
- **Bidi-isolate POS money** (grid / favourites / cart totals) via `<Ltr>`.

## Verification
Build clean; product suite green (incl. the new rollback test); Pint clean. Mergeable, no conflicts.