### PR TITLE
feat(settings): redesign General Settings — shell, section cards, field primitives (RTL, dark)

### DIFF
--- a/database/migrations/2026_07_13_134448_normalize_currency_preference_value.php
+++ b/database/migrations/2026_07_13_134448_normalize_currency_preference_value.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * The settings UI now stores the currency through a fixed ISO 4217
+     * <select> list. Normalise any previously free-text value (which was
+     * entered/stored ad hoc) so existing rows line up with a valid option:
+     * upper-case + trim, and fall back to the app default for anything that
+     * isn't a 3-letter code. Runs across every tenant's row uniformly.
+     */
+    public function up(): void
+    {
+        DB::table('preferences')
+            ->where('key', 'currency')
+            ->whereNotNull('value')
+            ->update(['value' => DB::raw('UPPER(TRIM(value))')]);
+
+        DB::table('preferences')
+            ->where('key', 'currency')
+            ->where(function ($query) {
+                $query->whereNull('value')
+                    ->orWhereRaw('LENGTH(TRIM(value)) <> 3');
+            })
+            ->update(['value' => 'SDG']);
+    }
+
+    /**
+     * Normalisation is not reversible; the original ad-hoc values are lost.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/js/Components/CurrencySelect.vue
+++ b/resources/js/Components/CurrencySelect.vue
@@ -1,0 +1,68 @@
+<script setup>
+    import { computed } from "vue";
+    import { usePage } from "@inertiajs/vue3";
+
+    /**
+     * Currency picker backed by a fixed ISO 4217 list. Option labels are
+     * localised at runtime via Intl.DisplayNames (so Arabic gets Arabic
+     * currency names) — no hardcoded, per-currency translation keys.
+     */
+    const props = defineProps({
+        modelValue: { type: String, default: "SDG" },
+        id: { type: String, default: undefined },
+        disabled: { type: Boolean, default: false },
+    });
+
+    defineEmits(["update:modelValue"]);
+
+    // Regionally relevant codes, SDG (app default) first.
+    const CURRENCY_CODES = [
+        "SDG", "USD", "EUR", "GBP", "SAR", "AED",
+        "EGP", "QAR", "KWD", "TRY", "ETB", "SSP", "CNY",
+    ];
+
+    const page = usePage();
+
+    const localizedName = (code) => {
+        try {
+            const names = new Intl.DisplayNames([page.props.locale || "en"], {
+                type: "currency",
+            });
+            return names.of(code) || code;
+        } catch (e) {
+            return code;
+        }
+    };
+
+    // Ensure a previously-stored value that isn't in the canonical list still
+    // appears as a selectable option (so migration/legacy data isn't lost).
+    const codes = computed(() => {
+        const current = props.modelValue;
+        if (current && !CURRENCY_CODES.includes(current)) {
+            return [current, ...CURRENCY_CODES];
+        }
+        return CURRENCY_CODES;
+    });
+
+    const options = computed(() =>
+        codes.value.map((code) => ({ code, label: `${code} — ${localizedName(code)}` }))
+    );
+</script>
+
+<template>
+    <select
+        :id="id"
+        :value="modelValue"
+        :disabled="disabled"
+        class="w-full rounded-lg border border-line bg-surface px-3 py-2 text-start text-sm text-primary focus:border-emerald-300 focus:outline-none focus:ring focus:ring-emerald-200 focus:ring-opacity-50 disabled:opacity-60 dark:focus:border-emerald-600 dark:focus:ring-emerald-800 sm:max-w-xs"
+        @change="$emit('update:modelValue', $event.target.value)"
+    >
+        <option
+            v-for="option in options"
+            :key="option.code"
+            :value="option.code"
+        >
+            {{ option.label }}
+        </option>
+    </select>
+</template>

