### PR TITLE
i18n(ar): translate the inventory-strategy settings strings

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,4 +1,11 @@
 {
+    "Inventory Management": "إدارة المخزون",
+    "Choose how you want to manage your inventory.": "اختر طريقة إدارة مخزونك.",
+    "Purchase-driven (strict)": "قائم على المشتريات (صارم)",
+    "Stock enters only through purchase invoices. Sales are blocked when stock runs out.": "لا يدخل المخزون إلا عبر فواتير الشراء، وتُمنع المبيعات عند نفاد المخزون.",
+    "Free-form (flexible)": "حر (مرن)",
+    "Adjust quantities freely without purchase invoices.": "عدّل الكميات بحرية دون الحاجة إلى فواتير شراء.",
+    "Allow selling below zero (overselling). Negative balances are surfaced for later reconciliation.": "السماح بالبيع تحت الصفر (البيع الزائد). تظهر الأرصدة السالبة لتسويتها لاحقاً.",
     "Edit Product": "تعديل منتج",
     "Fill in the product details below.": "أدخل تفاصيل المنتج أدناه.",
     "Pricing": "التسعير",


### PR DESCRIPTION
The **Inventory Management** section in Organization Settings (purchase-driven vs free-form, plus the overselling toggle) shipped with `__()` keys that had no Arabic values in `lang/ar.json`, so they rendered in English on the Arabic UI.

Adds the 7 missing translations:

| English | Arabic |
|---|---|
| Inventory Management | إدارة المخزون |
| Choose how you want to manage your inventory. | اختر طريقة إدارة مخزونك. |
| Purchase-driven (strict) | قائم على المشتريات (صارم) |
| Stock enters only through purchase invoices. Sales are blocked when stock runs out. | لا يدخل المخزون إلا عبر فواتير الشراء، وتُمنع المبيعات عند نفاد المخزون. |
| Free-form (flexible) | حر (مرن) |
| Adjust quantities freely without purchase invoices. | عدّل الكميات بحرية دون الحاجة إلى فواتير شراء. |
| Allow selling below zero (overselling). Negative balances are surfaced for later reconciliation. | السماح بالبيع تحت الصفر (البيع الزائد). تظهر الأرصدة السالبة لتسويتها لاحقاً. |

Translation-only; `ar.json` validated as well-formed. No code changes.