--- a/resources/js/Components/LogoUploader.vue
+++ b/resources/js/Components/LogoUploader.vue
@@ -1,0 +1,99 @@
+<script setup>
+    import { computed, ref } from "vue";
+    import SecondaryButton from "@/Components/SecondaryButton.vue";
+
+    /**
+     * Logo picker with a real image preview and a placeholder-icon fallback
+     * (instead of a broken <img> alt string). Emits the chosen File via
+     * v-model; the section persists it through the shared form.
+     */
+    const props = defineProps({
+        // The currently stored logo URL (shown until a new file is picked).
+        currentUrl: { type: String, default: "" },
+    });
+
+    const emit = defineEmits(["update:modelValue"]);
+
+    const fileInput = ref(null);
+    const newPreview = ref(null);
+    const currentFailed = ref(false);
+
+    // New pick wins; otherwise the stored logo (unless it failed to load).
+    const previewSrc = computed(() => {
+        if (newPreview.value) {
+            return newPreview.value;
+        }
+        if (props.currentUrl && !currentFailed.value) {
+            return props.currentUrl;
+        }
+        return null;
+    });
+
+    const pick = () => {
+        fileInput.value.click();
+    };
+
+    const onChange = () => {
+        const file = fileInput.value.files[0];
+        if (!file) {
+            return;
+        }
+        emit("update:modelValue", file);
+
+        const reader = new FileReader();
+        reader.onload = (e) => (newPreview.value = e.target.result);
+        reader.readAsDataURL(file);
+    };
+</script>
+
+<template>
+    <div class="flex items-center gap-x-4">
+        <input
+            ref="fileInput"
+            type="file"
+            accept="image/*"
+            class="hidden"
+            @change="onChange"
+        />
+
+        <!-- Preview / placeholder -->
+        <div
+            class="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-xl border border-line bg-surface-sunken"
+        >
+            <img
+                v-if="previewSrc"
+                :src="previewSrc"
+                alt=""
+                class="h-full w-full object-contain"
+                @error="currentFailed = true"
+            />
+            <svg
+                v-else
+                class="h-7 w-7 text-disabled"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+                />
+            </svg>
+        </div>
+
+        <div>
+            <SecondaryButton
+                type="button"
+                @click.prevent="pick"
+            >
+                {{ __("Select A New Logo") }}
+            </SecondaryButton>
+            <p class="mt-1.5 text-xs text-tertiary">
+                {{ __("PNG, JPG or SVG · up to 2MB.") }}
+            </p>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/NumberField.vue
+++ b/resources/js/Components/NumberField.vue
@@ -1,0 +1,56 @@
+<script setup>
+    /**
+     * Numeric input with a suffix addon (e.g. "%"). Uses a text input with
+     * `inputmode="decimal"` instead of `type="number"` so the browser's native
+     * spinner — which renders on the wrong side under RTL — never appears.
+     *
+     * The whole control is a single rounded, overflow-clipped group, so the
+     * addon's outer corners follow the group's logical radius in both
+     * directions with no direction-specific corner classes.
+     */
+    defineProps({
+        modelValue: { type: [String, Number], default: "" },
+        id: { type: String, default: undefined },
+        suffix: { type: String, default: "%" },
+        placeholder: { type: String, default: "" },
+        disabled: { type: Boolean, default: false },
+    });
+
+    const emit = defineEmits(["update:modelValue"]);
+
+    const onInput = (event) => {
+        // Keep digits and a single decimal separator only.
+        let value = event.target.value.replace(/[^\d.]/g, "");
+        const firstDot = value.indexOf(".");
+        if (firstDot !== -1) {
+            value =
+                value.slice(0, firstDot + 1) +
+                value.slice(firstDot + 1).replace(/\./g, "");
+        }
+        event.target.value = value;
+        emit("update:modelValue", value);
+    };
+</script>
+
+<template>
+    <div
+        class="flex overflow-hidden rounded-lg border border-line bg-surface transition focus-within:border-emerald-300 focus-within:ring focus-within:ring-emerald-200 focus-within:ring-opacity-50 dark:focus-within:border-emerald-600 dark:focus-within:ring-emerald-800"
+        :class="{ 'opacity-60': disabled }"
+    >
+        <input
+            :id="id"
+            type="text"
+            inputmode="decimal"
+            :value="modelValue"
+            :placeholder="placeholder"
+            :disabled="disabled"
+            class="min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-sm text-primary placeholder-disabled focus:outline-none focus:ring-0"
+            @input="onInput"
+        />
+        <span
+            class="flex select-none items-center border-s border-line bg-surface-sunken px-3 text-sm font-medium text-secondary"
+        >
+            {{ suffix }}
+        </span>
+    </div>
+</template>

--- a/resources/js/Components/SettingsSection.vue
+++ b/resources/js/Components/SettingsSection.vue
@@ -1,0 +1,38 @@
+<script setup>
+    /**
+     * A single settings card: a titled (optionally described) surface with a
+     * header bar and a content slot. `id` anchors the card so the section nav
+     * can scroll to it; `scroll-mt` offsets for the sticky page header.
+     *
+     * Colours use the theme-aware semantic tokens (surface / line / primary /
+     * secondary), which flip under the OS dark-mode media query.
+     */
+    defineProps({
+        id: { type: String, default: undefined },
+        title: { type: String, required: true },
+        description: { type: String, default: "" },
+    });
+</script>
+
+<template>
+    <section
+        :id="id"
+        class="scroll-mt-24 rounded-xl border border-line bg-surface"
+    >
+        <div class="border-b border-line px-6 py-4">
+            <h2 class="text-base font-semibold text-primary">
+                {{ title }}
+            </h2>
+            <p
+                v-if="description"
+                class="mt-1 text-sm text-secondary"
+            >
+                {{ description }}
+            </p>
+        </div>
+
+        <div class="p-6">
+            <slot />
+        </div>
+    </section>
+</template>

--- a/resources/js/Components/ToggleField.vue
+++ b/resources/js/Components/ToggleField.vue
@@ -1,0 +1,69 @@
+<script setup>
+    /**
+     * A switch paired with its label on a single, width-capped row — the
+     * control sits directly next to the label instead of being flung to the
+     * far edge by a full-width justify-between. Optional description line.
+     *
+     * The knob slides with a logical translate (`start-*` + `rtl:` mirror) so
+     * it moves toward the inline-end in both LTR and RTL.
+     */
+    const props = defineProps({
+        modelValue: { type: Boolean, default: false },
+        label: { type: String, default: "" },
+        description: { type: String, default: "" },
+        disabled: { type: Boolean, default: false },
+    });
+
+    const emit = defineEmits(["update:modelValue"]);
+
+    const toggle = () => {
+        if (!props.disabled) {
+            emit("update:modelValue", !props.modelValue);
+        }
+    };
+</script>
+
+<template>
+    <label
+        class="inline-flex max-w-md items-start gap-x-3"
+        :class="disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'"
+    >
+        <!-- Switch -->
+        <span
+            class="relative mt-0.5 inline-flex h-5 w-9 shrink-0 rounded-full transition-colors duration-200"
+            :class="modelValue ? 'bg-emerald-500' : 'bg-line-strong'"
+        >
+            <span
+                class="absolute top-0.5 start-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200"
+                :class="modelValue ? 'translate-x-4 rtl:-translate-x-4' : ''"
+            />
+        </span>
+
+        <!-- Native input drives state + accessibility; visually hidden. -->
+        <input
+            type="checkbox"
+            class="sr-only"
+            :checked="modelValue"
+            :disabled="disabled"
+            @change="toggle"
+        />
+
+        <span
+            v-if="label || description"
+            class="min-w-0"
+        >
+            <span
+                v-if="label"
+                class="block text-sm font-medium text-primary"
+            >
+                {{ label }}
+            </span>
+            <span
+                v-if="description"
+                class="mt-0.5 block text-sm text-secondary"
+            >
+                {{ description }}
+            </span>
+        </span>
+    </label>
+</template>

--- a/resources/js/Layouts/SettingsLayout.vue
+++ b/resources/js/Layouts/SettingsLayout.vue
@@ -1,0 +1,53 @@
+<script setup>
+    /**
+     * Shared shell for settings pages.
+     *
+     * Header and body live inside ONE max-width container so the sticky header
+     * stays aligned with the content below it. Colours use the theme-aware
+     * semantic tokens (surface / line / primary / secondary), which flip under
+     * the OS dark-mode media query with no `dark:` variant needed.
+     */
+    defineProps({
+        title: { type: String, required: true },
+        subtitle: { type: String, default: "" },
+    });
+</script>
+
+<template>
+    <div class="mx-auto max-w-7xl">
+        <!-- Sticky page header: title + subtitle on the start side, actions on the end. -->
+        <header
+            class="sticky top-0 z-10 flex items-center justify-between gap-x-4 border-b border-line bg-surface py-4"
+        >
+            <div class="min-w-0">
+                <h1 class="truncate text-xl font-semibold text-primary">
+                    {{ title }}
+                </h1>
+                <p
+                    v-if="subtitle"
+                    class="mt-0.5 truncate text-sm text-secondary"
+                >
+                    {{ subtitle }}
+                </p>
+            </div>
+
+            <div class="flex shrink-0 items-center gap-x-3">
+                <slot name="header-actions" />
+            </div>
+        </header>
+
+        <!-- Body: section nav on the start side, content on the end.
+             Single column below lg, two columns (150px nav + fluid content) at lg+. -->
+        <div
+            class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-[150px_minmax(0,1fr)] lg:gap-8"
+        >
+            <aside class="lg:sticky lg:top-24 lg:self-start">
+                <slot name="nav" />
+            </aside>
+
+            <div class="min-w-0 space-y-6">
+                <slot />
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
+++ b/resources/js/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue
@@ -1,119 +1,74 @@
 <script setup>
-    import { ref } from "vue";
-    import { useForm } from "@inertiajs/vue3";
-    import ActionMessage from "@/Components/ActionMessage.vue";
-    import FormSection from "@/Components/FormSection.vue";
+    import { computed, inject, watch } from "vue";
+    import CurrencySelect from "@/Components/CurrencySelect.vue";
     import InputError from "@/Components/InputError.vue";
     import InputLabel from "@/Components/InputLabel.vue";
-    import PrimaryButton from "@/Components/PrimaryButton.vue";
-    import SecondaryButton from "@/Components/SecondaryButton.vue";
-    import TextInput from "@/Components/TextInput.vue";
-    const alertsToggle = ref(preferences('alerts', true));
+    import LogoUploader from "@/Components/LogoUploader.vue";
+    import NumberField from "@/Components/NumberField.vue";
+    import SettingsSection from "@/Components/SettingsSection.vue";
+    import ToggleField from "@/Components/ToggleField.vue";
 
-    const truthy = (value) => [true, 1, "1", "true"].includes(value);
-    const oversellingToggle = ref(truthy(preferences('allow_overselling', false)));
+    // Form is owned by the page (Show.vue) so Save can live in the sticky header.
+    // This partial only renders the fields bound to that shared form.
+    const form = inject("settingsForm");
 
-    const form = useForm({
-        logo: preferences('logo'),
-        invoicesHeadline: preferences('invoicesHeadline'),
-        alerts: alertsToggle.value,
-        currency: preferences('currency', 'SDG'),
-        pecentage: preferences('pecentage', 60),
-        inventory_strategy: preferences('inventory_strategy', 'purchase_driven'),
-        allow_overselling: oversellingToggle.value,
+    const isFlexible = computed(
+        () => form.inventory_strategy === "free_form"
+    );
+
+    // Overselling is only meaningful under the flexible strategy. Reset it when
+    // the user switches to strict (change only — never on initial load, so an
+    // untouched form stays clean).
+    watch(
+        () => form.inventory_strategy,
+        (strategy) => {
+            if (strategy !== "free_form") {
+                form.allow_overselling = false;
+            }
+        }
+    );
+
+    // Resolve the stored logo path to a URL the browser can load. Bare disk
+    // paths (e.g. "logos/x.png") are served from the public storage symlink.
+    const currentLogoUrl = computed(() => {
+        const path = preferences("logo");
+        if (!path) {
+            return "/images/logo.svg";
+        }
+        if (path.startsWith("http") || path.startsWith("/")) {
+            return path;
+        }
+        return `/storage/${path}`;
     });
 
-    const logoPreview = ref(null);
-    const logoInput = ref(null);
-
-    const updateApplicationInformation = () => {
-        form.alerts = alertsToggle.value;
-        // allow_overselling only applies under free-form; purchase-driven always blocks.
-        form.allow_overselling =
-            form.inventory_strategy === "free_form" ? oversellingToggle.value : false;
-        if (logoInput.value && logoInput.value.files[0]) {
-            form.logo = logoInput.value.files[0];
-        }
-
-        form.post(route("preferences.update"), {
-            onSuccess: () => {
-                logoPreview.value = null;
-                if (logoInput.value) {
-                    logoInput.value.value = null;
-                }
-            },
-        });
-    };
-
-    const selectNewLogo = () => {
-        logoInput.value.click();
-    };
-
-    const updateLogoPreview = () => {
-        const logo = logoInput.value.files[0];
-        const reader = new FileReader();
-
-        if (!logo) return;
-        reader.onload = (e) => (logoPreview.value = e.target.result);
-        reader.readAsDataURL(logo);
-    };
+    const cardClass = (selected) => [
+        "rounded-xl border bg-surface transition-colors",
+        selected
+            ? "border-emerald-500 ring-1 ring-inset ring-emerald-500"
+            : "border-line hover:border-line-strong",
+    ];
 </script>
 
 <template>
-    <FormSection @submitted="updateApplicationInformation">
-        <template #title> {{ __("Application Information") }} </template>
-
-        <template #description>
-            {{ __("Update your Application information and Basic Data") }}.
-        </template>
-
-        <template #form>
-            <!-- Logo logo -->
-            <div class="col-span-6 sm:col-span-4">
-                <!-- Logo logo File Input -->
-                <input
-                    ref="logoInput"
-                    type="file"
-                    class="hidden"
-                    @change="updateLogoPreview"
-                />
-
+    <!-- Identity -->
+    <SettingsSection
+        id="identity"
+        :title="__('Identity')"
+        :description="__('Your logo and the header printed on invoices.')"
+    >
+        <div class="space-y-6">
+            <!-- Logo -->
+            <div>
                 <InputLabel
                     for="logo"
                     :value="__('Logo')"
                 />
-
-                <!-- Current Profile Logo -->
-                <div
-                    v-show="!logoPreview"
-                    class="mt-2"
-                >
-                    <img
-                        :src="preferences('logo', '/images/logo.svg')"
-                        alt="App Logo"
-                        class="object-contain w-12 h-12"
+                <div class="mt-2">
+                    <LogoUploader
+                        v-model="form.logo"
+                        :current-url="currentLogoUrl"
                     />
                 </div>
-
-                <!-- New Logo Preview -->
-                <div
-                    v-show="logoPreview"
-                    class="mt-2"
-                >
-                    <img
-                        :src="logoPreview"
-                        class="object-contain w-12 h-12"
-                    />
-                </div>
-
-                <SecondaryButton
-                    class="mt-2 mr-2"
-                    type="button"
-                    @click.prevent="selectNewLogo"
-                >
-                    {{ __("Select A New Logo") }}
-                </SecondaryButton>
-
                 <InputError
                     :message="form.errors.logo"
                     class="mt-2"
@@ -121,7 +76,7 @@
             </div>
 
             <!-- Invoices Headline -->
-            <div class="col-span-6 sm:col-span-4">
+            <div>
                 <InputLabel
                     for="invoicesHeadline"
                     :value="__('Invoices Headline')"
@@ -137,87 +92,47 @@
                     class="mt-2"
                 />
             </div>
+        </div>
+    </SettingsSection>
 
-            <!-- Alerts -->
-            <div class="col-span-6 sm:col-span-4">
-                <InputLabel
-                    for="alerts"
-                    :value="__('Alerts')"
-                />
-                <div
-                    class="flex items-center cursor-pointer"
-                    @click="alertsToggle = !alertsToggle"
-                >
-                    <div
-                        class="relative w-10 h-5 transition duration-200 ease-linear rounded-full"
-                        :class="[
-                            alertsToggle ? 'bg-emerald-500' : 'bg-gray-300',
-                        ]"
-                    >
-                        <label
-                            for="alertsToggle"
-                            class="absolute left-0 w-5 h-5 mb-2 transition duration-100 ease-linear transform bg-white border-2 rounded-full cursor-pointer"
-                            :class="[
-                                alertsToggle
-                                    ? 'translate-x-full border-emerald-500'
-                                    : 'translate-x-0 border-gray-300',
-                            ]"
-                            @click="alertsToggle = !alertsToggle"
-                        ></label>
-                        <input
-                            type="checkbox"
-                            name="alertsToggle"
-                            class="hidden w-full h-full rounded-full appearance-none active:outline-none focus:outline-none"
-                        />
-                    </div>
-
-                    <p class="mx-3 text-sm text-secondary">
-                        {{ __("Send Notifications When Stocks Running Out") }}
-                    </p>
-                </div>
-                <InputError
-                    :message="form.errors.alerts"
-                    class="mt-2"
-                />
-            </div>
-
-            <!-- Pecentage -->
-            <div class="col-span-6 sm:col-span-4">
+    <!-- Pricing & currency -->
+    <SettingsSection
+        id="pricing"
+        :title="__('Pricing & currency')"
+        :description="__('Default profit margin and the system-wide currency.')"
+    >
+        <div class="space-y-6">
+            <!-- Margin percentage -->
+            <div>
                 <InputLabel
                     for="pecentage"
-                    :value="__('Margin Revenu Percentage') + ' ' + '(%)'"
+                    :value="__('Margin Revenu Percentage')"
                 />
-                <TextInput
-                    id="pecentage"
-                    v-model="form.pecentage"
-                    type="number" inputmode="decimal"
-                    min="0"
-                    max="100"
-                    placeholder="60"
-                    class="block w-full mt-1"
-                    autocomplete="pecentage"
-                />
+                <div class="mt-1">
+                    <NumberField
+                        id="pecentage"
+                        v-model="form.pecentage"
+                        suffix="%"
+                        placeholder="60"
+                        class="sm:max-w-xs"
+                    />
+                </div>
                 <InputError
                     :message="form.errors.pecentage"
                     class="mt-2"
                 />
             </div>
 
-            <!-- currency (System Wide SDG) -->
-            <div class="col-span-6 sm:col-span-4">
+            <!-- Currency -->
+            <div>
                 <InputLabel
                     for="currency"
                     :value="__('Currency')"
                 />
-                <div class="flex gap-x-2 mt-1">
-                    <TextInput
+                <div class="mt-1">
+                    <CurrencySelect
                         id="currency"
                         v-model="form.currency"
-                        type="text"
-                        class="block w-full uppercase bg-surface-sunken"
-                        maxlength="3"
-                        readonly
-                        :placeholder="__('SDG')"
                     />
                 </div>
                 <InputError
@@ -225,106 +140,102 @@
                     class="mt-2"
                 />
             </div>
+        </div>
+    </SettingsSection>
 
-            <!-- Inventory strategy -->
-            <div class="col-span-6 sm:col-span-4">
-                <InputLabel :value="__('Inventory Management')" />
-                <p class="mt-1 text-sm text-secondary">
-                    {{ __("Choose how you want to manage your inventory.") }}
-                </p>
+    <!-- Inventory policy -->
+    <SettingsSection
+        id="inventory"
+        :title="__('Inventory policy')"
+        :description="__('How stock is tracked, and whether selling below zero is allowed.')"
+    >
+        <p class="text-sm text-secondary">
+            {{ __("Choose how you want to manage your inventory.") }}
+        </p>
 
-                <div class="mt-3 space-y-3">
-                    <label
-                        class="flex items-start gap-x-3 p-3 border border-line rounded-lg cursor-pointer bg-surface"
-                        :class="{ 'ring-1 ring-emerald-500/40 border-emerald-400': form.inventory_strategy === 'purchase_driven' }"
-                    >
-                        <input
-                            v-model="form.inventory_strategy"
-                            type="radio"
-                            value="purchase_driven"
-                            class="mt-0.5 text-emerald-600 border-line focus:ring-emerald-200"
-                        />
-                        <span>
-                            <span class="block text-sm font-medium text-primary">
-                                {{ __("Purchase-driven (strict)") }}
-                            </span>
-                            <span class="block text-xs text-secondary">
-                                {{ __("Stock enters only through purchase invoices. Sales are blocked when stock runs out.") }}
-                            </span>
+        <div class="mt-3 space-y-3">
+            <!-- Strict: whole card is the hit target -->
+            <label
+                class="block cursor-pointer p-4"
+                :class="cardClass(form.inventory_strategy === 'purchase_driven')"
+            >
+                <span class="flex items-start gap-x-3">
+                    <input
+                        v-model="form.inventory_strategy"
+                        type="radio"
+                        value="purchase_driven"
+                        class="mt-0.5 h-4 w-4 text-emerald-600 border-line focus:ring-emerald-200"
+                    />
+                    <span>
+                        <span class="block text-sm font-medium text-primary">
+                            {{ __("Purchase-driven (strict)") }}
                         </span>
-                    </label>
-
-                    <label
-                        class="flex items-start gap-x-3 p-3 border border-line rounded-lg cursor-pointer bg-surface"
-                        :class="{ 'ring-1 ring-emerald-500/40 border-emerald-400': form.inventory_strategy === 'free_form' }"
-                    >
-                        <input
-                            v-model="form.inventory_strategy"
-                            type="radio"
-                            value="free_form"
-                            class="mt-0.5 text-emerald-600 border-line focus:ring-emerald-200"
-                        />
-                        <span>
-                            <span class="block text-sm font-medium text-primary">
-                                {{ __("Free-form (flexible)") }}
-                            </span>
-                            <span class="block text-xs text-secondary">
-                                {{ __("Adjust quantities freely without purchase invoices.") }}
-                            </span>
+                        <span class="block text-xs text-secondary">
+                            {{ __("Stock enters only through purchase invoices. Sales are blocked when stock runs out.") }}
                         </span>
-                    </label>
-                </div>
+                    </span>
+                </span>
+            </label>
 
-                <!-- Overselling toggle: only meaningful under free-form -->
-                <div
-                    v-if="form.inventory_strategy === 'free_form'"
-                    class="flex items-center mt-4 cursor-pointer"
-                    @click="oversellingToggle = !oversellingToggle"
-                >
-                    <div
-                        class="relative w-10 h-5 transition duration-200 ease-linear rounded-full"
-                        :class="[oversellingToggle ? 'bg-emerald-500' : 'bg-gray-300']"
-                    >
-                        <label
-                            class="absolute left-0 w-5 h-5 mb-2 transition duration-100 ease-linear transform bg-white border-2 rounded-full cursor-pointer"
-                            :class="[
-                                oversellingToggle
-                                    ? 'translate-x-full border-emerald-500'
-                                    : 'translate-x-0 border-gray-300',
-                            ]"
-                        ></label>
-                    </div>
-                    <p class="mx-3 text-sm text-secondary">
-                        {{ __("Allow selling below zero (overselling). Negative balances are surfaced for later reconciliation.") }}
-                    </p>
-                </div>
+            <!-- Flexible: selectable header + nested overselling sub-row -->
+            <div
+                class="overflow-hidden"
+                :class="cardClass(isFlexible)"
+            >
+                <label class="flex cursor-pointer items-start gap-x-3 p-4">
+                    <input
+                        v-model="form.inventory_strategy"
+                        type="radio"
+                        value="free_form"
+                        class="mt-0.5 h-4 w-4 text-emerald-600 border-line focus:ring-emerald-200"
+                    />
+                    <span>
+                        <span class="block text-sm font-medium text-primary">
+                            {{ __("Free-form (flexible)") }}
+                        </span>
+                        <span class="block text-xs text-secondary">
+                            {{ __("Adjust quantities freely without purchase invoices.") }}
+                        </span>
+                    </span>
+                </label>
 
-                <InputError
-                    :message="form.errors.inventory_strategy"
-                    class="mt-2"
-                />
-                <InputError
-                    :message="form.errors.allow_overselling"
-                    class="mt-2"
-                />
+                <!-- Nested: only meaningful under flexible. Kept mounted (muted +
+                     disabled) under strict to avoid a layout jump. -->
+                <div class="border-t border-line bg-surface-sunken px-4 py-3">
+                    <ToggleField
+                        v-model="form.allow_overselling"
+                        :disabled="!isFlexible"
+                        :label="__('Allow overselling')"
+                        :description="__('Allow selling below zero (overselling). Negative balances are surfaced for later reconciliation.')"
+                    />
+                </div>
             </div>
-        </template>
+        </div>
 
-        <template #actions>
-            <ActionMessage
-                :on="form.recentlySuccessful"
-                class="mr-3"
-            >
-                {{ __("Saved.") }}
-            </ActionMessage>
+        <InputError
+            :message="form.errors.inventory_strategy"
+            class="mt-2"
+        />
+        <InputError
+            :message="form.errors.allow_overselling"
+            class="mt-2"
+        />
+    </SettingsSection>
 
-            <PrimaryButton
-                type="submit"
-                :class="{ 'opacity-25': form.processing }"
-                :disabled="form.processing"
-            >
-                {{ __("Save") }}
-            </PrimaryButton>
-        </template>
-    </FormSection>
+    <!-- Notifications -->
+    <SettingsSection
+        id="notifications"
+        :title="__('Notifications')"
+        :description="__('Alerts sent to keep you informed about your inventory.')"
+    >
+        <ToggleField
+            v-model="form.alerts"
+            :label="__('Alerts')"
+            :description="__('Send Notifications When Stocks Running Out')"
+        />
+        <InputError
+            :message="form.errors.alerts"
+            class="mt-2"
+        />
+    </SettingsSection>
 </template>

--- a/resources/js/Pages/Preferences/Show.vue
+++ b/resources/js/Pages/Preferences/Show.vue
@@ -1,25 +1,120 @@
 <script setup>
-    import AppLayout from "@/Layouts/AppLayout.vue";
-    import UpdateApplicationInformationForm from "@/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue";
     import { provide } from "vue";
+    import { useForm } from "@inertiajs/vue3";
+    import AppLayout from "@/Layouts/AppLayout.vue";
+    import SettingsLayout from "@/Layouts/SettingsLayout.vue";
+    import UpdateApplicationInformationForm from "@/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue";
+    import ActionMessage from "@/Components/ActionMessage.vue";
+    import PrimaryButton from "@/Components/PrimaryButton.vue";
+
     const props = defineProps({
         preferences: {
             type: Object,
         },
     });
+
     provide("preferences", props.preferences);
+
+    const truthy = (value) => [true, 1, "1", "true"].includes(value);
+
+    // Provided to the fields partial so it can bind to the shared form without
+    // mutating a prop (the page keeps ownership for the header Save + dirty state).
+
+    // Form ownership lives at the page level so the Save action can render in
+    // the sticky header (out of the page body entirely) while the fields stay
+    // in the content column.
+    const form = useForm({
+        // Null until a new file is picked, so an unchanged save never re-POSTs
+        // the stored path (which would fail the `image` rule); the action's
+        // null-skip then preserves the existing logo.
+        logo: null,
+        invoicesHeadline: preferences("invoicesHeadline"),
+        alerts: truthy(preferences("alerts", true)),
+        currency: preferences("currency", "SDG"),
+        pecentage: preferences("pecentage", 60),
+        inventory_strategy: preferences("inventory_strategy", "purchase_driven"),
+        allow_overselling: truthy(preferences("allow_overselling", false)),
+    });
+
+    provide("settingsForm", form);
+
+    const save = () => {
+        // allow_overselling only applies under free-form; purchase-driven always blocks.
+        if (form.inventory_strategy !== "free_form") {
+            form.allow_overselling = false;
+        }
+
+        form.post(route("preferences.update"), {
+            preserveScroll: true,
+            // Rebase the dirty baseline onto the saved values so the header's
+            // "unsaved changes" indicator clears after a successful save.
+            onSuccess: () => form.defaults(),
+        });
+    };
+
+    // Section anchors — the nav targets become the <SettingsSection> cards in Phase 2.
+    const sections = [
+        { id: "identity", label: __("Identity") },
+        { id: "pricing", label: __("Pricing & currency") },
+        { id: "inventory", label: __("Inventory policy") },
+        { id: "notifications", label: __("Notifications") },
+    ];
 </script>
 
 <template>
     <AppLayout :title="__('Organization Settings')">
-        <template #header>
-            <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-white">
-                {{ __("Organization Settings") }}
-            </h2>
-        </template>
+        <form @submit.prevent="save">
+            <SettingsLayout
+                :title="__('Organization Settings')"
+                :subtitle="__('Update your Application information and Basic Data')"
+            >
+                <template #header-actions>
+                    <ActionMessage :on="form.recentlySuccessful">
+                        {{ __("Saved.") }}
+                    </ActionMessage>
 
-        <div>
-            <UpdateApplicationInformationForm />
-        </div>
+                    <!-- Dirty indicator: only while there are unsaved edits. -->
+                    <span
+                        v-if="form.isDirty"
+                        class="inline-flex items-center gap-x-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                    >
+                        <span class="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                        {{ __("Unsaved changes") }}
+                    </span>
+
+                    <!-- Muted-looking when there's nothing to save, but still
+                         clickable; only hard-disabled while a save is in flight. -->
+                    <PrimaryButton
+                        type="submit"
+                        :class="{
+                            'opacity-25': form.processing,
+                            'opacity-50': !form.isDirty && !form.processing,
+                        }"
+                        :disabled="form.processing"
+                    >
+                        {{ __("Save") }}
+                    </PrimaryButton>
+                </template>
+
+                <!-- Section navigation (anchors wired to real sections in Phase 2). -->
+                <template #nav>
+                    <nav
+                        class="flex gap-1 overflow-x-auto lg:flex-col lg:overflow-visible"
+                    >
+                        <a
+                            v-for="section in sections"
+                            :key="section.id"
+                            :href="`#${section.id}`"
+                            class="shrink-0 rounded-lg px-3 py-2 text-sm text-secondary transition-colors duration-200 hover:bg-surface-sunken hover:text-primary"
+                        >
+                            {{ section.label }}
+                        </a>
+                    </nav>
+                </template>
+
+                <!-- Fields read the shared form via inject("settingsForm"). -->
+                <UpdateApplicationInformationForm />
+            </SettingsLayout>
+        </form>
     </AppLayout>
 </template>

--- a/tests/Feature/Preferences/NormalizeCurrencyMigrationTest.php
+++ b/tests/Feature/Preferences/NormalizeCurrencyMigrationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\Preference;
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Re-run the data migration's up() against seeded rows. Under RefreshDatabase
+ * the migration first runs on an empty table, so we invoke it explicitly here
+ * to exercise the normalisation logic.
+ */
+function runCurrencyNormalization(): void
+{
+    $migration = require database_path(
+        'migrations/2026_07_13_134448_normalize_currency_preference_value.php'
+    );
+
+    $migration->up();
+}
+
+function makeTenant(string $slug): Tenant
+{
+    return Tenant::create(['name' => $slug, 'slug' => $slug, 'is_active' => true]);
+}
+
+test('it upper-cases and trims stored currency codes', function () {
+    $one = makeTenant('one');
+    $two = makeTenant('two');
+    Preference::create(['tenant_id' => $one->id, 'key' => 'currency', 'value' => 'usd']);
+    Preference::create(['tenant_id' => $two->id, 'key' => 'currency', 'value' => ' eur ']);
+
+    runCurrencyNormalization();
+
+    expect(DB::table('preferences')->where('tenant_id', $one->id)->value('value'))->toBe('USD');
+    expect(DB::table('preferences')->where('tenant_id', $two->id)->value('value'))->toBe('EUR');
+});
+
+test('it falls back to SDG for blank or non three-letter values', function () {
+    $blank = makeTenant('blank');
+    $null = makeTenant('null');
+    $long = makeTenant('long');
+    Preference::create(['tenant_id' => $blank->id, 'key' => 'currency', 'value' => '']);
+    Preference::create(['tenant_id' => $null->id, 'key' => 'currency', 'value' => null]);
+    Preference::create(['tenant_id' => $long->id, 'key' => 'currency', 'value' => 'DOLLARS']);
+
+    runCurrencyNormalization();
+
+    expect(DB::table('preferences')->where('tenant_id', $blank->id)->value('value'))->toBe('SDG');
+    expect(DB::table('preferences')->where('tenant_id', $null->id)->value('value'))->toBe('SDG');
+    expect(DB::table('preferences')->where('tenant_id', $long->id)->value('value'))->toBe('SDG');
+});
+
+test('it leaves valid three-letter codes untouched', function () {
+    $tenant = makeTenant('valid');
+    Preference::create(['tenant_id' => $tenant->id, 'key' => 'currency', 'value' => 'SDG']);
+
+    runCurrencyNormalization();
+
+    expect(DB::table('preferences')->where('tenant_id', $tenant->id)->value('value'))->toBe('SDG');
+});
+
+test('it ignores preferences other than currency', function () {
+    $tenant = makeTenant('other');
+    Preference::create(['tenant_id' => $tenant->id, 'key' => 'invoicesHeadline', 'value' => 'my shop']);
+
+    runCurrencyNormalization();
+
+    expect(DB::table('preferences')->where('key', 'invoicesHeadline')->value('value'))->toBe('my shop');
+});


### PR DESCRIPTION
## Summary

Redesigns the **Organization Settings** page (`Preferences/Show.vue`) from a single flat card of nine stacked controls into a proper settings layout: a sticky header, a section nav, and four concern-scoped cards — Arabic RTL and dark-first throughout.

## What changed

**Page shell**
- New `Layouts/SettingsLayout.vue`: header and body share **one** max-width container (fixing the floating header). Sticky header holds title/subtitle on the start side and **Save + a dirty indicator** on the end side. Body is a `150px` nav + fluid content grid that collapses to one column below `lg`.
- Form ownership moves up to the page and is shared via `provide`/`inject`, so **Save leaves the page body entirely**.

**Section cards**
- New `Components/SettingsSection.vue`: reusable anchored card (`title`, `description`, slot). The one card becomes four — Identity, Pricing & currency, Inventory policy, Notifications — wired to the section nav.

**Field primitives**
- `ToggleField` — switch beside its label on a width-capped row (not flung to the edge); knob slides with logical RTL-aware translate.
- `NumberField` — `type=text inputmode=decimal` kills the native spinner (mis-renders in RTL); text input + `%` addon with logical corner radius.
- `CurrencySelect` — real `<select>` over an ISO 4217 list; labels localized via `Intl.DisplayNames` (no new i18n keys). Currency was previously a read-only free-text field.
- `LogoUploader` — real preview + placeholder-icon fallback + format/size hint (replaces the broken-`<img>`-alt preview).

**Inventory policy**
- Fully-clickable radio **cards** (`<label>` wraps the input). Selected card gets a 2px accent via `ring-1 ring-inset` (no layout shift). The **overselling toggle is nested inside the flexible card** in a tinted sub-row; under strict it's disabled + muted but **stays mounted** (no jump), and a watcher resets it on switch.

**Dirty state + save**
- Save is muted-but-clickable when clean, hard-disabled only while processing; dirty badge shows only when `form.isDirty` and clears on success via `form.defaults()`.

## Backend
- Data migration `normalize_currency_preference_value` — upper/trim the stored `currency` preference, `SDG` fallback for blank/non-3-letter values, across every tenant row. Covered by `tests/Feature/Preferences/NormalizeCurrencyMigrationTest.php`.
- **Bug fix:** initialize `form.logo = null` so an unchanged save no longer re-POSTs the stored logo path and trips the `image` validation rule; the update action's null-skip preserves the existing logo.
- No other backend/validation changes.

## Notes
- Logical Tailwind properties (`ps/pe/ms/me/start/end`) and existing semantic tokens (`surface`/`line`/`primary`/`secondary`) throughout; dark mode via the OS media query. No `dir` attributes touched, no new dependencies.
- New user-facing strings use `__()` with English keys (per direction during review); currency names are localized at runtime, so no per-currency keys were added.

## Testing
- `php artisan test` — preference, inventory, and new migration suites pass.
- ESLint + Vite build clean.