### PR TITLE
feat: Service product type & bookings (v1)

### DIFF
--- a/app/Actions/Bookings/CreateBookingAction.php
+++ b/app/Actions/Bookings/CreateBookingAction.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Actions\Bookings;
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\ServiceAddon;
+use App\ValueObjects\Money;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+/**
+ * Creates a booking from a service, snapshotting the base price and each
+ * selected add-on's name + price delta so later re-pricing of the service or
+ * its add-ons never mutates historical bookings. This is the single choke
+ * point for booking creation; the stored `total` is computed here once.
+ */
+class CreateBookingAction
+{
+    /**
+     * @param  array<int>  $addonIds  ids of the service's own add-ons to snapshot
+     *
+     * @throws InvalidArgumentException when an add-on id does not belong to the service
+     */
+    public function handle(
+        Product $service,
+        Customer $customer,
+        CarbonInterface $startsAt,
+        array $addonIds = [],
+        ?string $address = null,
+        ?string $notes = null,
+        BookingStatus $status = BookingStatus::Confirmed,
+    ): Booking {
+        return DB::transaction(function () use ($service, $customer, $startsAt, $addonIds, $address, $notes, $status) {
+            $addons = $this->resolveAddons($service, $addonIds);
+
+            $total = Money::fromMajor($service->price ?? 0);
+            foreach ($addons as $addon) {
+                $total = $total->add(Money::fromMajor($addon->price_delta ?? 0));
+            }
+
+            $booking = new Booking([
+                'service_product_id' => $service->id,
+                'customer_id' => $customer->id,
+                'starts_at' => $startsAt,
+                'status' => $status,
+                'address' => $address,
+                'notes' => $notes,
+                'base_price' => $service->price ?? 0,
+                'total' => $total->major(),
+            ]);
+            $booking->setRelation('service', $service);
+            $booking->save();
+
+            foreach ($addons as $addon) {
+                $booking->addons()->create([
+                    'service_addon_id' => $addon->id,
+                    'name' => $addon->name,
+                    'price_delta' => $addon->price_delta,
+                ]);
+            }
+
+            return $booking->load('addons');
+        });
+    }
+
+    /**
+     * Load the requested add-ons scoped to the service, rejecting any id that
+     * does not belong to it (cross-service / cross-tenant guard).
+     *
+     * @param  array<int>  $addonIds
+     * @return Collection<int, ServiceAddon>
+     */
+    private function resolveAddons(Product $service, array $addonIds)
+    {
+        $addonIds = array_values(array_unique($addonIds));
+
+        if ($addonIds === []) {
+            return $service->serviceAddons()->whereRaw('1 = 0')->get();
+        }
+
+        $addons = $service->serviceAddons()->whereKey($addonIds)->get();
+
+        if ($addons->count() !== count($addonIds)) {
+            throw new InvalidArgumentException('One or more add-ons do not belong to the selected service.');
+        }
+
+        return $addons;
+    }
+}

--- a/app/Actions/Bookings/SyncServiceAddonsAction.php
+++ b/app/Actions/Bookings/SyncServiceAddonsAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions\Bookings;
+
+use App\Models\Product;
+
+/**
+ * Reconciles a service product's add-ons with the submitted list: existing
+ * rows are updated, new rows created, and omitted rows soft-deleted. Historical
+ * booking snapshots (`booking_addons`) are untouched — they hold their own
+ * copies, so removing a source add-on never mutates a past booking.
+ */
+class SyncServiceAddonsAction
+{
+    /**
+     * @param  array<int, array{id?: int|null, name: string, price_delta: numeric}>  $addons
+     */
+    public function handle(Product $service, array $addons): void
+    {
+        $keptIds = [];
+
+        foreach ($addons as $row) {
+            if (empty($row['name'])) {
+                continue;
+            }
+
+            $addon = $service->serviceAddons()->updateOrCreate(
+                ['id' => $row['id'] ?? null],
+                ['name' => $row['name'], 'price_delta' => $row['price_delta'] ?? 0],
+            );
+
+            $keptIds[] = $addon->id;
+        }
+
+        $service->serviceAddons()->whereNotIn('id', $keptIds)->delete();
+    }
+}

--- a/app/Actions/Stock/DeliverTransactionAction.php
+++ b/app/Actions/Stock/DeliverTransactionAction.php
@@ -14,14 +14,17 @@ class DeliverTransactionAction
         DB::transaction(function () use ($transaction, $actor, $fromStorage) {
             $storage = $fromStorage ?? $transaction->storage;
 
-            // Deduct stock
-            $storage->deductStock(
-                product: $transaction->product_id,
-                quantity: (int) $transaction->base_quantity,
-                reason: 'sale_delivery',
-                movable: $transaction,
-                actor: $actor
-            );
+            // Services carry no stock — they sell as line items with no ledger
+            // movement. Only physical goods deduct on delivery.
+            if (! $transaction->product?->isService()) {
+                $storage->deductStock(
+                    product: $transaction->product_id,
+                    quantity: (int) $transaction->base_quantity,
+                    reason: 'sale_delivery',
+                    movable: $transaction,
+                    actor: $actor
+                );
+            }
 
             // Mark as delivered
             $transaction->deliver($actor, $storage);

--- a/app/Enums/BookingStatus.php
+++ b/app/Enums/BookingStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum BookingStatus: string
+{
+    case Confirmed = 'confirmed';
+    case Cancelled = 'cancelled';
+    case Completed = 'completed';
+
+    /**
+     * Human-readable label (localize at the call site via __()).
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Confirmed => 'Confirmed',
+            self::Cancelled => 'Cancelled',
+            self::Completed => 'Completed',
+        };
+    }
+}

--- a/app/Enums/ProductType.php
+++ b/app/Enums/ProductType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Enums;
+
+enum ProductType: string
+{
+    case Physical = 'physical';
+    case Service = 'service';
+
+    /**
+     * Human-readable label (localize at the call site via __()).
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Physical => 'Physical',
+            self::Service => 'Service',
+        };
+    }
+}

--- a/app/Exceptions/BookingOverlapException.php
+++ b/app/Exceptions/BookingOverlapException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Models\Booking;
+use Exception;
+use Illuminate\Support\Collection;
+
+/**
+ * Thrown when a new/edited booking's time range overlaps an existing confirmed
+ * booking of the same service and the service does not permit overlaps. This is
+ * a hard block — the caller must not persist the booking.
+ */
+class BookingOverlapException extends Exception
+{
+    /**
+     * @param  Collection<int, Booking>  $conflicts
+     */
+    public function __construct(public Collection $conflicts)
+    {
+        parent::__construct('The selected time overlaps an existing booking for this service.');
+    }
+}

--- a/app/Filters/ProductFilter.php
+++ b/app/Filters/ProductFilter.php
@@ -6,11 +6,16 @@ use App\ValueObjects\Money;
 
 class ProductFilter extends Filters
 {
-    protected $filters = ['search', 'status', 'category', 'min_cost', 'max_cost', 'expire_from', 'expire_to'];
+    protected $filters = ['search', 'status', 'type', 'category', 'min_cost', 'max_cost', 'expire_from', 'expire_to'];
 
     public function search($searchTerm)
     {
         return $this->builder->search($searchTerm);
+    }
+
+    public function type($type)
+    {
+        return $this->builder->where('type', $type);
     }
 
     public function status($status)

--- a/app/Http/Controllers/Api/ProductsController.php
+++ b/app/Http/Controllers/Api/ProductsController.php
@@ -14,6 +14,7 @@ class ProductsController extends Controller
         $products = Product::query()
             ->with('units')
             ->when($request->filled('type'), fn ($query) => $query->where('type', $request->get('type')))
+            ->when($request->get('type') === 'service', fn ($query) => $query->with('serviceAddons'))
             ->search($request->get('search'))
             ->latest()
             ->simplePaginate(20);

--- a/app/Http/Controllers/Api/ProductsController.php
+++ b/app/Http/Controllers/Api/ProductsController.php
@@ -15,6 +15,9 @@ class ProductsController extends Controller
             ->with('units')
             ->when($request->filled('type'), fn ($query) => $query->where('type', $request->get('type')))
             ->when($request->get('type') === 'service', fn ($query) => $query->with('serviceAddons'))
+            // Line-sale pickers (invoices, quotes) exclude bookable services;
+            // those are booked, not line-sold.
+            ->when($request->boolean('line_sale'), fn ($query) => $query->sellableAsLineItem())
             ->search($request->get('search'))
             ->latest()
             ->simplePaginate(20);

--- a/app/Http/Controllers/Api/ProductsController.php
+++ b/app/Http/Controllers/Api/ProductsController.php
@@ -13,6 +13,7 @@ class ProductsController extends Controller
     {
         $products = Product::query()
             ->with('units')
+            ->when($request->filled('type'), fn ($query) => $query->where('type', $request->get('type')))
             ->search($request->get('search'))
             ->latest()
             ->simplePaginate(20);

--- a/app/Http/Controllers/BookingsController.php
+++ b/app/Http/Controllers/BookingsController.php
@@ -27,7 +27,7 @@ class BookingsController extends Controller
     {
         return inertia('Bookings/Index', [
             'bookings' => Booking::query()
-                ->with(['service:id,name,duration_minutes,on_site', 'customer:id,name', 'addons'])
+                ->with(['service:id,name,duration_minutes,on_site,price', 'service.serviceAddons', 'customer:id,name', 'addons'])
                 ->orderByDesc('starts_at')
                 ->paginate(parent::ELEMENTS_PER_PAGE)
                 ->withQueryString(),

--- a/app/Http/Controllers/BookingsController.php
+++ b/app/Http/Controllers/BookingsController.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\Bookings\CreateBookingAction;
+use App\Enums\BookingStatus;
+use App\Exceptions\BookingOverlapException;
+use App\Http\Requests\BookingRequest;
+use App\Models\Booking;
+use App\Models\Customer;
+use App\Models\Product;
+use App\Services\Bookings\BookingScheduler;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\ValidationException;
+
+class BookingsController extends Controller
+{
+    public function __construct(
+        private BookingScheduler $scheduler,
+        private CreateBookingAction $createBooking,
+    ) {}
+
+    public function index()
+    {
+        return inertia('Bookings/Index', [
+            'bookings' => Booking::query()
+                ->with(['service:id,name,duration_minutes,on_site', 'customer:id,name', 'addons'])
+                ->orderByDesc('starts_at')
+                ->paginate(parent::ELEMENTS_PER_PAGE)
+                ->withQueryString(),
+        ]);
+    }
+
+    public function store(BookingRequest $request): RedirectResponse
+    {
+        $service = Product::findOrFail($request->integer('service_product_id'));
+        $customer = Customer::findOrFail($request->integer('customer_id'));
+
+        $warnings = $this->guardSchedule($request, $service);
+
+        if ($warnings !== null) {
+            return back()->with('travel_buffer_warnings', $warnings);
+        }
+
+        $this->createBooking->handle(
+            service: $service,
+            customer: $customer,
+            startsAt: Carbon::parse($request->input('starts_at')),
+            addonIds: $request->input('addons', []),
+            address: $request->input('address'),
+            notes: $request->input('notes'),
+            status: $request->enum('status', BookingStatus::class) ?? BookingStatus::Confirmed,
+        );
+
+        return redirect()->route('bookings.index')->with('success', __('Booking created successfully.'));
+    }
+
+    public function update(Booking $booking, BookingRequest $request): RedirectResponse
+    {
+        $service = Product::findOrFail($request->integer('service_product_id'));
+
+        $warnings = $this->guardSchedule($request, $service, ignoreId: $booking->id);
+
+        if ($warnings !== null) {
+            return back()->with('travel_buffer_warnings', $warnings);
+        }
+
+        $booking->update([
+            'service_product_id' => $service->id,
+            'customer_id' => $request->integer('customer_id'),
+            'starts_at' => Carbon::parse($request->input('starts_at')),
+            'address' => $request->input('address'),
+            'notes' => $request->input('notes'),
+            'status' => $request->enum('status', BookingStatus::class) ?? $booking->status,
+        ]);
+
+        $this->resnapshotAddons($booking, $service, $request->input('addons', []));
+
+        return redirect()->route('bookings.index')->with('success', __('Booking updated successfully.'));
+    }
+
+    /**
+     * Merchant-only cancellation. Frees the slot immediately for rebooking.
+     */
+    public function cancel(Booking $booking): RedirectResponse
+    {
+        $booking->update(['status' => BookingStatus::Cancelled]);
+
+        return back()->with('success', __('Booking cancelled.'));
+    }
+
+    /**
+     * Run the scheduling engine: hard-block on overlap (422), otherwise return
+     * the unacknowledged travel-buffer warnings for the UI to confirm, or null
+     * when the placement is clear or the warnings were acknowledged.
+     *
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function guardSchedule(BookingRequest $request, Product $service, ?int $ignoreId = null): ?array
+    {
+        $candidate = new Booking([
+            'service_product_id' => $service->id,
+            'starts_at' => Carbon::parse($request->input('starts_at')),
+        ]);
+        $candidate->setRelation('service', $service);
+
+        try {
+            $warnings = $this->scheduler->assertBookable($candidate, $ignoreId);
+        } catch (BookingOverlapException $e) {
+            throw ValidationException::withMessages([
+                'starts_at' => __('The selected time overlaps an existing booking for this service.'),
+            ]);
+        }
+
+        if ($warnings !== [] && ! $request->boolean('acknowledge_buffer')) {
+            return array_map(fn ($warning) => $warning->jsonSerialize(), $warnings);
+        }
+
+        return null;
+    }
+
+    /**
+     * Replace the booking's add-on snapshots with the currently-selected ones
+     * and recompute the stored total (base price stays the original snapshot).
+     *
+     * @param  array<int>  $addonIds
+     */
+    private function resnapshotAddons(Booking $booking, Product $service, array $addonIds): void
+    {
+        $booking->addons()->delete();
+
+        $addons = $service->serviceAddons()->whereKey($addonIds)->get();
+        $total = $booking->base_price;
+
+        foreach ($addons as $addon) {
+            $booking->addons()->create([
+                'service_addon_id' => $addon->id,
+                'name' => $addon->name,
+                'price_delta' => $addon->price_delta,
+            ]);
+            $total += $addon->price_delta;
+        }
+
+        $booking->update(['total' => $total]);
+    }
+}

--- a/app/Http/Controllers/BookingsController.php
+++ b/app/Http/Controllers/BookingsController.php
@@ -9,9 +9,11 @@ use App\Http\Requests\BookingRequest;
 use App\Models\Booking;
 use App\Models\Customer;
 use App\Models\Product;
+use App\Notifications\BookingCancelledNotification;
 use App\Services\Bookings\BookingScheduler;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
 
 class BookingsController extends Controller
@@ -86,6 +88,9 @@ class BookingsController extends Controller
     public function cancel(Booking $booking): RedirectResponse
     {
         $booking->update(['status' => BookingStatus::Cancelled]);
+
+        $recipients = app('currentTenant')->merchantUsers();
+        Notification::send($recipients, new BookingCancelledNotification($booking->load(['service', 'customer'])));
 
         return back()->with('success', __('Booking cancelled.'));
     }

--- a/app/Http/Controllers/Catalog/ProductsController.php
+++ b/app/Http/Controllers/Catalog/ProductsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Catalog;
 
+use App\Actions\Bookings\SyncServiceAddonsAction;
 use App\Actions\Stock\RecordAdjustmentAction;
 use App\Actions\SyncCategoriesAction;
 use App\Exceptions\ManualStockIncreaseNotAllowedException;
@@ -54,25 +55,29 @@ class ProductsController extends Controller
         ]);
     }
 
-    public function store(ProductRequest $request, SyncCategoriesAction $syncCategoriesAction, RecordAdjustmentAction $recordAdjustment)
+    public function store(ProductRequest $request, SyncCategoriesAction $syncCategoriesAction, RecordAdjustmentAction $recordAdjustment, SyncServiceAddonsAction $syncServiceAddons)
     {
         $this->authorize('create', Product::class);
 
         try {
-            DB::transaction(function () use ($request, $syncCategoriesAction, $recordAdjustment) {
-                $product = Product::create($request->safe()->except(['units', 'categories', 'quantities']));
+            DB::transaction(function () use ($request, $syncCategoriesAction, $recordAdjustment, $syncServiceAddons) {
+                $product = Product::create($request->safe()->except(['units', 'categories', 'quantities', 'addons']));
 
-                $units = $request->get('units');
-
-                if (empty($units)) {
-                    $product->units()->create(['name' => __('Base Unit'), 'conversion_factor' => 1]);
+                if ($product->isService()) {
+                    $syncServiceAddons->handle($product, $request->get('addons', []));
                 } else {
-                    $product->syncUnits($units);
+                    $units = $request->get('units');
+
+                    if (empty($units)) {
+                        $product->units()->create(['name' => __('Base Unit'), 'conversion_factor' => 1]);
+                    } else {
+                        $product->syncUnits($units);
+                    }
+
+                    $this->syncOnHandQuantities($product, $request, $recordAdjustment);
                 }
 
-                $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
-
-                $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+                $syncCategoriesAction->handle($product, $request->get('categories') ?? [], 'product');
             });
         } catch (ManualStockIncreaseNotAllowedException $e) {
             return redirect()->route('products.index')->with('error', $e->getMessage());
@@ -90,19 +95,23 @@ class ProductsController extends Controller
         return back()->with('success', __('Product updated successfully'));
     }
 
-    public function update(Product $product, ProductRequest $request, SyncCategoriesAction $syncCategoriesAction, RecordAdjustmentAction $recordAdjustment)
+    public function update(Product $product, ProductRequest $request, SyncCategoriesAction $syncCategoriesAction, RecordAdjustmentAction $recordAdjustment, SyncServiceAddonsAction $syncServiceAddons)
     {
         $this->authorize('update', $product);
 
         try {
-            DB::transaction(function () use ($product, $request, $syncCategoriesAction, $recordAdjustment) {
-                $product->update($request->safe()->except(['units', 'categories', 'quantities']));
+            DB::transaction(function () use ($product, $request, $syncCategoriesAction, $recordAdjustment, $syncServiceAddons) {
+                $product->update($request->safe()->except(['units', 'categories', 'quantities', 'addons']));
 
-                $product->syncUnits($request->get('units'));
+                if ($product->isService()) {
+                    $syncServiceAddons->handle($product, $request->get('addons', []));
+                } else {
+                    $product->syncUnits($request->get('units'));
 
-                $syncCategoriesAction->handle($product, $request->get('categories'), 'product');
+                    $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+                }
 
-                $this->syncOnHandQuantities($product, $request, $recordAdjustment);
+                $syncCategoriesAction->handle($product, $request->get('categories') ?? [], 'product');
             });
         } catch (ManualStockIncreaseNotAllowedException $e) {
             return back()->with('error', $e->getMessage());

--- a/app/Http/Controllers/Sales/PosSessionController.php
+++ b/app/Http/Controllers/Sales/PosSessionController.php
@@ -40,6 +40,7 @@ class PosSessionController extends Controller
         }
 
         $products = Product::with('units')
+            ->sellableAsLineItem() // bookable services are booked, not POS-sold
             ->when(request('search'), fn ($q, $search) => $q->where('name', 'ilike', "%{$search}%"))
             ->leftJoin('stocks', function ($join) use ($storage) {
                 $join->on('stocks.product_id', '=', 'products.id')
@@ -136,6 +137,7 @@ class PosSessionController extends Controller
         }
 
         $products = Product::with('units')
+            ->sellableAsLineItem() // bookable services are booked, not POS-sold
             ->whereIn('products.id', $orderedProductIds)
             ->leftJoin('stocks', function ($join) use ($storage) {
                 $join->on('stocks.product_id', '=', 'products.id')

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -77,6 +77,7 @@ class HandleInertiaRequests extends Middleware
                 'success' => session()->get('success'),
                 'error' => session()->get('error'),
                 'response' => session()->get('response'),
+                'travel_buffer_warnings' => session()->get('travel_buffer_warnings'),
             ],
             'isSuperAdmin' => fn () => Auth::guard('admin')->check(),
             'isImpersonating' => fn () => (bool) session('impersonating_from'),

--- a/app/Http/Requests/BookingRequest.php
+++ b/app/Http/Requests/BookingRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\BookingStatus;
+use App\Enums\ProductType;
+use App\Models\Product;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+
+class BookingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'customer_id' => ['required', Rule::exists('customers', 'id')],
+            'service_product_id' => ['required', Rule::exists('products', 'id')->where('type', ProductType::Service->value)],
+            'starts_at' => ['required', 'date'],
+            'address' => ['nullable', 'string'],
+            'notes' => ['nullable', 'string'],
+            'status' => ['nullable', new Enum(BookingStatus::class)],
+            'addons' => ['nullable', 'array'],
+            'addons.*' => ['integer'],
+            'acknowledge_buffer' => ['nullable', 'boolean'],
+        ];
+    }
+
+    /**
+     * Rules that depend on the selected service: it must be bookable, and an
+     * on-site service requires an address.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $service = Product::find($this->input('service_product_id'));
+
+            if (! $service) {
+                return;
+            }
+
+            if (! $service->requires_booking) {
+                $validator->errors()->add('service_product_id', __('This service is not bookable.'));
+            }
+
+            if ($service->on_site && blank($this->input('address'))) {
+                $validator->errors()->add('address', __('An address is required for on-site services.'));
+            }
+        });
+    }
+}

--- a/app/Http/Requests/ProductRequest.php
+++ b/app/Http/Requests/ProductRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests;
 
+use App\Enums\ProductType;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
 
 class ProductRequest extends FormRequest
 {
@@ -16,13 +18,51 @@ class ProductRequest extends FormRequest
     }
 
     /**
+     * Normalise the service flags to real booleans before validation.
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->isService()) {
+            $this->merge([
+                'requires_booking' => $this->boolean('requires_booking'),
+                'on_site' => $this->boolean('on_site'),
+                'allow_overlap' => $this->boolean('allow_overlap'),
+            ]);
+        }
+    }
+
+    /**
      * Get the validation rules that apply to the request.
+     *
+     * Services are priced by their base price (no `cost > 0` requirement) and
+     * carry their own attributes; physical products keep exactly today's rules.
      *
      * @return array<string, Rule|array|string>
      */
     public function rules(): array
     {
+        if ($this->isService()) {
+            return [
+                'type' => [new Enum(ProductType::class)],
+                'name' => 'required',
+                'price' => 'required|numeric|min:0',
+                'currency' => 'nullable|string|max:3',
+                'duration_minutes' => 'nullable|integer|min:1',
+                'requires_booking' => 'boolean',
+                'on_site' => 'boolean',
+                'allow_overlap' => 'boolean',
+                'travel_buffer_minutes' => 'nullable|integer|min:0',
+                'addons' => 'nullable|array',
+                'addons.*.name' => 'required_with:addons',
+                'addons.*.price_delta' => 'required_with:addons|numeric|min:0',
+                'categories' => 'nullable|array',
+                'categories.*.id' => 'required',
+                'categories.*.name' => 'required',
+            ];
+        }
+
         return [
+            'type' => ['nullable', 'in:'.ProductType::Physical->value],
             'name' => 'required',
             'cost' => 'required|numeric|gt:0',
             'price' => 'nullable|numeric|min:0',
@@ -39,5 +79,33 @@ class ProductRequest extends FormRequest
             'categories.*.id' => 'required',
             'categories.*.name' => 'required',
         ];
+    }
+
+    /**
+     * Conditionally require the scheduling attributes only where they matter:
+     * a bookable service needs a positive duration, and an on-site service
+     * needs a travel buffer.
+     */
+    public function withValidator($validator): void
+    {
+        $validator->sometimes(
+            'duration_minutes',
+            'required|integer|min:1',
+            fn () => $this->isService() && $this->boolean('requires_booking'),
+        );
+
+        $validator->sometimes(
+            'travel_buffer_minutes',
+            'required|integer|min:0',
+            fn () => $this->isService() && $this->boolean('on_site'),
+        );
+    }
+
+    /**
+     * Whether this request describes a service product.
+     */
+    private function isService(): bool
+    {
+        return $this->input('type') === ProductType::Service->value;
     }
 }

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -40,6 +40,7 @@ class Booking extends BaseModel
             'status' => BookingStatus::class,
             'base_price' => MoneyCast::class,
             'total' => MoneyCast::class,
+            'reminder_sent_at' => 'datetime',
         ];
     }
 

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\MoneyCast;
+use App\Enums\BookingStatus;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Booking extends BaseModel
+{
+    use HasFactory, SoftDeletes;
+
+    protected static function booted(): void
+    {
+        parent::booted();
+
+        // Keep the persisted `ends_at` consistent with the service duration
+        // whenever the start moves (or on first save). B2 overlap detection and
+        // the B3 calendar range-scan by the stored interval.
+        static::saving(function (Booking $booking) {
+            if ($booking->isDirty('starts_at') || $booking->ends_at === null) {
+                $booking->ends_at = $booking->deriveEndsAt();
+            }
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => 'datetime',
+            'ends_at' => 'datetime',
+            'status' => BookingStatus::class,
+            'base_price' => MoneyCast::class,
+            'total' => MoneyCast::class,
+        ];
+    }
+
+    /**
+     * The service product being booked.
+     */
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Product::class, 'service_product_id');
+    }
+
+    /**
+     * The customer the booking is for.
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    /**
+     * The snapshotted add-ons selected on this booking.
+     */
+    public function addons(): HasMany
+    {
+        return $this->hasMany(BookingAddon::class);
+    }
+
+    /**
+     * Derive the end instant from the start plus the service duration. Falls
+     * back to the start itself when the service has no duration (guarded so a
+     * data-layer booking never crashes; a real duration is enforced in B3).
+     */
+    public function deriveEndsAt(): Carbon
+    {
+        $start = $this->starts_at instanceof Carbon
+            ? $this->starts_at->copy()
+            : Carbon::parse($this->starts_at);
+
+        return $start->addMinutes((int) ($this->service?->duration_minutes ?? 0));
+    }
+
+    /**
+     * Scope to a given booking status.
+     */
+    public function scopeStatus(Builder $query, BookingStatus $status): Builder
+    {
+        return $query->where('status', $status);
+    }
+
+    /**
+     * Scope to confirmed bookings (the only status that constrains scheduling).
+     */
+    public function scopeConfirmed(Builder $query): Builder
+    {
+        return $query->where('status', BookingStatus::Confirmed);
+    }
+}

--- a/app/Models/BookingAddon.php
+++ b/app/Models/BookingAddon.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\MoneyCast;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BookingAddon extends BaseModel
+{
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'price_delta' => MoneyCast::class,
+        ];
+    }
+
+    /**
+     * The booking this snapshot line belongs to.
+     */
+    public function booking(): BelongsTo
+    {
+        return $this->belongsTo(Booking::class);
+    }
+
+    /**
+     * The source add-on this line was snapshotted from (nullable — nulls out if
+     * the source add-on is later deleted; the snapshot name/price remain).
+     */
+    public function serviceAddon(): BelongsTo
+    {
+        return $this->belongsTo(ServiceAddon::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\MoneyCast;
+use App\Enums\ProductType;
 use App\Queries\StockBalanceQuery;
 use App\Traits\WithTrashScope;
 use App\ValueObjects\Money;
@@ -220,7 +221,45 @@ class Product extends BaseModel
             'cost' => MoneyCast::class,
             'average_cost' => MoneyCast::class,
             'is_global_favorite' => 'boolean',
+            'type' => ProductType::class,
+            'duration_minutes' => 'integer',
+            'requires_booking' => 'boolean',
+            'on_site' => 'boolean',
+            'allow_overlap' => 'boolean',
+            'travel_buffer_minutes' => 'integer',
         ];
+    }
+
+    /**
+     * Whether this product is a bookable/sellable service (vs a physical good).
+     */
+    public function isService(): bool
+    {
+        return $this->type === ProductType::Service;
+    }
+
+    /**
+     * Scope to only service products.
+     */
+    public function scopeServices(Builder $query): Builder
+    {
+        return $query->where('type', ProductType::Service);
+    }
+
+    /**
+     * Scope to only physical products (includes every backfilled legacy row).
+     */
+    public function scopePhysical(Builder $query): Builder
+    {
+        return $query->where('type', ProductType::Physical);
+    }
+
+    /**
+     * The add-ons defined for this service.
+     */
+    public function serviceAddons(): HasMany
+    {
+        return $this->hasMany(ServiceAddon::class);
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -263,6 +263,20 @@ class Product extends BaseModel
     }
 
     /**
+     * Products that may be sold as an ordinary invoice/POS line item: every
+     * physical good, plus services that are not booking-driven (walk-in
+     * services). Bookable services are excluded — they are booked, not
+     * line-sold.
+     */
+    public function scopeSellableAsLineItem(Builder $query): Builder
+    {
+        return $query->where(function (Builder $query) {
+            $query->where('type', '!=', ProductType::Service->value)
+                ->orWhere('requires_booking', false);
+        });
+    }
+
+    /**
      * The stock details for this product.
      */
     public function stock(): BelongsToMany

--- a/app/Models/ServiceAddon.php
+++ b/app/Models/ServiceAddon.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\MoneyCast;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ServiceAddon extends BaseModel
+{
+    use HasFactory, SoftDeletes;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'price_delta' => MoneyCast::class,
+        ];
+    }
+
+    /**
+     * The service product this add-on belongs to.
+     */
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 
 class Tenant extends Model
 {
@@ -69,6 +70,17 @@ class Tenant extends Model
     public function owner(): ?User
     {
         return $this->users()->wherePivot('role', 'owner')->first();
+    }
+
+    /**
+     * The "merchant" recipients for booking notifications: the owner and every
+     * admin of the tenant. Resolved in the unbound reminder scan.
+     *
+     * @return Collection<int, User>
+     */
+    public function merchantUsers(): Collection
+    {
+        return $this->users()->wherePivotIn('role', ['owner', 'admin'])->get();
     }
 
     public function isActive(): bool

--- a/app/Notifications/BookingCancelledNotification.php
+++ b/app/Notifications/BookingCancelledNotification.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Booking;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Sent to the merchant (tenant owner + admins) when a booking is cancelled.
+ * The slot is freed immediately for rebooking.
+ *
+ * TODO(B4): add an 'sms'/'whatsapp' channel once a real gateway is wired — see
+ * BookingReminderNotification for the deferred-provider note.
+ */
+class BookingCancelledNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Booking $booking) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'broadcast'];
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return 'booking_cancelled';
+    }
+
+    public function broadcastType(): string
+    {
+        return 'booking_cancelled';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'Booking cancelled: :service',
+            'title_params' => ['service' => $this->booking->service?->name],
+            'body' => "{$this->booking->customer?->name} — {$this->booking->starts_at?->format('Y-m-d H:i')}",
+            'url' => route('bookings.index', absolute: false),
+            'meta' => [
+                'booking_id' => $this->booking->id,
+                'service' => $this->booking->service?->name,
+                'customer' => $this->booking->customer?->name,
+                'starts_at' => $this->booking->starts_at?->toIso8601String(),
+            ],
+        ];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('Booking cancelled'))
+            ->line(__('A booking has been cancelled.'))
+            ->line(__('Service: :service', ['service' => $this->booking->service?->name]))
+            ->line(__('Customer: :customer', ['customer' => $this->booking->customer?->name]))
+            ->line(__('Was scheduled for: :time', ['time' => $this->booking->starts_at?->format('Y-m-d H:i')]))
+            ->action(__('View Bookings'), route('bookings.index'));
+    }
+}

--- a/app/Notifications/BookingReminderNotification.php
+++ b/app/Notifications/BookingReminderNotification.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Booking;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Fixed 24-hour-before reminder for a confirmed booking, sent to the merchant
+ * (tenant owner + admins). Not configurable in v1.
+ *
+ * TODO(B4): add an 'sms'/'whatsapp' channel here once a real gateway is wired.
+ * No working provider exists yet — the installed laravel-notification-channels/
+ * twilio package is unused and config/services.php has a dangling `mazin_host`
+ * SMS stub (MAZIN_HOST_SMS_API_KEY / MAZIN_HOST_SENDER_ID, no keys in
+ * .env.example). Wiring it needs a channel class + `routeNotificationForSms()`
+ * on the User notifiable + env keys. Deferred to a future initiative.
+ */
+class BookingReminderNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Booking $booking) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'broadcast'];
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return 'booking_reminder';
+    }
+
+    public function broadcastType(): string
+    {
+        return 'booking_reminder';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'title' => 'Upcoming booking: :service',
+            'title_params' => ['service' => $this->booking->service?->name],
+            'body' => "{$this->booking->customer?->name} — {$this->booking->starts_at?->format('Y-m-d H:i')}",
+            'url' => route('bookings.index', absolute: false),
+            'meta' => [
+                'booking_id' => $this->booking->id,
+                'service' => $this->booking->service?->name,
+                'customer' => $this->booking->customer?->name,
+                'starts_at' => $this->booking->starts_at?->toIso8601String(),
+            ],
+        ];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('Upcoming booking reminder'))
+            ->line(__('This is a reminder for an upcoming booking.'))
+            ->line(__('Service: :service', ['service' => $this->booking->service?->name]))
+            ->line(__('Customer: :customer', ['customer' => $this->booking->customer?->name]))
+            ->line(__('Starts: :time', ['time' => $this->booking->starts_at?->format('Y-m-d H:i')]))
+            ->action(__('View Bookings'), route('bookings.index'))
+            ->line(__('Thank you for using our application!'));
+    }
+}

--- a/app/Services/Bookings/BookingScheduler.php
+++ b/app/Services/Bookings/BookingScheduler.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Bookings;
+
+use App\Exceptions\BookingOverlapException;
+use App\Models\Booking;
+use App\ValueObjects\TravelBufferWarning;
+
+/**
+ * The single seam B3 consumes: assert the hard rules (overlap) first, then
+ * return any soft travel-buffer warnings for the caller to surface. A thrown
+ * BookingOverlapException means the booking must not be saved; a non-empty
+ * return is advisory only.
+ */
+class BookingScheduler
+{
+    public function __construct(
+        private OverlapDetector $overlapDetector,
+        private TravelBufferChecker $travelBufferChecker,
+    ) {}
+
+    /**
+     * @return array<int, TravelBufferWarning>
+     *
+     * @throws BookingOverlapException
+     */
+    public function assertBookable(Booking $candidate, ?int $ignoreId = null): array
+    {
+        $this->overlapDetector->assertNoConflict($candidate, $ignoreId);
+
+        return $this->travelBufferChecker->warningsFor($candidate, $ignoreId);
+    }
+}

--- a/app/Services/Bookings/OverlapDetector.php
+++ b/app/Services/Bookings/OverlapDetector.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Services\Bookings;
+
+use App\Exceptions\BookingOverlapException;
+use App\Models\Booking;
+use App\ValueObjects\TimeRange;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * Hard-block overlap detection, scoped per-service. A candidate booking is
+ * checked only against other CONFIRMED bookings of the same service; cancelled
+ * and completed bookings never constrain placement, so cancelling a booking
+ * immediately frees its slot. When the service permits overlaps the check is a
+ * no-op.
+ */
+class OverlapDetector
+{
+    /**
+     * @throws BookingOverlapException when the candidate collides and the service disallows overlap
+     */
+    public function assertNoConflict(Booking $candidate, ?int $ignoreId = null): void
+    {
+        if ($candidate->service?->allow_overlap) {
+            return;
+        }
+
+        $conflicts = $this->conflicts($candidate, $ignoreId);
+
+        if ($conflicts->isNotEmpty()) {
+            throw new BookingOverlapException($conflicts);
+        }
+    }
+
+    /**
+     * Confirmed, same-service bookings whose stored interval overlaps the
+     * candidate under half-open semantics (`starts_at < end AND ends_at > start`),
+     * mirroring TimeRange::overlaps. `$ignoreId` excludes the row being edited.
+     *
+     * @return Collection<int, Booking>
+     */
+    public function conflicts(Booking $candidate, ?int $ignoreId = null): Collection
+    {
+        [$start, $end] = $this->interval($candidate);
+
+        return Booking::query()
+            ->confirmed()
+            ->where('service_product_id', $candidate->service_product_id)
+            ->when($ignoreId, fn ($query) => $query->whereKeyNot($ignoreId))
+            ->where('starts_at', '<', $end)
+            ->where('ends_at', '>', $start)
+            ->get();
+    }
+
+    /**
+     * Resolve the candidate's [start, end) interval, deriving the end from the
+     * service duration when the candidate has not yet been persisted.
+     *
+     * @return array{0: CarbonInterface, 1: CarbonInterface}
+     */
+    private function interval(Booking $candidate): array
+    {
+        $range = new TimeRange(
+            $candidate->starts_at,
+            $candidate->ends_at ?? $candidate->deriveEndsAt(),
+        );
+
+        return [$range->start, $range->end];
+    }
+}

--- a/app/Services/Bookings/TravelBufferChecker.php
+++ b/app/Services/Bookings/TravelBufferChecker.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Services\Bookings;
+
+use App\Models\Booking;
+use App\ValueObjects\TravelBufferWarning;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Soft travel-buffer detection for on-site services. Surfaces a warning when a
+ * neighbouring confirmed booking (preceding or following) sits closer than the
+ * service's travel buffer — both directions independently, so a booking wedged
+ * between two others can warn twice. Never throws and never blocks; the caller
+ * decides how to surface and whether to proceed.
+ */
+class TravelBufferChecker
+{
+    /**
+     * @return array<int, TravelBufferWarning>
+     */
+    public function warningsFor(Booking $candidate, ?int $ignoreId = null): array
+    {
+        $service = $candidate->service;
+
+        if (! $service?->on_site) {
+            return [];
+        }
+
+        $buffer = (int) ($service->travel_buffer_minutes ?? 0);
+
+        if ($buffer <= 0) {
+            return [];
+        }
+
+        $start = $candidate->starts_at;
+        $end = $candidate->ends_at ?? $candidate->deriveEndsAt();
+
+        $warnings = [];
+
+        $preceding = $this->baseQuery($candidate, $ignoreId)
+            ->where('ends_at', '<=', $start)
+            ->orderByDesc('ends_at')
+            ->first();
+
+        if ($preceding && ($gap = $this->minutesBetween($preceding->ends_at, $start)) < $buffer) {
+            $warnings[] = new TravelBufferWarning($preceding, $gap, $buffer, 'before');
+        }
+
+        $following = $this->baseQuery($candidate, $ignoreId)
+            ->where('starts_at', '>=', $end)
+            ->orderBy('starts_at')
+            ->first();
+
+        if ($following && ($gap = $this->minutesBetween($end, $following->starts_at)) < $buffer) {
+            $warnings[] = new TravelBufferWarning($following, $gap, $buffer, 'after');
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * @return Builder<Booking>
+     */
+    private function baseQuery(Booking $candidate, ?int $ignoreId)
+    {
+        return Booking::query()
+            ->confirmed()
+            ->where('service_product_id', $candidate->service_product_id)
+            ->when($ignoreId, fn ($query) => $query->whereKeyNot($ignoreId));
+    }
+
+    /**
+     * Whole minutes between two instants, computed on the underlying UTC
+     * timestamps so it is timezone-correct regardless of the stored wall clock.
+     */
+    private function minutesBetween(CarbonInterface $from, CarbonInterface $to): int
+    {
+        return intdiv($to->getTimestamp() - $from->getTimestamp(), 60);
+    }
+}

--- a/app/ValueObjects/TimeRange.php
+++ b/app/ValueObjects/TimeRange.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\ValueObjects;
+
+use Carbon\CarbonInterface;
+
+/**
+ * A half-open time interval [start, end). Half-open is the load-bearing choice:
+ * two bookings that exactly abut (one ends at the instant the next starts) do
+ * NOT overlap, so back-to-back scheduling is allowed. The same boundary
+ * operators (`<` end, `>` start) are mirrored by the SQL predicate in
+ * OverlapDetector; TimeRangeParity asserts the two agree.
+ */
+final class TimeRange
+{
+    public function __construct(
+        public readonly CarbonInterface $start,
+        public readonly CarbonInterface $end,
+    ) {}
+
+    /**
+     * Whether this range overlaps another under half-open semantics.
+     */
+    public function overlaps(self $other): bool
+    {
+        return $this->start->lessThan($other->end)
+            && $this->end->greaterThan($other->start);
+    }
+}

--- a/app/ValueObjects/TravelBufferWarning.php
+++ b/app/ValueObjects/TravelBufferWarning.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\ValueObjects;
+
+use App\Models\Booking;
+use JsonSerializable;
+
+/**
+ * A soft warning that an on-site booking sits too close to a neighbouring
+ * booking for the service's travel buffer. Never a hard block — the scheduler
+ * may acknowledge it and proceed. `direction` is 'before' when the neighbour
+ * precedes the candidate, 'after' when it follows.
+ */
+final class TravelBufferWarning implements JsonSerializable
+{
+    public function __construct(
+        public readonly Booking $neighbor,
+        public readonly int $gapMinutes,
+        public readonly int $requiredBufferMinutes,
+        public readonly string $direction,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'neighbor_id' => $this->neighbor->id,
+            'gap_minutes' => $this->gapMinutes,
+            'required_buffer_minutes' => $this->requiredBufferMinutes,
+            'direction' => $this->direction,
+        ];
+    }
+}

--- a/database/factories/BookingAddonFactory.php
+++ b/database/factories/BookingAddonFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Booking;
+use App\Models\BookingAddon;
+use App\Models\ServiceAddon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BookingAddonFactory extends Factory
+{
+    protected $model = BookingAddon::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'booking_id' => Booking::factory(),
+            'service_addon_id' => ServiceAddon::factory(),
+            'name' => $this->faker->randomElement([
+                'كشف إضافي',
+                'تقرير مفصّل',
+                'خدمة عاجلة',
+            ]),
+            'price_delta' => $this->faker->numberBetween(10, 200),
+        ];
+    }
+}

--- a/database/factories/BookingFactory.php
+++ b/database/factories/BookingFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\Customer;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class BookingFactory extends Factory
+{
+    protected $model = Booking::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $startsAt = $this->faker->dateTimeBetween('+1 hour', '+2 weeks');
+
+        return [
+            'service_product_id' => Product::factory()->service(),
+            'customer_id' => Customer::factory(),
+            'starts_at' => $startsAt,
+            'status' => BookingStatus::Confirmed,
+            'address' => null,
+            'notes' => null,
+            'base_price' => $this->faker->numberBetween(50, 500),
+            'total' => 0,
+            // ends_at is derived from the service duration by the model's saving hook.
+        ];
+    }
+
+    public function cancelled(): static
+    {
+        return $this->state(fn () => ['status' => BookingStatus::Cancelled]);
+    }
+
+    public function completed(): static
+    {
+        return $this->state(fn () => ['status' => BookingStatus::Completed]);
+    }
+
+    /**
+     * Anchor the booking to a specific start instant.
+     */
+    public function startingAt(\DateTimeInterface|string $startsAt): static
+    {
+        return $this->state(fn () => ['starts_at' => $startsAt]);
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ProductType;
 use App\Models\Product;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -73,5 +74,52 @@ class ProductFactory extends Factory
             'average_cost' => $cost,
             'expire_date' => $this->faker->dateTimeBetween('+1 month', '+2 years'),
         ];
+    }
+
+    /**
+     * A physical good — explicit equivalent of the default state.
+     */
+    public function physical(): static
+    {
+        return $this->state(fn () => ['type' => ProductType::Physical->value]);
+    }
+
+    /**
+     * A bookable service: no stock/expiry, a positive duration, priced by its
+     * base price. Defaults to a non-on-site, non-overlapping, bookable service.
+     */
+    public function service(): static
+    {
+        return $this->state(fn () => [
+            'type' => ProductType::Service->value,
+            'cost' => 0,
+            'price' => $this->faker->numberBetween(50, 500),
+            'average_cost' => 0,
+            'expire_date' => null,
+            'duration_minutes' => $this->faker->randomElement([30, 45, 60, 90]),
+            'requires_booking' => true,
+            'on_site' => false,
+            'allow_overlap' => false,
+            'travel_buffer_minutes' => null,
+        ]);
+    }
+
+    /**
+     * An on-site service that requires travel (address + travel buffer apply).
+     */
+    public function onSite(int $bufferMinutes = 30): static
+    {
+        return $this->state(fn () => [
+            'on_site' => true,
+            'travel_buffer_minutes' => $bufferMinutes,
+        ]);
+    }
+
+    /**
+     * A service that permits overlapping (double-booked) appointments.
+     */
+    public function allowOverlap(): static
+    {
+        return $this->state(fn () => ['allow_overlap' => true]);
     }
 }

--- a/database/factories/ServiceAddonFactory.php
+++ b/database/factories/ServiceAddonFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\ServiceAddon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceAddonFactory extends Factory
+{
+    protected $model = ServiceAddon::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'product_id' => Product::factory()->service(),
+            'name' => $this->faker->randomElement([
+                'كشف إضافي',
+                'تقرير مفصّل',
+                'خدمة عاجلة',
+                'متابعة منزلية',
+            ]),
+            'price_delta' => $this->faker->numberBetween(10, 200),
+        ];
+    }
+}

--- a/database/migrations/2026_07_14_100000_add_type_to_products_table.php
+++ b/database/migrations/2026_07_14_100000_add_type_to_products_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasColumn('products', 'type')) {
+            Schema::table('products', function (Blueprint $table) {
+                $table->string('type')->default('physical')->after('id')->index();
+            });
+        }
+
+        // Backfill every existing row to the physical meaning so the column is
+        // never null and legacy products keep exactly today's behavior.
+        DB::table('products')->whereNull('type')->update(['type' => 'physical']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasColumn('products', 'type')) {
+            Schema::table('products', function (Blueprint $table) {
+                $table->dropColumn('type');
+            });
+        }
+    }
+};

--- a/database/migrations/2026_07_14_100100_add_service_attributes_to_products_table.php
+++ b/database/migrations/2026_07_14_100100_add_service_attributes_to_products_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Service-specific attributes on products. They are meaningful only when
+     * `type = service`; every existing physical row reads them at their default
+     * (no duration, non-booking, non-on-site, non-overlap), i.e. today's meaning.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            if (! Schema::hasColumn('products', 'duration_minutes')) {
+                $table->unsignedInteger('duration_minutes')->nullable()->after('price');
+            }
+            if (! Schema::hasColumn('products', 'requires_booking')) {
+                $table->boolean('requires_booking')->default(false)->after('duration_minutes');
+            }
+            if (! Schema::hasColumn('products', 'on_site')) {
+                $table->boolean('on_site')->default(false)->after('requires_booking');
+            }
+            if (! Schema::hasColumn('products', 'allow_overlap')) {
+                $table->boolean('allow_overlap')->default(false)->after('on_site');
+            }
+            if (! Schema::hasColumn('products', 'travel_buffer_minutes')) {
+                $table->unsignedInteger('travel_buffer_minutes')->nullable()->after('allow_overlap');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn([
+                'duration_minutes',
+                'requires_booking',
+                'on_site',
+                'allow_overlap',
+                'travel_buffer_minutes',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_07_14_100200_create_service_addons_table.php
+++ b/database/migrations/2026_07_14_100200_create_service_addons_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('service_addons', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->unsignedInteger('price_delta')->default(0); // minor units (MoneyCast)
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('product_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('service_addons');
+    }
+};

--- a/database/migrations/2026_07_14_100300_create_bookings_table.php
+++ b/database/migrations/2026_07_14_100300_create_bookings_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('bookings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('service_product_id')->constrained('products')->cascadeOnDelete();
+            $table->foreignId('customer_id')->constrained()->cascadeOnDelete();
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->string('status')->default('confirmed');
+            $table->text('address')->nullable();
+            $table->text('notes')->nullable();
+            $table->unsignedInteger('base_price')->default(0); // minor units (MoneyCast)
+            $table->unsignedInteger('total')->default(0); // minor units (MoneyCast)
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Serves B2 overlap detection and the B3 calendar range-scan.
+            $table->index(['service_product_id', 'status', 'starts_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('bookings');
+    }
+};

--- a/database/migrations/2026_07_14_100400_create_booking_addons_table.php
+++ b/database/migrations/2026_07_14_100400_create_booking_addons_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * A per-booking snapshot of each selected add-on. `name` and `price_delta`
+     * are copied at booking time so later edits to the source `service_addons`
+     * row never mutate historical bookings. `service_addon_id` is a nullable
+     * provenance back-reference that nulls out if the source add-on is deleted.
+     */
+    public function up(): void
+    {
+        Schema::create('booking_addons', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('booking_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('service_addon_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('name');
+            $table->unsignedInteger('price_delta')->default(0); // minor units (MoneyCast)
+            $table->timestamps();
+
+            $table->index('booking_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('booking_addons');
+    }
+};

--- a/database/migrations/2026_07_14_100500_add_reminder_sent_at_to_bookings_table.php
+++ b/database/migrations/2026_07_14_100500_add_reminder_sent_at_to_bookings_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Dedupe marker for the 24h reminder: the hourly scan reminds each booking
+     * exactly once, filtering on `reminder_sent_at IS NULL` and stamping it
+     * after dispatch.
+     */
+    public function up(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            if (! Schema::hasColumn('bookings', 'reminder_sent_at')) {
+                $table->timestamp('reminder_sent_at')->nullable()->after('total');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            $table->dropColumn('reminder_sent_at');
+        });
+    }
+};

--- a/docs/service-bookings/B1-data-layer.md
+++ b/docs/service-bookings/B1-data-layer.md
@@ -1,0 +1,127 @@
+# PRD — B1: Data layer — type discriminator, service attributes, add-ons, bookings, snapshots
+
+**Status:** Draft · **Milestone:** B1 · **Depends on:** — · **PR grouping:** one PR (T1.1–T1.6)
+
+## 1. Problem
+
+Today the catalog knows exactly one kind of product: a physical good with cost, price, stock, units and an expiry. Merchants who sell **time** — clinics, mobile/outfield clinics, home-service providers — have nowhere to model a bookable service. Before any booking engine (B2), UI (B3) or notifications (B4) can exist, the data layer needs a `type` discriminator on products, the service-specific attributes (duration, add-ons, the three behavior flags, a travel buffer), and the `bookings` + `booking_addons` tables that record an appointment with **price snapshots** so historical bookings never mutate when a service is later re-priced. This milestone lays that foundation and nothing else: schema, models, relationships, factories, the `physical` backfill, and full model-layer tests. It ships behavior-neutral — every existing product is backfilled to `physical` and the physical read/write paths are untouched.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A `products.type` discriminator (`App\Enums\ProductType`: `physical` default | `service`), indexed, with every existing row backfilled to `physical`.
+- Service attribute columns on `products` (`duration_minutes`, `requires_booking`, `on_site`, `allow_overlap`, `travel_buffer_minutes`); base price reuses the existing `price` column.
+- `service_addons` (`ServiceAddon`) — merchant-defined per-service extras with a price delta.
+- `bookings` (`Booking`) + `App\Enums\BookingStatus` and `booking_addons` (`BookingAddon`) snapshot rows, with the base price and each selected add-on delta/name captured at booking time (immutability).
+- Relationships, factories with `physical`/`service` named states, and 100% model-layer test coverage.
+
+**Non-goals**
+- Overlap detection, travel-buffer warning, `ends_at` scheduling semantics beyond a pure derivation helper (all B2).
+- Any controller, request validation, POS/line-item integration, or UI (B3).
+- Notifications / scheduling (B4).
+- Changing physical-product behavior, stock, units, costing, or their validation.
+
+## 3. Current state (from audit, with file:line)
+
+- `Product` extends `BaseModel` (`app/Models/BaseModel.php:12-22`), whose `booted()` calls `static::unguard()` — the whole app is **unguarded**, there is no `$fillable`, so a new column is mass-assignable the moment it exists. `Product` adds `HasFactory, SoftDeletes, WithTrashScope` (`app/Models/Product.php:24`).
+- `Product::booted()` (`app/Models/Product.php:35-44`) chains `parent::booted()` then a `creating` hook defaulting `currency` (from `preference('currency','SDG')`), `price` ← `cost` ← 0 and `average_cost` ← `cost` ← 0. These are **physical-goods defaults**; a service reuses `price` as its base price but does not need `cost`/`average_cost`/stock — the hook must stay harmless for services (it already only defaults, never overwrites a provided value).
+- Money casts (`app/Models/Product.php:215-224`): `price`, `cost`, `average_cost` → `App\Casts\MoneyCast`; `is_global_favorite` → `boolean`. `MoneyCast` round-trips **integer minor units** (DB) ↔ major units (PHP/JS) via `App\ValueObjects\Money` (`fromMinor`/`major`, `fromMajor`/`minor`). New money fields (`service_addons.price_delta`, `bookings.base_price`, `booking_addons.price_delta`) follow the same `unsignedInteger`/`MoneyCast` convention (deltas are non-negative — they are *added*).
+- **No `type`/discriminator column exists on `products` today** — the clean gap. Enums live in `app/Enums/` with TitleCase keys (pattern: `MovementType`, `InventoryStrategyType`; string-backed with `label()` helpers).
+- Products base migration `database/migrations/2023_01_07_162612_create_products_table.php`; `price`/`cost` are `unsignedInteger`. `tenant_id` was retrofitted onto every domain table by `2026_04_20_104832_add_tenant_id_to_all_tables.php`. New columns follow the additive-migration convention; `type` gets an index (list/filter by type in B3).
+- Multi-tenancy: single shared DB + `tenant_id`, stamped on `creating` by `app/Traits/BelongsToTenant.php` and enforced by `app/Scopes/TenantScope.php` (fails closed → `whereRaw('1=0')` when no tenant resolves). New models (`ServiceAddon`, `Booking`, `BookingAddon`) **extend `BaseModel`** so they inherit tenant scoping + unguard automatically.
+- `Customer` (`app/Models/Customer.php`, extends `BaseModel`) is the reused client: single free-text `address`, `phone_number`, **no email**. `Booking.customer_id` FKs to `customers`; the booking `address` is a **per-booking snapshot** (pre-fillable from the customer in B3), nullable at the DB layer and required-when-`on_site` only in B3 request validation.
+- `ProductFactory` (`database/factories/ProductFactory.php`) sets no `type` and relies on the `BelongsToTenant` `creating` hook for `tenant_id`; because the model is unguarded, new columns are settable without touching `$fillable`.
+- Eloquent rules (`.ai/Eloquent rules`): models singular; `Model::unguard()` inherited via `BaseModel`; **100% model test coverage mandatory**.
+
+## 4. Design & behavior
+
+`products.type` is a string cast to `ProductType`, defaulting to `physical`; the migration backfills existing rows to `physical` in the same change so the column is never null. The five service attributes live as columns on `products` (not a side table): they are cheap, nullable/boolean, and keep a service a single row — consistent with how the app already colocates product attributes. `duration_minutes` and `travel_buffer_minutes` are nullable `unsignedInteger`; `requires_booking`, `on_site`, `allow_overlap` are booleans defaulting `false` so **every existing physical row reads as a non-booking, non-on-site, non-overlap product with no duration** — exactly today's meaning.
+
+Add-ons are a per-service child table. A `ServiceAddon` has a `name` and a `price_delta` that is *added* to the base price when selected on a booking.
+
+A `Booking` belongs to a service `Product` (`service_product_id`) and a `Customer`, has `starts_at`, a **derived** `ends_at`, a `status` (`confirmed` default | `cancelled` | `completed`), an optional per-booking `address` and `notes`, and a **snapshotted** `base_price`. `ends_at` is computed as `starts_at + duration_minutes` by a pure model helper in this milestone (the *engine* meaning — overlap, buffer — is B2); we **persist** `ends_at` (see §10) so B2's overlap queries and the calendar can range-scan without joining the service each time.
+
+**Snapshot / immutability** is the load-bearing rule. When a booking is created from a service, it copies the service's current `price` into `bookings.base_price` and, for each selected add-on, inserts a `booking_addons` row copying the add-on's current `name` and `price_delta` (with a nullable `service_addon_id` back-reference for provenance). The booking's `total` (`base_price` + Σ `booking_addons.price_delta`) is likewise **computed once at creation and stored as a column** — because all operands are already immutable snapshots, the stored total can never drift, and persisting it lets B3 reporting sort/sum totals in SQL. Because every value is copied, later edits to the service `price` or its `ServiceAddon` rows **do not** change any existing booking. A small helper (`Booking::createForService($service, $customer, $startsAt, $addonIds, …)` or a factory helper) centralizes the snapshot so callers can't forget it.
+
+## 5. Data model / schema changes
+
+- **`products`** (additive columns): `type` string default `'physical'` **indexed** (+ backfill existing → `physical`); `duration_minutes` unsignedInteger nullable; `requires_booking` boolean default `false`; `on_site` boolean default `false`; `allow_overlap` boolean default `false`; `travel_buffer_minutes` unsignedInteger nullable. Add `type` → `ProductType`, and the two booleans/durations to `Product::$casts` as appropriate (`type` → enum; booleans → `boolean`).
+- **`service_addons`** (new): `id`, `tenant_id` (FK, per `BelongsToTenant`), `product_id` (FK → products, `cascadeOnDelete`), `name` string, `price_delta` unsignedInteger (`MoneyCast`), timestamps, softDeletes. Index `product_id`.
+- **`bookings`** (new): `id`, `tenant_id`, `service_product_id` (FK → products), `customer_id` (FK → customers), `starts_at` datetime, `ends_at` datetime, `status` string default `'confirmed'` **indexed**, `address` text nullable, `notes` text nullable, `base_price` unsignedInteger (`MoneyCast`), `total` unsignedInteger (`MoneyCast`) — computed once at booking time (`base_price` + Σ selected add-on deltas) and stored, timestamps, softDeletes. Composite index `[service_product_id, status, starts_at]` to serve B2 overlap and the calendar (justified now, consumed in B2/B3).
+- **`booking_addons`** (new): `id`, `tenant_id`, `booking_id` (FK → bookings, `cascadeOnDelete`), `service_addon_id` (FK → service_addons, **nullable**, `nullOnDelete`), `name` string, `price_delta` unsignedInteger (`MoneyCast`), timestamps. Index `booking_id`.
+- **Enums:** `App\Enums\ProductType` (`Physical='physical'`, `Service='service'`) and `App\Enums\BookingStatus` (`Confirmed='confirmed'`, `Cancelled='cancelled'`, `Completed='completed'`), each with a localized `label()` per the `MovementType` pattern.
+- All additive and reversible; `down()` drops the new tables and the added `products` columns.
+
+## 6. Task specs
+
+### T1.1 — `ProductType` enum + `type` column + backfill · **S**
+- **Behavior:** add `App\Enums\ProductType` (string-backed, TitleCase keys, `label()`). Migration adds `products.type` string default `'physical'`, indexed, and backfills existing rows to `physical` in the same migration. Cast `type` → `ProductType` on `Product`. Add convenience scopes/accessors (`scopeServices`, `scopePhysical`, `isService()`).
+- **Files:** *new* `app/Enums/ProductType.php`; *new* `database/migrations/…_add_type_to_products_table.php`; `app/Models/Product.php` (`$casts`, scopes/accessors).
+- **Edge cases:** column must be non-null after migrate (default + backfill); an unknown string in DB should surface as an enum error, not silently coerce; physical scope must include legacy rows (guaranteed by backfill).
+- **Acceptance criteria:** all existing rows read `ProductType::Physical`; `Product::factory()->service()` reads `Service`; `scopeServices`/`scopePhysical` partition the table; migrate + rollback clean.
+- **Test plan:** unit test enum values/labels; migration/model test asserting backfill, cast, scopes, `isService()`.
+
+### T1.2 — Service attribute columns + casts · **S**
+- **Behavior:** migration adds `duration_minutes`, `requires_booking`, `on_site`, `allow_overlap`, `travel_buffer_minutes` to `products` with the defaults in §5; add boolean/enum casts; `price` remains the base price (no new column). Add a `serviceAddons()` `hasMany` relationship to `Product`.
+- **Files:** *new* `database/migrations/…_add_service_attributes_to_products_table.php`; `app/Models/Product.php` (`$casts`, `serviceAddons()`).
+- **Edge cases:** existing physical rows read `requires_booking/on_site/allow_overlap = false`, `duration_minutes/travel_buffer_minutes = null` (today's meaning); zero-duration service allowed at the data layer (a real duration is enforced in B3); booleans coerce from `0/1/'true'`.
+- **Acceptance criteria:** physical rows unchanged; a service row round-trips all five attributes; `serviceAddons()` returns the product's add-ons.
+- **Test plan:** model test asserting defaults on a physical product and round-trip on a service; regression that a physical factory product is untouched.
+
+### T1.3 — `ServiceAddon` model + table + factory · **S**
+- **Behavior:** `ServiceAddon` (extends `BaseModel`, `SoftDeletes`) with `product()` `belongsTo`, `price_delta` → `MoneyCast`. Migration per §5. Factory with a tenant-aware default and a way to attach to a service product.
+- **Files:** *new* `app/Models/ServiceAddon.php`; *new* `database/migrations/…_create_service_addons_table.php`; *new* `database/factories/ServiceAddonFactory.php`.
+- **Edge cases:** `price_delta` of 0 is valid (free add-on); deleting a product cascades its add-ons; add-ons are tenant-scoped like every `BaseModel`.
+- **Acceptance criteria:** an add-on persists with a money delta, belongs to its product, is tenant-scoped, and cascades on product delete.
+- **Test plan:** model test for relationship, `MoneyCast` round-trip, tenant scoping, cascade.
+
+### T1.4 — `Booking` model + `BookingStatus` enum + table · **M**
+- **Behavior:** `App\Enums\BookingStatus` (`confirmed`/`cancelled`/`completed`, `label()`). `Booking` (extends `BaseModel`, `SoftDeletes`): relationships `service()` (`belongsTo` Product via `service_product_id`), `customer()`, `addons()` (`hasMany` `BookingAddon`); casts `starts_at`/`ends_at` → `datetime`, `status` → `BookingStatus`, `base_price` → `MoneyCast`, `total` → `MoneyCast`; a pure helper `deriveEndsAt()` = `starts_at + service.duration_minutes`. `total` is a **stored column** written once by the create helper (T1.5) as `base_price` + Σ snapshot add-on deltas — not a live accessor, since all operands are immutable. Persist `ends_at` on save from the derivation (a `saving` hook or explicit set in the create helper). Migration per §5.
+- **Files:** *new* `app/Enums/BookingStatus.php`; *new* `app/Models/Booking.php`; *new* `database/migrations/…_create_bookings_table.php`.
+- **Edge cases:** null `duration_minutes` → `ends_at == starts_at` (guard, no crash) — a real duration is a B3 concern; `status` defaults `confirmed`; `address`/`notes` nullable; stored `total` with no add-ons == `base_price`; **no overlap/buffer logic here** (B2). Timezone: `starts_at`/`ends_at` stored as `datetime` in the app timezone (Sudan `Africa/Khartoum`, no DST) — DST/tz edge tests are B2's remit, but the columns and casts are fixed here.
+- **Acceptance criteria:** a booking persists with derived `ends_at`, correct `total()`, enum status, and all three relationships load; tenant-scoped; soft-deletable.
+- **Test plan:** model test: relationships, `datetime`/enum/`MoneyCast` casts, `deriveEndsAt()` (incl. null duration), stored `total` with/without add-ons (written by the create helper), default status.
+
+### T1.5 — `BookingAddon` snapshot model + table + create-from-service helper · **M**
+- **Behavior:** `BookingAddon` (extends `BaseModel`) with `booking()` `belongsTo`, optional `serviceAddon()` `belongsTo` (nullable), `price_delta` → `MoneyCast`, `name` snapshot. A create helper — `Booking::createForService(Product $service, Customer $customer, CarbonInterface $startsAt, array $addonIds = [], ?string $address = null, ?string $notes = null): Booking` — snapshots `base_price` from `service->price`, derives/persists `ends_at`, inserts one `BookingAddon` per selected add-on copying its current `name` + `price_delta`, and writes the stored `total` (`base_price` + Σ inserted deltas). Wrapped in a transaction.
+- **Files:** *new* `app/Models/BookingAddon.php`; *new* `database/migrations/…_create_booking_addons_table.php`; *new* `database/factories/BookingAddonFactory.php`; helper on `app/Models/Booking.php` (or a small `app/Actions/Bookings/CreateBookingAction.php` if it keeps the model lean — lean toward an action to avoid fattening the model).
+- **Edge cases:** **immutability** — after creating a booking, editing the source `ServiceAddon`'s `price_delta`/`name` (or the service `price`) must not change the booking's snapshot rows/`base_price`/stored `total`; selecting zero add-ons → no `booking_addons` rows, stored `total == base_price`; a later-deleted source add-on → `service_addon_id` nulls out but the snapshot `name`/`price_delta` remain (history preserved); passing an add-on id from another service → helper ignores/validates (data-layer guards against cross-service add-ons).
+- **Acceptance criteria:** the helper snapshots base price and selected deltas; mutating the source afterward leaves the booking total unchanged; deleting a source add-on preserves the snapshot; cross-service add-on ids are rejected.
+- **Test plan:** the **immutability test is mandatory** — create booking, mutate `ServiceAddon` + service `price`, assert booking stored `total`/`base_price`/rows unchanged; test zero-add-on and deleted-source-add-on paths; assert transactional creation.
+
+### T1.6 — Factories, named states & seeder touch · **S**
+- **Behavior:** extend `ProductFactory` with `service()` (sets `type=service`, a `duration_minutes`, sensible flags) and `physical()` (explicit, = today's default) states; ensure `ServiceAddonFactory`/`BookingFactory`/`BookingAddonFactory` compose (e.g. `Booking::factory()->for(Product::factory()->service())`). Optionally seed one demo service + booking in the example seeder (only if it mirrors existing demo-seed patterns; otherwise skip).
+- **Files:** `database/factories/ProductFactory.php`; *new* `database/factories/BookingFactory.php`; `database/seeders/DashboardExampleSeeder.php` (optional, guarded).
+- **Edge cases:** `service()` state must not set physical-only fields in a way that breaks the `creating` hook; factories must not set `tenant_id` explicitly (rely on the trait) to match existing convention; a `physical()` product must be indistinguishable from a legacy row.
+- **Acceptance criteria:** `Product::factory()->service()->create()` yields a valid bookable service; booking/add-on factories build a complete booking-with-snapshots graph; seeded demo data (if added) stays tenant-consistent.
+- **Test plan:** factory tests building each graph; assert `service()`/`physical()` states set the right `type` and attributes.
+
+## 7. Edge cases (cross-task)
+
+- **Physical regression:** every added column defaults to the physical meaning (`type=physical`, flags `false`, durations null); a broad regression test asserts an existing physical product's behavior/attributes are unchanged after all migrations.
+- **Snapshot immutability** (the headline invariant): re-priced services and edited/deleted add-ons must never alter historical bookings — covered explicitly in T1.5.
+- **Zero values:** zero `price_delta`, zero/undefined `duration_minutes`, and zero-cost services are all representable; higher-layer minimums are B3.
+- **Tenant scoping:** `service_addons`/`bookings`/`booking_addons` are all `BaseModel` → auto-scoped; a booking must never reference a cross-tenant customer/service (enforced by scoping; assert in tests).
+- **Cascade/soft-delete:** deleting a product cascades add-ons; soft-deleting a booking retains its snapshot rows; a nulled `service_addon_id` keeps the snapshot readable.
+- **`on_site` + null `address`** is permitted at the data layer (the required-when-`on_site` rule is B3 validation); note it so B3 owns it.
+
+## 8. Test plan (summary)
+
+- Enum unit tests: `ProductType`, `BookingStatus` values/labels (T1.1, T1.4).
+- Product model tests: `type` cast/scopes/backfill, service attributes defaults & round-trip, `serviceAddons()` (T1.1–T1.2).
+- `ServiceAddon`/`Booking`/`BookingAddon` model tests: relationships, `MoneyCast`/`datetime`/enum casts, `deriveEndsAt()`, stored `total`, tenant scoping, cascade/soft-delete (T1.3–T1.5).
+- **Immutability test** (mandatory): mutate source service price + add-ons, assert booking snapshot unchanged (T1.5).
+- Factory graph tests + `service()`/`physical()` states (T1.6).
+- Regression: existing product/stock feature tests stay green; a physical product is unaffected by every new migration/column.
+- 100% model-layer coverage across the four new/updated models.
+
+## 9. Rollout & backwards compatibility
+
+Fully additive and reversible. `products.type` backfills to `physical` in the same migration, and every new attribute defaults to the physical meaning, so existing tenants see **zero behavior change** — no controller, request, POS, stock, or UI path reads the new columns yet (those arrive in B2–B4). New tables are empty until B3 creates bookings. `down()` drops the three new tables and the six added `products` columns. Deploy as a single PR ahead of B2.
+
+## 10. Resolved decisions
+
+- **Persist `ends_at`** (decided). Set from `deriveEndsAt()` on save via a `saving` hook / the create helper, so B2 overlap detection and B3's calendar range-scan by time without joining the service. The `saving` hook keeps it consistent when `starts_at` changes.
+- **Store `total` as a column** (decided). Computed once at booking time (`base_price` + Σ snapshot deltas) and persisted — safe because every operand is an immutable snapshot, and it lets B3 reporting sort/sum totals in SQL. Written by the create helper (T1.5), never recomputed live.
+- **`requires_booking = false` services create no `bookings` rows** (decided). They sell as ordinary line items through POS/invoices (a B3/POS concern). B1 only guarantees the column exists and defaults `false`.
+- **Cross-service add-on guard: defense in depth** (decided). The create helper (T1.5) rejects add-on ids that don't belong to the service, and B3's request re-validates — the helper is the single snapshot choke point.

--- a/docs/service-bookings/B2-booking-engine.md
+++ b/docs/service-bookings/B2-booking-engine.md
@@ -1,0 +1,125 @@
+# PRD — B2: Booking engine (overlap hard-block + travel-buffer soft-warning)
+
+**Status:** Draft · **Milestone:** B2 · **Depends on:** B1 · **PR grouping:** one PR (T2.1–T2.4 + tests)
+
+## 1. Problem
+
+Bookings must not silently collide. When a merchant schedules a service appointment, two independent scheduling rules apply and they behave very differently:
+
+- **Overlap** is a hard constraint. A single tenant has one calendar (no staff/resource model in v1), so for a given service the same slot cannot be sold twice — unless the merchant has explicitly opted that service into double-booking (`allow_overlap`). A colliding booking must be **hard-blocked** with a clear, localized error.
+- **Travel buffer** is a *soft* constraint. For on-site services, staff travel between clients; if a new on-site booking starts too soon after the previous one ends, we should **warn** the scheduler — but never block. The merchant knows traffic better than we do, so they confirm and proceed.
+
+This milestone builds the **pure domain engine** that answers "can this booking be placed, and is there anything the scheduler should be warned about?" — no UI, no controllers, no persistence changes. B3 consumes it; the engine here is behavior-neutral until then.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A half-open interval overlap primitive (`[starts_at, ends_at)`) so back-to-back bookings that exactly abut do **not** count as overlapping.
+- Overlap detection **scoped per-service** (same `service_product_id`) against **`Confirmed`** bookings only, hard-blocking via `App\Exceptions\BookingOverlapException`, and skipped entirely when the service has `allow_overlap = true`.
+- Travel-buffer detection for **on-site services only**, returning a **soft warning** value object (never throwing) when the gap from the previous confirmed booking's end is shorter than the service's `travel_buffer_minutes`.
+- A single orchestration seam (`BookingScheduler::assertBookable()`) that runs the hard checks and returns any soft warnings — the one method B3 calls.
+- An `ignore` hook so editing/rescheduling a booking excludes itself from its own overlap/buffer checks.
+- Exhaustive unit coverage of the edge cases below (this is the phase the initiative flags for thorough testing).
+
+**Non-goals**
+- Any UI, controller, route, or FormRequest (all B3).
+- Persisting bookings, deriving/storing `ends_at`, or the booking total (B1 owns the schema + `ends_at`; the engine only reads them).
+- Notifications on placement/cancel (B4).
+- Cross-service overlap, staff/resource conflicts, recurring appointments, route/distance math (out of v1 scope).
+
+## 3. Current state (from audit)
+
+- **No booking/scheduling engine exists.** There is no `app/Services/Bookings/`, no overlap or buffer logic anywhere in the codebase (Phase 0 confirmed no booking/appointment/calendar concept). The engine is net-new.
+- **Pattern to mirror:** the inventory policy seam. `app/Services/Inventory/` holds a contract (`InventoryStrategy`) with concrete implementations resolved from tenant state, and enforcement throws a domain exception (`InsufficientStockException`) at a single choke point (`Storage::deductStock`). B2 follows the same shape — a small service class in `app/Services/Bookings/` and a domain exception in `app/Exceptions/`.
+- **B1 provides the inputs the engine reads:** `Booking` model + `App\Enums\BookingStatus` (`Confirmed` | `Cancelled` | `Completed`, default `Confirmed`), with `service_product_id`, `customer_id`, `starts_at` (datetime), `ends_at` (datetime, derived from the service `duration_minutes`), `status`. The service product carries the per-service flags `allow_overlap` (bool, default false), `on_site` (bool, default false), and `travel_buffer_minutes` (unsignedInteger, nullable). Overlap/buffer are **per-service** (confirmed by product owner): a new booking for service X is compared only against other bookings of service X.
+- **Tenant scoping is implicit.** Every `Booking` query runs under `TenantScope` (`app/Scopes/TenantScope.php`), which constrains to the resolved tenant and **fails closed** (`whereRaw('1 = 0')` when no tenant resolves). Overlap queries in a normal request context therefore need no explicit `tenant_id` clause — they inherit the scope. (The unbound, scheduled-command context is B4's concern, not B2's.)
+- **Timezone:** `starts_at`/`ends_at` are Eloquent `datetime` casts (Carbon instances). App timezone is a single tenant timezone; Sudan (Africa/Khartoum) observes **no DST**, so wall-clock and instant comparisons don't diverge in production today — but the engine must still compare **instants** (Carbon), never naive strings, so a future timezone/DST change can't silently corrupt overlap math.
+
+## 4. Design & behavior
+
+Two rules, one seam.
+
+**Interval semantics — half-open `[start, end)`.** A booking occupies `starts_at` inclusive to `ends_at` exclusive. Two intervals `A` and `B` overlap iff `A.start < B.end AND B.start < A.end`. This makes back-to-back bookings that touch at the boundary (`A.end == B.start`) **non-overlapping** — the correct real-world behavior (a 09:00–09:30 and a 09:30–10:00 appointment do not conflict). We commit to this convention explicitly and test it at the boundary.
+
+**Overlap (hard block).** For a candidate booking (service `S`, interval `I`, optional `ignoreId`):
+- If `S.allow_overlap === true` → skip; no block. (Merchant opted into double-booking.)
+- Else query existing bookings where `service_product_id = S.id`, `status = Confirmed`, `id != ignoreId`, and the stored interval overlaps `I` (half-open). If any exist → throw `BookingOverlapException` carrying the conflicting booking(s) and a localized message.
+- Only `Confirmed` participates — a `Cancelled` booking is excluded, so cancelling instantly frees the slot for rebooking. `Completed` is likewise excluded (see §10).
+
+**Travel buffer (soft warning).** Only when `S.on_site === true` **and** `S.travel_buffer_minutes` is a positive value:
+- Find the nearest **preceding** confirmed same-service booking (the one whose `ends_at` is the greatest `ends_at <= I.start`, excluding `ignoreId`). If the gap `I.start - previous.ends_at` (in minutes) is `< travel_buffer_minutes`, return a `TravelBufferWarning` value object (conflicting booking + actual gap + required buffer). Otherwise return `null`.
+- This **never throws**. If `on_site` is false, or `travel_buffer_minutes` is null/zero, always return `null`.
+- The forward-looking direction (the *next* booking starting too soon after *this* one ends) is symmetric and also surfaced — the detector returns all buffer violations adjacent to `I` (preceding and following), so inserting a booking between two others warns about both neighbors. B3 decides how to render them.
+
+**Orchestration seam.** `BookingScheduler::assertBookable(Booking|candidate $b, ?int $ignoreId = null): TravelBufferWarning[]`:
+1. Runs the overlap check first — throws `BookingOverlapException` on a hard conflict (nothing else runs).
+2. If it passes, runs the buffer detector and **returns** the (possibly empty) array of soft warnings.
+
+So the contract is: *throws* ⇒ cannot proceed; *returns warnings* ⇒ may proceed, surface these; *returns `[]`* ⇒ clean. B3's booking controller calls this once and branches on the outcome.
+
+Layout mirrors `app/Services/Inventory/`: a `BookingScheduler` service (constructor-injectable, resolvable from the container) delegating to two focused collaborators — `OverlapDetector` and `TravelBufferChecker` — so each rule is independently testable. Exceptions live in `app/Exceptions/`.
+
+## 5. Data model / schema changes
+
+**None.** B2 is pure logic over the schema B1 defines. It reads `bookings.starts_at/ends_at/status/service_product_id` and the service product's `allow_overlap/on_site/travel_buffer_minutes`. It writes nothing and adds no columns. `ends_at` is assumed present (stored, set from `duration_minutes` at creation — B1); the engine does not derive it.
+
+## 6. Task specs
+
+### T2.1 — Interval / overlap primitive · **S**
+- **Behavior:** a small, pure `TimeInterval` helper (or a private method on `OverlapDetector`) implementing half-open overlap: `overlaps(A, B) = A.start < B.end && B.start < A.end`, comparing Carbon instants. Boundary-touching intervals (`A.end == B.start`) return `false`.
+- **Files:** *new* `app/Services/Bookings/TimeInterval.php` (value object wrapping two Carbon instants) or an inlined primitive in `OverlapDetector.php` — prefer the value object for testability and reuse by the buffer checker.
+- **Edge cases:** exact abutment (no overlap); identical intervals (overlap); one interval fully inside another (overlap); zero-duration interval `start == end` (see §7); instants across a naive-string boundary must still compare correctly (assert with differing offsets if the cast ever changes).
+- **Acceptance criteria:** `overlaps` is symmetric; abutting → false; any positive intersection → true; comparison is instant-based (Carbon), not string-based.
+- **Test plan:** unit table of interval pairs (abut, overlap-partial, contained, identical, disjoint, zero-duration) asserting expected boolean; a case constructed to fail under naive string comparison but pass under instant comparison.
+
+### T2.2 — Overlap hard-block honoring `allow_overlap` · **M**
+- **Behavior:** `OverlapDetector::assertNoConflict(candidate, ?ignoreId)` — returns early (no-op) when the service `allow_overlap` is true; otherwise queries `Booking::where('service_product_id', S.id)->where('status', BookingStatus::Confirmed)->when(ignoreId, fn ($q) => $q->whereKeyNot(ignoreId))` and filters to those overlapping the candidate interval (half-open). If any match, throw `App\Exceptions\BookingOverlapException` with the conflicting booking(s) and a localized (`__()`) message.
+- **Files:** *new* `app/Services/Bookings/OverlapDetector.php`, `app/Exceptions/BookingOverlapException.php`. Uses T2.1.
+- **Edge cases:** `allow_overlap=true` → never throws even with a real collision; cancelled/completed bookings excluded (only `Confirmed` queried) so the slot is free; `ignoreId` excludes the row being edited from its own check; empty calendar → passes; DB-level overlap can be pushed into the query (`where starts_at < :end and ends_at > :start`) for efficiency, but the boundary semantics must match T2.1 exactly (`<`/`>`, not `<=`/`>=`).
+- **Acceptance criteria:** a colliding confirmed same-service booking throws; the same collision with `allow_overlap=true` does not; a cancelled colliding booking does not throw; editing a booking to the same time it already occupies (self) does not throw when `ignoreId` is passed; a different service at the same time does not throw.
+- **Test plan:** unit/feature tests for each: collision-blocks, allow_overlap-permits, cancelled-frees-slot, self-ignored-on-edit, different-service-ignored, abutting-allowed. Assert the exception carries the conflicting booking.
+
+### T2.3 — Travel-buffer soft-warning detector · **M**
+- **Behavior:** `TravelBufferChecker::warningsFor(candidate, ?ignoreId): TravelBufferWarning[]` — returns `[]` immediately unless the service `on_site === true` and `travel_buffer_minutes > 0`. Otherwise finds the adjacent confirmed same-service bookings (nearest preceding by `ends_at`, nearest following by `starts_at`, excluding `ignoreId`) and, for each, computes the gap in minutes; if `gap < travel_buffer_minutes`, includes a `TravelBufferWarning` (neighbor booking, actual gap, required buffer, direction). Never throws.
+- **Files:** *new* `app/Services/Bookings/TravelBufferChecker.php`, `app/Services/Bookings/TravelBufferWarning.php` (immutable value object; implements `JsonSerializable` so B3 can hand it to Inertia).
+- **Edge cases:** `on_site=false` → always `[]`; `travel_buffer_minutes` null or `0` → `[]`; gap exactly equal to buffer → **no** warning (strictly `<`); gap larger than buffer → no warning; neighbor is cancelled → ignored; both neighbors too close → two warnings; `ignoreId` excludes self; a booking placed between two others warns for preceding and following independently.
+- **Acceptance criteria:** warnings only for on-site + positive buffer + gap strictly under buffer; boundary gap `== buffer` yields none; cancelled neighbors never trigger; the warning value object exposes gap, required buffer, and the neighbor; serializes cleanly to JSON.
+- **Test plan:** unit tests over gap vs buffer (under/equal/over), on_site true/false, null/zero buffer, cancelled neighbor, both-neighbors-close, self-ignored. Assert `warningsFor` never throws.
+
+### T2.4 — `BookingScheduler` orchestration seam · **S**
+- **Behavior:** `BookingScheduler::assertBookable(candidate, ?ignoreId = null): TravelBufferWarning[]` — calls `OverlapDetector::assertNoConflict()` (may throw `BookingOverlapException`), then returns `TravelBufferChecker::warningsFor()`. This is the single method B3 invokes. Register the service (and its two collaborators) in the container so it's constructor-injectable, matching the inventory resolver's provider registration.
+- **Files:** *new* `app/Services/Bookings/BookingScheduler.php`; binding in a service provider (e.g. `app/Providers/AppServiceProvider.php`).
+- **Edge cases:** overlap throws ⇒ buffer check never runs (fail fast); clean placement ⇒ returns `[]`; placement that passes overlap but violates buffer ⇒ returns non-empty warnings (does not throw); `ignoreId` threaded to both collaborators.
+- **Acceptance criteria:** throws on hard conflict; returns warnings (never throws) on soft conflict; returns `[]` when clean; resolvable from the container.
+- **Test plan:** integration-style unit test wiring the real collaborators: assert throw-on-overlap short-circuits buffer, assert warning-return on buffer-only, assert clean returns `[]`.
+
+## 7. Edge cases (cross-task)
+
+- **Exact abutment.** `A.end == B.start` is **not** an overlap (half-open convention, T2.1) — a deliberate, tested choice; back-to-back bookings are always allowed.
+- **Back-to-back within buffer.** Two abutting on-site bookings do not overlap but *may* trip the travel-buffer warning (gap = 0 < buffer) — the two rules are independent and both are asserted in one scenario.
+- **Cancellation frees the slot.** Only `Confirmed` bookings are queried by both detectors, so cancelling a booking makes its interval immediately rebookable with no cleanup step. Explicitly tested: place → cancel → rebook same slot succeeds.
+- **`allow_overlap=true`** bypasses the overlap query entirely (never throws), independent of the buffer rule (which still applies if on-site).
+- **Buffer only when on-site + positive buffer**; gap `== buffer` yields no warning (strict `<`); null/zero buffer yields none.
+- **Zero-duration service** (`starts_at == ends_at`, e.g. a duration-less service): with half-open intervals a zero-length interval overlaps nothing (its `start == end` makes `A.start < A.end` false), so two zero-duration bookings at the same instant do **not** register as overlapping. Flagged as an open question (§10) — if merchants create bookable zero-duration services this may need a special-case; for v1 we document the behavior and test it rather than special-casing.
+- **Self-exclusion on edit.** Rescheduling passes the booking's own id as `ignoreId` so it never conflicts with itself; tested for both overlap and buffer.
+- **Timezone/DST.** All comparisons use Carbon instants. Sudan has no DST so no production divergence, but tests assert instant-based comparison (not naive string) and cover intervals that would mis-sort under string compare.
+- **Tenant isolation.** In-request queries inherit `TenantScope`; the engine adds no cross-tenant clause and must never be handed a query with global scopes removed (that unbound context belongs to B4's scheduled command, not B2).
+
+## 8. Test plan (summary)
+
+- Interval primitive: abut/overlap/contained/identical/disjoint/zero-duration + instant-vs-string (T2.1).
+- Overlap: collision-blocks, allow_overlap-permits, cancelled-frees-slot, self-ignored-on-edit, different-service-ignored, abutting-allowed (T2.2).
+- Buffer: gap under/equal/over, on_site true/false, null/zero buffer, cancelled neighbor, two-neighbors, self-ignored, never-throws (T2.3).
+- Scheduler seam: throw-short-circuits-buffer, warning-only-returns, clean-returns-empty, container-resolvable (T2.4).
+- Regression: no existing tests touch this net-new namespace; the engine is inert until B3 calls it.
+
+## 9. Rollout & backwards compatibility
+
+Fully additive and behavior-neutral. B2 introduces a new `app/Services/Bookings/` namespace and one exception; nothing calls the engine yet (B3 wires it into the booking controller). No schema, no migration, no change to any existing path — physical products and every current flow are completely untouched. Ship as one PR after B1.
+
+## 10. Resolved decisions
+
+- **Only `Confirmed` bookings block overlap** (decided). A `Completed` booking is in the past and its slot is spent; `Cancelled` already frees its slot. New placements are constrained purely by future `Confirmed` bookings of the same service. B3/B4 must not assume otherwise.
+- **Return both-neighbor buffer warnings** (decided). The travel-buffer check surfaces both the preceding-neighbor gap (new booking starts too soon after the previous ends) and the following-neighbor gap (next booking starts too soon after the new one ends); B3 decides which to render. Cheap and more informative.
+- **Bookable services require a positive duration** (decided). B3 validation enforces `duration_minutes > 0` for `requires_booking = true`; B2 still documents and defensively tests the half-open zero-duration behavior (same-instant zero-duration bookings never overlap) but it is not a supported real case.
+- **Push the overlap predicate to SQL** (decided, impl detail). Query `status = Confirmed AND service_product_id = :id AND starts_at < :end AND ends_at > :start` in the DB for scale, with a shared constant defining the boundary operators and a unit test asserting byte-for-byte parity with the in-memory T2.1 primitive.

--- a/docs/service-bookings/B3-merchant-ui.md
+++ b/docs/service-bookings/B3-merchant-ui.md
@@ -1,0 +1,130 @@
+# PRD — B3: Merchant UI (service form, booking form, calendar)
+
+**Status:** Draft · **Milestone:** B3 · **Depends on:** B1 (schema/models), B2 (booking engine seam) · **PR grouping:** one PR (T3.1–T3.5, T3.7); T3.6 line-item sale path is a **separate** PR (or explicit follow-up)
+
+## 1. Problem
+
+B1 gives us the `service` product type, add-ons, and bookings; B2 gives us the overlap/travel-buffer engine. Neither is reachable by a merchant. This milestone is the entire merchant-facing surface: extend the existing product form so a merchant can define a service (duration, add-ons, the three flags, per-service travel buffer), add a booking create/edit flow that reuses the customer picker and honors the B2 engine (hard-block on overlap, soft-warn on tight travel buffer), and give a tenant-wide calendar to see the schedule. Everything is Arabic-first, RTL-correct, dark-mode-correct, and **must not** change how `physical` products are created or edited.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A `type` toggle (physical | service) in the product form; when `service`, reveal service sections and hide the goods-oriented sections (stock, units, expiry, cost).
+- Add-ons editor: repeatable name + price-delta rows persisted to `service_addons`.
+- The three flags (`requires_booking`, `on_site`, `allow_overlap`) and a `travel_buffer_minutes` field **revealed only when `on_site` is on**.
+- Booking create/edit: customer picker (reused), service picker (service-type only), date + start time with **derived read-only end time**, add-on selector (snapshotting deltas), address **conditional on `on_site`**, notes, status.
+- Surface B2: overlap → hard error that blocks submit; travel buffer → **soft warning** the scheduler can confirm-and-proceed past.
+- A tenant-wide calendar view of bookings — localized names, correct locale week-start, consistent numerals, bidi-isolated times/addresses.
+
+**Non-goals**
+- Client-facing booking/cancellation UI (v1 is merchant-only).
+- Staff/resource columns on the calendar (one calendar for the whole tenant).
+- Notifications wiring (B4) and the booking engine internals (B2).
+- Recurring appointments, waitlists, deposits, no-show UI.
+
+## 3. Current state (from audit)
+
+- **Product create/edit is modal-driven, not page-based.** There are no `Products/Create.vue`/`Edit.vue` and no `create()`/`edit()` controller methods. The reused form component is `resources/js/Components/Products/ProductForm.vue` (Inertia `useForm`; infers edit vs create from the optional `product` prop; edit → `put route('products.update', product)`, create → `post route('products.index')`). `resources/js/Pages/Products/Index.vue` also has its own inline new-product `useForm` + quick-update; `Show.vue` is read-only.
+- `ProductsController::store`/`update` (`app/Http/Controllers/Catalog/ProductsController.php:57,93`) always create a base `Unit` and run `syncOnHandQuantities()` inside a transaction — the **service path must bypass** stock/units. Routes: `Route::resource('/products', ProductsController::class)` (`routes/tenant.php:208`).
+- `ProductRequest` (`app/Http/Requests/ProductRequest.php`) hard-requires `cost` `numeric|gt:0` and has **no `type` rule** — validation must become conditional: services validate `price` (base price), not `cost > 0`.
+- **Reusable pickers:** `resources/js/Components/CustomSelect.vue` (remote async select: `label`, `track-by`, `:remote`, `:loading`, `@search-change`, `@scroll-end`) + `resources/js/Composables/useAsyncOptions.js`. Live examples to copy: `resources/js/Components/Quotes/QuoteForm.vue:18-24,87-97` (customer async options + `onCustomerSelect` + inline add) and POS `resources/js/Pages/Pos/Session.vue:47-58`. Inline customer create modal: `resources/js/Components/QuickAddPartyModal.vue` (`type="customer"`, emits `created`). Customers API: `GET /api/customers` → `route('api.customers.index')` (`routes/tenant.php:160`).
+- Shared form primitives: `InputError`, `InputLabel`, `PrimaryButton`, `TextInput`, `CustomSelect`.
+- `Customer` has a single free-text `address` and **no email** — the booking `address` is a **per-booking snapshot** field, pre-filled from the customer's address when `on_site`.
+- Money serializes to **major units (decimal)** to the frontend via `Money::jsonSerialize()` — the add-on delta and base-price inputs are major-unit decimal fields, consistent with the existing cost/price inputs.
+- Design system: flat, emerald primary, `.ai/Design rules` (summarized in CLAUDE.md) — logical RTL props only (`ms/me/ps/pe/text-start`), full dark-mode pairs, inline Heroicons SVG, no new component library.
+
+## 4. Design & behavior
+
+**Product form.** A segmented `type` control at the top of `ProductForm.vue`. `physical` (default) renders today's form unchanged. `service` swaps the body: base price (reuse the `price` input), `duration_minutes`, the add-ons editor, and a flags block (`requires_booking`, `on_site`, `allow_overlap`) as toggles; `travel_buffer_minutes` renders **only when `on_site` is true** (mirrors the M3 nested-toggle pattern). The stock/units/expiry/cost sections are hidden for services. On submit the form sends `type` plus service fields; `ProductRequest` branches its rules on `type`.
+
+**Booking form.** A dedicated create/edit form component. Customer picker (reuse `CustomSelect` + `useAsyncOptions(route('api.customers.index'))` + optional `QuickAddPartyModal`). Service picker limited to service-type products (a filtered async endpoint or a passed prop). Selecting a service drives: available add-ons, the duration used to compute a **read-only** `ends_at` from the chosen `starts_at`, and whether the address field is shown/required (`on_site`). Add-on multi-select snapshots each selected delta+name into `booking_addons` on save; the total (`base_price` + Σ deltas) is shown live. Notes free-text; status defaults `Confirmed`.
+
+**Engine surfacing (B2).** On submit the server runs the B2 checks. An **overlap** (same-service, confirmed) throws `BookingOverlapException` → a 422 with a clear localized message; the form shows it and does **not** persist. A **travel-buffer** breach (on-site only) is a **soft warning**: the first submit returns the warning without saving; the form surfaces it inline with a "confirm and proceed" affordance that re-submits with an acknowledgement flag, and the booking saves. The soft path never hard-blocks.
+
+**Calendar.** A month/week grid of the tenant's bookings (one calendar, no resource lanes). Localized month/day names and correct locale week-start (Arabic week starts on the locale's first day), one consistent numeral system per view, and bidi isolation for times/addresses/Latin text embedded in Arabic. Clicking a booking opens edit; clicking a slot opens create pre-filled. Dark-mode contrast verified on every cell/state.
+
+## 5. Data model / schema changes
+
+**None** — B3 is UI + controller/validation only against B1's schema (`products.type` + service columns, `service_addons`, `bookings`, `booking_addons`). No migrations.
+
+## 6. Task specs
+
+### T3.1 — Product `type` toggle + conditional service sections · **M**
+- **Behavior:** add a `type` segmented control to `ProductForm.vue`; bind `type`, `duration_minutes`, `requires_booking`, `on_site`, `allow_overlap`, `travel_buffer_minutes` into the `useForm`. Render service sections when `type === 'service'` and hide stock/units/expiry/cost; keep physical rendering byte-for-byte behavior. `travel_buffer_minutes` shown only when `on_site`.
+- **Files:** `resources/js/Components/Products/ProductForm.vue`; possibly `resources/js/Pages/Products/Index.vue` (inline new-product form parity); shared toggle/segmented component under `resources/js/Components` if none exists.
+- **Edge cases:** editing an existing physical product must show physical layout with no service fields leaking; switching type mid-edit clears the now-irrelevant fields from the payload; `on_site` toggled off must not submit a `travel_buffer_minutes`.
+- **Acceptance criteria:** physical create/edit unchanged; service toggle reveals/hides the correct sections; buffer field visibility bound to `on_site`; all strings localized; RTL + dark mode correct.
+- **Test plan:** Inertia/feature test asserting the product form page/props; component-level assertion (or Dusk) that service sections toggle and buffer reveals only under `on_site`.
+
+### T3.2 — Add-ons editor + conditional validation · **M**
+- **Behavior:** repeatable add-on rows (name + major-unit price-delta, add/remove) in the service section; persist to `service_addons` in `ProductsController::store/update` (sync: create/update/soft-delete removed rows), bypassing the base-Unit/`syncOnHandQuantities()` path for services. Make `ProductRequest` conditional on `type`: services require `price` (base price ≥ 0), do **not** require `cost > 0`, and validate `duration_minutes` (int, min 1), the three flag booleans, `travel_buffer_minutes` (int min 0, required-with `on_site`), and `addons.*` (name required, price_delta numeric ≥ 0).
+- **Files:** `resources/js/Components/Products/ProductForm.vue` (editor UI); `app/Http/Controllers/Catalog/ProductsController.php:57,93` (branch service persistence); `app/Http/Requests/ProductRequest.php` (conditional rules); `app/Http/Requests/QuickUpdateProductRequest.php` if quick-edit touches type.
+- **Edge cases:** removing an add-on already referenced by historical bookings must **not** mutate those bookings (snapshots live in `booking_addons`); zero-cost service passes validation (today's `cost > 0` blocks it); physical validation path untouched.
+- **Acceptance criteria:** add-ons round-trip on create/edit; physical products still validate as before; a zero-cost service saves; removed add-ons don't corrupt past bookings.
+- **Test plan:** feature tests for service create/edit persisting add-ons; regression test that physical create/edit + validation is unchanged; validation test for the conditional branch.
+
+### T3.3 — Bookings controller, routes, index + form · **L**
+- **Behavior:** a `BookingsController` (index/create-less modal or page, store, edit, update, destroy/cancel) + `Route::resource` in `routes/tenant.php`; a booking create/edit form component with customer picker, service picker (service-type only), `starts_at` date+time, derived read-only `ends_at`, add-on selector, conditional address (required when service `on_site`, pre-filled from customer), notes, status. A `BookingRequest` form request with rules (customer exists, service is a `service` product, `starts_at` required date, address required-when on_site, addons belong to the service, status in enum).
+- **Files:** *new* `app/Http/Controllers/BookingsController.php`, `app/Http/Requests/BookingRequest.php`; `routes/tenant.php`; *new* `resources/js/Pages/Bookings/Index.vue` + `resources/js/Components/Bookings/BookingForm.vue`; reuse `CustomSelect`/`useAsyncOptions`/`QuickAddPartyModal`.
+- **Edge cases:** service with `requires_booking = false` should not be bookable here (route to line-item sale, T3.6); changing the selected service recomputes duration/address-requirement/add-on list and clears stale add-ons; end time recomputes on start-time change; cancelled bookings are read-only.
+- **Acceptance criteria:** booking create/edit round-trips; address required iff on_site; end time derived correctly; add-on deltas snapshotted; totals correct; localized + RTL + dark mode.
+- **Test plan:** feature tests for store/update/cancel incl. snapshot immutability and on_site address requirement; Inertia prop tests for the index/form.
+
+### T3.4 — Wire B2 engine into the booking form · **M**
+- **Behavior:** on store/update, run B2's overlap + travel-buffer checks. Overlap (same-service, confirmed, honoring `allow_overlap`) → `BookingOverlapException` mapped to a 422 with a clear localized message; form blocks and shows it, nothing persists. Travel buffer (on-site only) → soft warning: first submit returns the warning without saving; the form shows it with a confirm-and-proceed affordance that re-submits with an acknowledgement flag; second submit saves.
+- **Files:** `app/Http/Controllers/BookingsController.php` (call the B2 seam, translate outcomes), `resources/js/Components/Bookings/BookingForm.vue` (error + warning surfaces + acknowledge flow), exception→response mapping (`app/Exceptions` or handler).
+- **Edge cases:** `allow_overlap = true` service silently permits overlap (no error); soft warning must never become a hard block; acknowledging the warning must not also suppress a genuine overlap error; back-to-back bookings that exactly abut are allowed (per B2).
+- **Acceptance criteria:** overlap blocks and does not persist; buffer warning surfaces and proceeds on confirm; `allow_overlap` bypasses the block; messages localized.
+- **Test plan:** feature tests: overlapping submit returns 422 and no row; buffer-breach submit returns warning then saves on acknowledge; `allow_overlap` service saves overlapping silently.
+
+### T3.5 — Calendar view · **L**
+- **Behavior:** a tenant-wide month/week calendar of bookings (no resource lanes). Localized month/day names, locale-correct week-start, one consistent numeral system, bidi-isolated times/addresses, dark-mode contrast on every cell/state. Clicking a booking → edit; clicking an empty slot → create pre-filled. Hand-built grid using logical Tailwind props (no new dependency).
+- **Files:** *new* `resources/js/Pages/Bookings/Calendar.vue` (or a `Components/Bookings/Calendar.vue` embedded in Index), a small date-util composable if needed; `BookingsController` calendar data method.
+- **Edge cases:** RTL day-order and week-start; DST/month boundaries (delegate time math to server-provided `starts_at`/`ends_at`); overlapping bookings rendered legibly; long month with many bookings scrolls without horizontal page overflow.
+- **Acceptance criteria:** correct locale week-start and localized names; consistent numerals; RTL layout correct; dark mode legible; navigation to prev/next period works.
+- **Test plan:** Inertia prop test for the calendar payload; optional Dusk smoke test for RTL rendering and period navigation.
+
+### T3.6 — (SEPARATE PR / follow-up) `requires_booking = false` line-item sale path · **M**
+- **Behavior:** a service with `requires_booking = false` sells like a normal line item in POS/invoices with **no calendar involvement** — base price + selected add-ons as an ad-hoc line. Either integrate into the POS/quote/invoice line picker or explicitly defer with justification.
+- **Files:** POS `resources/js/Pages/Pos/Session.vue`, quote/invoice line components, and the relevant checkout/invoice actions.
+- **Edge cases:** such services must be sellable but **not** appear in the bookings calendar/booking form; add-on deltas still snapshot onto the sale line.
+- **Acceptance criteria:** non-booking service sells as a line item with add-ons; does not create a booking; booking flow excludes it.
+
+### T3.7 — Catalog surface + `type` API filter + Bookings nav item · **M**
+- **Behavior:** (a) surface service products in the existing `Products/Index.vue` list with a `type` badge and a `type` filter chip, reusing the existing filter-drawer pattern (`[[filter-drawer-pattern]]`) — no separate Services page; (b) add a `type` filter param to the web products index query and to the `api.products` endpoint so the booking form's service picker can request `?type=service` (service-type products only); (c) add a top-level **Bookings** sidebar nav item (calendar + list) following the existing nav-link active/inactive pattern.
+- **Files:** `resources/js/Pages/Products/Index.vue` (badge + filter chip); `app/Http/Controllers/Catalog/ProductsController.php` (index `type` filter) and `app/Http/Controllers/Api/ProductsController.php` (`type` filter for the picker); the sidebar nav component under `resources/js/` (add the Bookings link); route names already defined in T3.3.
+- **Edge cases:** default (no filter) shows all products as today — physical list unchanged; the `type` filter must compose with existing filters/search in the drawer; the API `type=service` must also respect `requires_booking` if the picker should only offer bookable services (offer all services, let the form guard `requires_booking`); nav active-state highlights on all Bookings sub-routes.
+- **Acceptance criteria:** service products visible + filterable in the existing list with a type badge; `api.products?type=service` returns only service products; Bookings nav item present with correct active state; physical-only list behavior unchanged when no type filter is applied; localized + RTL + dark mode.
+- **Test plan:** feature test for the `type` filter on both the web index and `api.products`; Inertia prop test that the list carries the type badge/filter; nav-render test/assertion for the Bookings link.
+- **Test plan:** feature test selling a `requires_booking=false` service through POS/invoice with an add-on; assert no booking row created.
+- **Note:** lean toward a **separate PR** — this touches the sales/POS surface, which is orthogonal to the booking UI and higher-risk; keep B3's core PR reviewable.
+
+## 7. Edge cases (cross-task)
+
+- Editing a product's `type` after data exists (physical→service or reverse) must not orphan or leak the other type's fields; hide + drop irrelevant payload keys.
+- `on_site` toggled off must not submit a misleading `address` (booking) or `travel_buffer_minutes` (service).
+- Overlapping submit shows the hard error and persists nothing; the soft buffer warning surfaces but allows proceed.
+- RTL: calendar direction, day order, and week-start all follow the locale; chevrons rotate; times/addresses bidi-isolated.
+- One numeral system per view — no mixing Arabic-Indic and Latin digits in the same calendar/booking view.
+- Dark-mode contrast verified on the calendar grid, badges, and warning/error surfaces.
+- Physical product create/edit and validation remain byte-for-byte unchanged (backwards compatibility).
+
+## 8. Test plan (summary)
+
+- Product form: physical unchanged; service toggle reveals/hides sections; buffer visibility bound to `on_site` (T3.1); add-ons round-trip + conditional validation + zero-cost service saves (T3.2).
+- Bookings: store/update/cancel, on_site address requirement, derived end time, add-on snapshot immutability (T3.3).
+- Engine surfacing: overlap blocks (no row), buffer warns then proceeds on acknowledge, `allow_overlap` bypasses (T3.4).
+- Calendar: prop/payload test + optional Dusk RTL/navigation smoke (T3.5).
+- Line-item sale (T3.6, separate): non-booking service sells with add-ons, no booking created.
+- Regression: existing product/POS feature tests stay green.
+
+## 9. Rollout & backwards compatibility
+
+Additive UI. Physical products keep exactly today's create/edit/validation behavior — service branches are gated on `type`. No schema change. B3 requires B1 (schema) and B2 (engine seam) merged first. Ship T3.1–T3.5 as one PR; T3.6 (POS/line-item) as a separate PR to keep the diff reviewable. Calendar is hand-built to avoid a new dependency.
+
+## 10. Resolved decisions
+
+- **Hand-built calendar** (decided). A hand-built month/week grid using logical RTL props and the existing design system — **no new dependency**. No calendar package is pulled in.
+- **New top-level "Bookings" nav item** (decided). Bookings (calendar + list) get a dedicated top-level sidebar entry, following the existing nav-link active/inactive pattern in `.ai/Design rules`; not nested under Products/POS.
+- **Service products live in the existing Products list** (decided). They appear in `resources/js/Pages/Products/Index.vue` with a `type` badge and a `type` filter chip, reusing the existing filter-drawer pattern (`[[filter-drawer-pattern]]`) — no separate Services page.
+- **Service picker uses a `?type=service` filter on the products API** (decided). Add a `type` filter to the existing `api.products` endpoint (`App\Http\Controllers\Api\ProductsController`); the picker reuses `CustomSelect` + `useAsyncOptions`. No dedicated `api.services` endpoint.

--- a/docs/service-bookings/B4-notifications.md
+++ b/docs/service-bookings/B4-notifications.md
@@ -1,0 +1,105 @@
+# PRD — B4: Notifications (24h reminder + cancellation notice)
+
+**Status:** Draft · **Milestone:** B4 · **Depends on:** B1 (Booking model + `Cancelled` status); realistically ships after B2/B3 · **PR grouping:** one PR (T4.1, T4.2, T4.3, T4.4)
+
+## 1. Problem
+
+A confirmed booking is a commitment on the merchant's calendar, and today nothing reminds them it is coming or tells them when one is cancelled. v1 needs two merchant-facing messages: a **single reminder 24 hours before start** (fixed offset, not configurable) and a **cancellation notice** when a booking is cancelled. Clients are **not** notified in v1 — there is no client portal and no client-side delivery. The work is to ride the existing, mature Laravel Notifications pipeline (which already gives us mail + a database bell + live broadcast) rather than invent a new delivery mechanism. Real WhatsApp/SMS delivery does not exist in this codebase and is explicitly deferred; B4 leaves a clearly-marked TODO channel seam, nothing live.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- `BookingReminderNotification` delivered once per booking, ~24h before `starts_at`, to the merchant.
+- `BookingCancelledNotification` delivered to the merchant the moment a booking is cancelled.
+- A scheduled command that scans upcoming confirmed bookings and sends the reminder exactly once, correctly across all tenants (unbound context).
+- Both notifications light the existing frontend notification bell for free via the `broadcast` channel, and persist in the database channel.
+- A documented, **inert** SMS/WhatsApp channel seam so a future initiative can wire a real provider without rearchitecting.
+
+**Non-goals**
+- Any client-facing notification, portal, or self-service (out of scope for v1).
+- Configurable reminder timing or multiple reminders (fixed 24h, exactly one).
+- Wiring a real WhatsApp/SMS provider (Twilio or `mazin_host`) — TODO only, no credentials, no live send.
+- Reminder for services with `requires_booking = false` (they create no booking).
+
+## 3. Current state (from audit)
+
+- **Notification blueprint to clone:** `app/Notifications/ChequeDueNotification.php` — a due-date reminder that `implements ShouldQueue`, `via()` returns `['mail','database','broadcast']` (`ChequeDueNotification.php:25`), with `toMail()` (MailMessage), `toArray()` (database payload), and `databaseType()`/`broadcastType()` string tags the frontend bell keys on. `app/Notifications/AnnouncementNotification.php` shows the conditional-channel variant (`AnnouncementNotification.php:22-31`).
+- **Scheduled-scan blueprint:** `routes/console.php:18-32` defines inline Artisan command `cheques:notify-for-due` — queries records due within a config window (`->where('due','<=',now()->addDays(config('app.cheques_notify_before_days',3)))`), lifts the tenant global scope with `Cheque::withoutGlobalScopes()` (**critical** — scheduled commands run unbound, so `TenantScope` would otherwise fail closed and return nothing), loops recipients, calls `$admin->notify(new ChequeDueNotification(...))`; registered `Schedule::command('cheques:notify-for-due')->daily()` (`routes/console.php:32`). A 90-day notifications prune and other `->daily()` scans (`expenses:generate-recurring`, `stock:reconcile`, `exports:prune`, `backup:scheduled`) live alongside.
+- **Queue/broadcast infra is live:** Horizon `^5.46` + Redis queues (`config/queue.php:65-86`), queued-job pattern `app/Jobs/SendAnnouncementJob.php:18-33` (`Notification::send()` over chunked recipients). Reverb/Echo are real: `resources/js/Components/NotificationBell.vue:107-117` listens on `window.Echo.private('App.Models.User.'+id).notification(...)`, so adding `broadcast` to `via()` lights the bell with no frontend work. Channels authorized in `routes/channels.php` (`App.Models.User.{id}`).
+- **No working WhatsApp/SMS delivery exists:** `laravel-notification-channels/twilio` is in `composer.json:15` but has **zero** usage — no `toTwilio()`, no `TwilioChannel`, no `routeNotificationForTwilio`, no `services.twilio` config. `config/services.php:34-36` has a dangling, unreferenced `mazin_host` SMS stub (`MAZIN_HOST_SMS_API_KEY`, `MAZIN_HOST_SENDER_ID`), no channel class, no env keys in `.env.example`. The notifiable (`app/Models/User.php`) has no `routeNotificationFor*` method today.
+- **Merchant recipients:** users belong to a tenant via the `tenant_user` pivot (role_id, is_active); the reminder/cancel audience is the tenant's owner + admins, resolved the same way `cheques:notify-for-due` resolves its admins.
+
+## 4. Design & behavior
+
+Two notifications cloned from `ChequeDueNotification`, both `ShouldQueue`, both `via()` → `['mail','database','broadcast']`, both carrying a `databaseType()`/`broadcastType()` tag (`booking.reminder`, `booking.cancelled`) and a `toArray()` payload with booking id, service name, customer name, `starts_at`, and (for reminders) address when on-site. All copy localized via `__()`, Arabic-first; times/addresses isolated for bidi per the design rules.
+
+**Reminder scheduling.** A new Artisan command `bookings:notify-upcoming` clones the `cheques:notify-for-due` shape:
+- Scan `Booking::withoutGlobalScopes()` where `status = Confirmed`, `reminder_sent_at IS NULL`, and `starts_at <= now()->addDay()` (i.e. start is within the next 24h) **and** `starts_at >= now()` (not already past).
+- For each match, resolve that booking's tenant's merchant users and `notify(new BookingReminderNotification($booking))`, then stamp `reminder_sent_at = now()` in the same pass so the booking is reminded **exactly once** (dedupe). Wrap the per-booking stamp so a re-run can't double-send.
+- **Cadence: hourly.** Justified — the offset is a specific 24h point; a `->daily()` scan (as cheques use) would fire the reminder anywhere from ~0 to ~24h before start depending on run time, which is too coarse for an appointment. Hourly bounds the reminder to within an hour of the intended 24h mark at negligible cost. Registered `Schedule::command('bookings:notify-upcoming')->hourly()` in `routes/console.php`.
+
+**Cancellation notice.** Fired imperatively from the cancel path (the cancel action/controller introduced in B3), **not** the scheduler: on transition to `Cancelled`, `notify(new BookingCancelledNotification($booking))` to the merchant users. This keeps it immediate and avoids a scan.
+
+**SMS/WhatsApp seam.** Add a documented but inert channel: a `routeNotificationForSms()`/`toSms()` (or `toTwilio()`) stub on the notifiable/notifications marked `// TODO: no live SMS/WhatsApp provider wired — see B4 §10`, and a note of the env keys a real provider would need. `via()` does **not** include the SMS channel in v1, so nothing is sent. No provider credentials, no `services.twilio`/`mazin_host` wiring.
+
+## 5. Data model / schema changes
+
+- **One additive column** on `bookings`: `reminder_sent_at` (nullable timestamp) — the dedupe marker so the hourly scan reminds each booking once. Additive, reversible.
+- No other schema change. Notifications persist in the existing `notifications` table (database channel) exactly like `ChequeDueNotification`.
+
+## 6. Task specs
+
+### T4.1 — `BookingReminderNotification` · **M**
+- **Behavior:** notification cloned from `ChequeDueNotification` — `implements ShouldQueue`, `via()` → `['mail','database','broadcast']`; `toMail()` a localized MailMessage naming the service, customer, and start time (address line when the service is on-site); `toArray()` database payload (booking id, service name, customer name, `starts_at`, on-site address); `databaseType()`/`broadcastType()` → `booking.reminder`. Constructor takes the `Booking`.
+- **Files:** *new* `app/Notifications/BookingReminderNotification.php`.
+- **Edge cases:** on-site vs not (include/omit address line); missing customer name; all strings via `__()`; consistent numeral system and bidi isolation for time/address.
+- **Acceptance criteria:** queued; three channels present; database + broadcast type tags correct; bell renders it; no hard-coded English.
+- **Test plan:** unit/feature with `Notification::fake()` asserting the notification, its channels, and payload shape for on-site and non-on-site bookings.
+
+### T4.2 — `bookings:notify-upcoming` command + dedupe column + schedule · **M**
+- **Behavior:** additive migration adding `bookings.reminder_sent_at` (nullable timestamp). New inline/console command `bookings:notify-upcoming` cloning `cheques:notify-for-due`: scan `Booking::withoutGlobalScopes()` where `status = Confirmed AND reminder_sent_at IS NULL AND starts_at >= now() AND starts_at <= now()->addDay()`; per booking resolve the tenant's merchant users, notify, and stamp `reminder_sent_at`. Register `Schedule::command('bookings:notify-upcoming')->hourly()`.
+- **Files:** *new* migration `..._add_reminder_sent_at_to_bookings_table.php`; command in `routes/console.php` (or `app/Console/Commands/` following `GenerateRecurringExpenses.php`); schedule registration in `routes/console.php`.
+- **Edge cases:** unbound tenant context — must lift `TenantScope` and still notify the *correct* tenant's users; command run twice in the same hour must not double-send (dedupe via `reminder_sent_at`); booking created <24h before start → picked up on the next hourly scan (window is `<= now+24h` and not-yet-reminded), which is the desired behavior; bookings already past (`starts_at < now()`) skipped; timezone — comparison is instant-based against `now()` (app tz Africa/Khartoum, no DST) so no wall-clock drift.
+- **Acceptance criteria:** exactly one reminder per eligible booking; none for cancelled/completed/past/already-reminded bookings; re-running the command sends nothing new; cross-tenant correctness.
+- **Test plan:** feature tests with `Notification::fake()` + time travel: reminder sent for a booking starting in ~23h, not for one in ~30h, not for cancelled/completed/past bookings, not sent twice on a second run; multi-tenant test asserting each tenant's merchant is the recipient.
+
+### T4.3 — `BookingCancelledNotification` fired on cancel · **S**
+- **Behavior:** notification cloned from `ChequeDueNotification` (`ShouldQueue`, `via()` → mail+database+broadcast, type tag `booking.cancelled`, localized). Fired from the cancel action/controller path (B3) to the tenant's merchant users when a booking transitions to `Cancelled`.
+- **Files:** *new* `app/Notifications/BookingCancelledNotification.php`; hook the `notify()` call into the cancel action introduced in B3 (reference only — the action lives in B3).
+- **Edge cases:** cancelling an already-cancelled booking must not re-notify (guard on the status transition, owned by B3's action); notification independent of whether a reminder was already sent.
+- **Acceptance criteria:** merchant receives exactly one cancellation notice per cancel transition; three channels present; bell renders it.
+- **Test plan:** feature test with `Notification::fake()` cancelling a confirmed booking and asserting the notice to merchant users; asserting no notice on a no-op re-cancel.
+
+### T4.4 — SMS/WhatsApp TODO channel scaffold (inert) · **S**
+- **Behavior:** add a documented but non-functional SMS/WhatsApp seam — a `routeNotificationForSms()` (or `toTwilio()`) stub marked TODO, plus a comment listing the env keys a real provider would need (the installed-but-unused Twilio channel, or the `mazin_host` stub). `via()` **excludes** the SMS channel in v1 so nothing is sent. No credentials, no `services.twilio`/`mazin_host` activation.
+- **Files:** `app/Models/User.php` (routing stub, TODO); a short note in this PRD / a code comment referencing §10; optionally a placeholder `app/Channels/` doc-comment — no live class.
+- **Edge cases:** the stub must never be reached by `via()` (guard against accidental enable); no runtime dependency on Twilio/mazin_host config.
+- **Acceptance criteria:** no SMS/WhatsApp is ever sent in v1; the seam is discoverable and documented; test suite unaffected.
+- **Test plan:** assert `via()` returns only `['mail','database','broadcast']` (no sms/twilio channel) for both notifications.
+
+## 7. Edge cases (cross-task)
+
+- **Unbound tenant scan:** the hourly command runs outside any tenant; it must `withoutGlobalScopes()` to see all bookings yet still resolve and notify each booking's own tenant's merchant users (never cross-notify).
+- **Idempotency:** a second run within the hour, an overlapping run, or a retried queue job must not produce a duplicate reminder — enforced by `reminder_sent_at`.
+- **Late creation:** a booking created 10h before start is reminded on the next hourly scan (correct — within the 24h window and not yet reminded), not skipped.
+- **State transitions after reminder:** a booking cancelled after its reminder was sent gets a cancellation notice but no further reminder.
+- **Timezone:** all window math is instant-based against `now()`; app timezone is Africa/Khartoum (no DST), so there is no wall-clock ambiguity, but tests should still pin time explicitly.
+- **`requires_booking = false`:** such services create no booking, so they never enter the reminder scan.
+
+## 8. Test plan (summary)
+
+- `Notification::fake()` feature tests for reminder eligibility (in-window vs out-of-window vs past), status exclusion (cancelled/completed), once-only dedupe on re-run, and multi-tenant recipient correctness (T4.1/T4.2).
+- Cancellation notice fired on cancel, not on no-op re-cancel (T4.3).
+- `via()` returns only mail+database+broadcast — no SMS ever sent (T4.4).
+- Regression: existing notification and scheduled-command tests stay green; the new column is additive.
+
+## 9. Rollout & backwards compatibility
+
+Fully additive: one nullable `bookings.reminder_sent_at` column, two new notification classes, one new scheduled command, and an inert SMS seam. No existing notification, schedule entry, or table changes. Existing tenants are unaffected until they have service bookings. The reminder command is safe to enable immediately (it no-ops when there are no eligible bookings). SMS/WhatsApp stays off until a future initiative wires a real provider.
+
+## 10. Resolved decisions
+
+- **Hourly scan** (decided). `bookings:notify-upcoming` runs hourly (`Schedule::command(...)->hourly()`) so the fixed 24h reminder lands within ~1h of the true offset — a light query on the indexed `starts_at`/`reminder_sent_at` window.
+- **`reminder_sent_at` column for dedupe** (decided). Add a nullable `reminder_sent_at` timestamp to `bookings` (additive migration in T4.2); the scan filters `reminder_sent_at IS NULL` within the window and stamps it after dispatch, keeping the scan cheap, indexable, and self-contained. No dependency on the `notifications` table for dedupe.
+- **Recipients = owner + admins** (decided). Both the reminder and the cancellation notice go to the tenant **owner and all admin users**, resolved in the unbound scan exactly as `cheques:notify-for-due` resolves its admin recipients. Clients are never notified in v1 (no client portal).
+- **Real SMS/WhatsApp provider deferred** (decided). B4 leaves the `via()` seam + a marked TODO channel only; choosing between the installed-but-unused Twilio channel and the `mazin_host` stub — and adding the env keys / `routeNotificationFor*` — is a future initiative, not this milestone.

--- a/docs/service-bookings/README.md
+++ b/docs/service-bookings/README.md
@@ -1,0 +1,79 @@
+# Service Product Type & Bookings — PRDs
+
+Product requirements for introducing a second product type — **service** — alongside the existing **physical** product, so merchants who sell time (clinics, mobile/outfield clinics, home-service providers) can sell bookable services through the same POS, with a merchant-side calendar to manage appointments.
+
+> **Scope guardrail (v1):** merchant-side only — **no client-facing portal**. Clients are notified, they do not self-serve. Existing `physical` products keep **zero behavior change** (strict backwards-compatibility). Out of scope for v1: staff/resource assignment, recurring appointments, configurable reminder timing, client self-service, route/distance calculation, waitlists, deposits, no-show tracking. Do not scaffold these "just in case".
+
+See the Phase 0 survey findings that motivate this work (product/customer/notification audit). **Headline:** products are a single tenant-scoped table with **no `type` discriminator today** (the clean gap we fill); the whole app is `unguard()`ed; money is integer-minor-units via `MoneyCast`. The `Customer` entity is reused as the client (single free-text `address`, `phone_number`, **no email**). A mature Laravel Notifications pipeline exists (`ChequeDueNotification` + the scheduled `cheques:notify-for-due` command is a near-exact blueprint for the 24h reminder), but **no working WhatsApp/SMS delivery** exists — so we ship on `mail`+`database`+`broadcast` and leave the SMS/WhatsApp channel as a clearly-marked TODO.
+
+## Milestones
+
+| PRD | Milestone | One PR? | Depends on |
+|---|---|---|---|
+| [B1](B1-data-layer.md) | Data layer — `type` discriminator, service attributes, add-ons, bookings, snapshots, `physical` backfill | yes | — |
+| [B2](B2-booking-engine.md) | Booking engine — overlap hard-block + travel-buffer soft-warning (pure domain, no UI) | yes | B1 |
+| [B3](B3-merchant-ui.md) | Merchant UI — service create/edit, booking create/edit, calendar view | yes | B1, B2 |
+| [B4](B4-notifications.md) | Notifications — 24h reminder + cancellation notice (following `ChequeDueNotification`) | yes | B1 (realistically after B2/B3) |
+
+**Critical path:** B1 → B2 → B3. B4 depends only on B1 (bookings + cancel action) but ships after B3 in practice.
+
+## Canonical schema & naming (single source of truth — every PRD conforms to this)
+
+Decided in Phase 0 (with the prompt's delegated calls resolved):
+
+### Product type discriminator
+- **`products.type`** — `string`, cast to new enum **`App\Enums\ProductType`** (`Physical` | `Service`, TitleCase keys per PHP rules; string values `physical` | `service`). **Default `physical`**, indexed, **backfill all existing rows to `physical`**. Follows the `MovementType`/`InventoryStrategyType` enum convention (`app/Enums/`).
+
+### Service attributes (columns on `products`, meaningful only when `type = service`)
+- **Base price** — reuse the existing **`price`** column (integer minor units via `MoneyCast`). No new base-price column.
+- **`duration_minutes`** — `unsignedInteger`, nullable.
+- **`requires_booking`** — `boolean`, default `false`. When false the service sells as a normal line item (no calendar).
+- **`on_site`** — `boolean`, default `false`. When true, booking requires an address and the travel buffer applies.
+- **`allow_overlap`** — `boolean`, default `false`. When false, overlapping **same-service** confirmed bookings are hard-blocked.
+- **`travel_buffer_minutes`** — `unsignedInteger`, nullable. **Per-service** (not merchant-level) — justified because `on_site` is per-service and Phase 3 reveals this field inside the service form; buffer reflects the travel/setup character of that service.
+
+### Add-ons (merchant-defined per service)
+- Table **`service_addons`**, model **`ServiceAddon`** (extends `BaseModel`). Columns: `tenant_id`, `product_id` (FK → products, cascade), `name` (string), `price_delta` (integer minor units via `MoneyCast`), timestamps, softDeletes. A booking's total = base price + Σ selected add-on deltas.
+
+### Booking
+- Table **`bookings`**, model **`Booking`** (extends `BaseModel`). Columns: `tenant_id`, `service_product_id` (FK → products), `customer_id` (FK → customers), `starts_at` (datetime), `ends_at` (datetime, derived from `starts_at` + service `duration_minutes` and **persisted** on save), `status` (string → enum **`App\Enums\BookingStatus`**: `Confirmed` | `Cancelled` | `Completed`, default `Confirmed`), `address` (text, nullable — **required only when the service is `on_site`**, snapshotted per-booking), `notes` (text, nullable), **`base_price`** (integer minor, **snapshot** at booking time), **`total`** (integer minor, computed once at booking time = `base_price` + Σ snapshot deltas and **stored**), timestamps, softDeletes. (`reminder_sent_at` nullable timestamp is added later as an additive migration in **B4**.)
+- **Overlap & buffer are per-service** (confirmed via user): a new booking for service X is checked only against other **`Confirmed`** bookings of service X (`Completed`/`Cancelled` never block); `allow_overlap = true` skips the block entirely.
+
+### Booking add-on snapshots (immutability)
+- Table **`booking_addons`**, model **`BookingAddon`** (extends `BaseModel`). Columns: `tenant_id`, `booking_id` (FK → bookings, cascade), `service_addon_id` (FK → service_addons, **nullable** source reference), `name` (**snapshot**), `price_delta` (**snapshot**, integer minor via `MoneyCast`), timestamps.
+- **Snapshot rule:** both the booking `base_price` and each `booking_addons.price_delta`/`name` are captured at booking time. Later edits to the service price or its add-ons **must not** mutate historical bookings.
+
+### Booking engine (B2)
+- `app/Services/Bookings/` — a `BookingScheduler` (or split `OverlapDetector` + `TravelBufferChecker`) mirroring the `app/Services/Inventory/` strategy layout. Overlap → throws `App\Exceptions\BookingOverlapException` (hard block) unless the service `allow_overlap`. Travel buffer → returns a **soft warning** (nullable value object / boolean+message), **never** throws; on-site services only.
+
+### Notifications (B4)
+- `App\Notifications\BookingReminderNotification` (24h fixed offset, not configurable) and `App\Notifications\BookingCancelledNotification` (to the merchant on cancel), following `ChequeDueNotification` — `implements ShouldQueue`, `via()` → `['mail','database','broadcast']`. Scheduled command (e.g. `bookings:notify-upcoming`) in `routes/console.php` following `cheques:notify-for-due` (window scan, `withoutGlobalScopes()` for the unbound tenant context). SMS/WhatsApp = **marked TODO** (no working channel exists; Twilio installed-but-unused, `mazin_host` stub).
+
+## Cross-cutting conventions (apply to every task)
+
+- **TDD** — Pest test written first (`php artisan make:test --pest`); run `php artisan test --compact --filter=…`. 100% model coverage is mandatory.
+- **Localization** — every user-facing string via `__()`; Arabic-first.
+- **RTL + dark mode** — every Vue element per `.ai/Design rules`; **logical** properties only (`ms/me/ps/pe/text-start/text-end`), never physical. One consistent numeral system per view; isolate bidi (times/addresses/Latin inside Arabic).
+- **Pint** — `vendor/bin/pint --dirty --format agent` on touched PHP before finalizing.
+- **Additive & reversible migrations only**; nothing destructive. New tables carry `tenant_id` and extend `BaseModel` (models are unguarded via `BaseModel::booted()`).
+- **Backwards compatibility** — `physical` products keep exactly today's behavior: service-only paths (stock, units, expiry, booking) must be bypassed for physical, and physical validation/flow is untouched.
+- **No new dependencies** without explicit approval.
+
+## PRD template
+
+Each milestone PRD follows this structure (standard depth, ~1 page + task specs):
+
+```
+# PRD — Bx: <Title>
+Status · Milestone · Depends on · PR grouping
+## 1. Problem
+## 2. Goals / Non-goals
+## 3. Current state (from audit, with file:line)
+## 4. Design & behavior
+## 5. Data model / schema changes
+## 6. Task specs   → per task: Behavior · Files · Edge cases · Acceptance criteria · Test plan · Size
+## 7. Edge cases (cross-task)
+## 8. Test plan (summary)
+## 9. Rollout & backwards compatibility
+## 10. Open questions
+```

--- a/resources/js/Components/Bookings/BookingCalendar.vue
+++ b/resources/js/Components/Bookings/BookingCalendar.vue
@@ -1,0 +1,170 @@
+<script setup>
+import { ref, computed } from "vue";
+
+const props = defineProps({
+    bookings: { type: Array, default: () => [] },
+});
+
+const emit = defineEmits(["select", "create"]);
+
+const locale = preferences("language", "en") === "ar" ? "ar" : "en";
+// Arabic calendars conventionally start the week on Saturday; otherwise Sunday.
+const weekStart = locale === "ar" ? 6 : 0;
+
+const today = new Date();
+const cursor = ref(new Date(today.getFullYear(), today.getMonth(), 1));
+
+const monthLabel = computed(() =>
+    cursor.value.toLocaleDateString(locale, { month: "long", year: "numeric" })
+);
+
+// Localised weekday short names, rotated to the locale's week start.
+const weekdays = computed(() => {
+    const base = new Date(2026, 1, 1); // a Sunday
+    return Array.from({ length: 7 }, (_, i) => {
+        const d = new Date(base);
+        d.setDate(base.getDate() + ((weekStart + i) % 7));
+        return d.toLocaleDateString(locale, { weekday: "short" });
+    });
+});
+
+const pad = (n) => String(n).padStart(2, "0");
+const dateKey = (d) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+// Group bookings by calendar day (local date portion of starts_at).
+const byDay = computed(() => {
+    const map = {};
+    for (const b of props.bookings) {
+        if (!b.starts_at) continue;
+        const key = b.starts_at.slice(0, 10);
+        (map[key] ??= []).push(b);
+    }
+    return map;
+});
+
+// Build the 6-week grid covering the visible month.
+const cells = computed(() => {
+    const year = cursor.value.getFullYear();
+    const month = cursor.value.getMonth();
+    const first = new Date(year, month, 1);
+    const lead = (first.getDay() - weekStart + 7) % 7;
+    const start = new Date(year, month, 1 - lead);
+
+    return Array.from({ length: 42 }, (_, i) => {
+        const d = new Date(start.getFullYear(), start.getMonth(), start.getDate() + i);
+        const key = dateKey(d);
+        return {
+            key,
+            day: d.toLocaleDateString(locale, { day: "numeric" }),
+            inMonth: d.getMonth() === month,
+            isToday: key === dateKey(today),
+            bookings: byDay.value[key] ?? [],
+        };
+    });
+});
+
+const timeOf = (b) =>
+    b.starts_at
+        ? new Date(b.starts_at).toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" })
+        : "";
+
+const statusClass = (status) =>
+    ({
+        confirmed: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400",
+        completed: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+        cancelled: "bg-red-50 text-red-600 line-through dark:bg-red-900/20 dark:text-red-400",
+    }[status] ?? "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400");
+
+const shift = (delta) => {
+    cursor.value = new Date(cursor.value.getFullYear(), cursor.value.getMonth() + delta, 1);
+};
+const goToday = () => {
+    cursor.value = new Date(today.getFullYear(), today.getMonth(), 1);
+};
+</script>
+
+<template>
+    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+        <!-- Header -->
+        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <div class="flex items-center gap-x-2">
+                <button
+                    type="button"
+                    class="p-2 text-gray-500 dark:text-gray-400 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    :title="__('Previous')"
+                    @click="shift(-1)"
+                >
+                    <svg class="h-4 w-4 rtl:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+                </button>
+                <h3 class="text-base font-semibold text-gray-900 dark:text-white min-w-[9rem] text-center">{{ monthLabel }}</h3>
+                <button
+                    type="button"
+                    class="p-2 text-gray-500 dark:text-gray-400 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                    :title="__('Next')"
+                    @click="shift(1)"
+                >
+                    <svg class="h-4 w-4 rtl:rotate-180" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+                </button>
+            </div>
+            <button
+                type="button"
+                class="px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+                @click="goToday"
+            >
+                {{ __("Today") }}
+            </button>
+        </div>
+
+        <!-- Weekday header -->
+        <div class="grid grid-cols-7 border-b border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/40">
+            <div
+                v-for="wd in weekdays"
+                :key="wd"
+                class="px-2 py-2 text-center text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500"
+            >
+                {{ wd }}
+            </div>
+        </div>
+
+        <!-- Day grid -->
+        <div class="grid grid-cols-7">
+            <div
+                v-for="cell in cells"
+                :key="cell.key"
+                class="min-h-[6rem] border-b border-e border-gray-100 dark:border-gray-800 p-1.5 cursor-pointer transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                :class="cell.inMonth ? 'bg-white dark:bg-gray-900' : 'bg-gray-50/40 dark:bg-gray-800/20'"
+                @click="emit('create', cell.key)"
+            >
+                <div class="flex items-center justify-between">
+                    <span
+                        class="inline-flex items-center justify-center w-6 h-6 text-xs rounded-full"
+                        :class="[
+                            cell.isToday ? 'bg-emerald-600 text-white font-semibold' : 'text-gray-500 dark:text-gray-400',
+                            !cell.inMonth && !cell.isToday ? 'opacity-40' : '',
+                        ]"
+                    >
+                        {{ cell.day }}
+                    </span>
+                </div>
+
+                <div class="mt-1 space-y-1">
+                    <button
+                        v-for="b in cell.bookings.slice(0, 3)"
+                        :key="b.id"
+                        type="button"
+                        class="block w-full px-1.5 py-1 text-start rounded-md text-[11px] leading-tight truncate transition-colors"
+                        :class="statusClass(b.status)"
+                        @click.stop="emit('select', b)"
+                        :title="`${b.service?.name ?? ''} — ${b.customer?.name ?? ''}`"
+                    >
+                        <Ltr class="font-semibold">{{ timeOf(b) }}</Ltr>
+                        <span class="ms-1">{{ b.service?.name }}</span>
+                    </button>
+                    <p v-if="cell.bookings.length > 3" class="px-1.5 text-[10px] text-gray-400 dark:text-gray-500">
+                        +{{ cell.bookings.length - 3 }} {{ __("more") }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/Components/Bookings/BookingForm.vue
+++ b/resources/js/Components/Bookings/BookingForm.vue
@@ -1,0 +1,393 @@
+<script setup>
+import { ref, computed, watch } from "vue";
+import { useForm, usePage } from "@inertiajs/vue3";
+import InputError from "@/Components/InputError.vue";
+import InputLabel from "@/Components/InputLabel.vue";
+import PrimaryButton from "@/Components/PrimaryButton.vue";
+import TextInput from "@/Components/TextInput.vue";
+import QuickAddPartyModal from "@/Components/QuickAddPartyModal.vue";
+import { useAsyncOptions } from "@/Composables/useAsyncOptions";
+
+const props = defineProps({
+    show: { type: Boolean, default: false },
+    booking: { type: Object, default: null },
+    prefillStart: { type: String, default: null },
+});
+
+const emit = defineEmits(["close", "saved"]);
+
+const isEditing = computed(() => !!props.booking);
+const modalDir = preferences("language", "en") === "ar" ? "rtl" : "ltr";
+
+const {
+    options: customerOptions,
+    loading: customersLoading,
+    loadMore: loadMoreCustomers,
+    onSearch: searchCustomers,
+} = useAsyncOptions(route("api.customers.index"));
+
+const {
+    options: serviceOptions,
+    loading: servicesLoading,
+    loadMore: loadMoreServices,
+    onSearch: searchServices,
+} = useAsyncOptions(route("api.products.index", { type: "service" }));
+
+const selectedCustomer = ref(props.booking?.customer ?? null);
+const selectedService = ref(props.booking?.service ?? null);
+const showQuickAddModal = ref(false);
+const bufferWarnings = ref([]);
+
+const form = useForm({
+    service_product_id: props.booking?.service_product_id ?? null,
+    customer_id: props.booking?.customer_id ?? null,
+    starts_at: props.booking?.starts_at
+        ? props.booking.starts_at.slice(0, 16)
+        : props.prefillStart ?? "",
+    address: props.booking?.address ?? "",
+    notes: props.booking?.notes ?? "",
+    status: props.booking?.status ?? "confirmed",
+    addons: [],
+    acknowledge_buffer: false,
+});
+
+// Reset the form whenever the modal is (re)opened for a new context.
+watch(
+    () => props.show,
+    (open) => {
+        if (!open) return;
+        bufferWarnings.value = [];
+        selectedCustomer.value = props.booking?.customer ?? null;
+        selectedService.value = props.booking?.service ?? null;
+        form.defaults({
+            service_product_id: props.booking?.service_product_id ?? null,
+            customer_id: props.booking?.customer_id ?? null,
+            starts_at: props.booking?.starts_at
+                ? props.booking.starts_at.slice(0, 16)
+                : props.prefillStart ?? "",
+            address: props.booking?.address ?? "",
+            notes: props.booking?.notes ?? "",
+            status: props.booking?.status ?? "confirmed",
+            addons: [],
+            acknowledge_buffer: false,
+        });
+        form.reset();
+        form.clearErrors();
+    }
+);
+
+const serviceAddons = computed(() => selectedService.value?.service_addons ?? []);
+const requiresAddress = computed(() => !!selectedService.value?.on_site);
+
+const endsAt = computed(() => {
+    if (!form.starts_at || !selectedService.value?.duration_minutes) return null;
+    const start = new Date(form.starts_at);
+    if (isNaN(start.getTime())) return null;
+    const end = new Date(start.getTime() + selectedService.value.duration_minutes * 60000);
+    return end.toISOString().slice(0, 16).replace("T", " ");
+});
+
+const bookingTotal = computed(() => {
+    const base = parseFloat(selectedService.value?.price) || 0;
+    const extras = serviceAddons.value
+        .filter((a) => form.addons.includes(a.id))
+        .reduce((sum, a) => sum + (parseFloat(a.price_delta) || 0), 0);
+    return base + extras;
+});
+
+const onCustomerSelect = (customerId) => {
+    selectedCustomer.value = customerOptions.value.find((c) => c.id == customerId) ?? selectedCustomer.value;
+    form.customer_id = customerId ?? null;
+};
+
+const onCustomerCreated = (customer) => {
+    selectedCustomer.value = customer;
+    form.customer_id = customer.id;
+    customerOptions.value.unshift(customer);
+    showQuickAddModal.value = false;
+};
+
+const onServiceSelect = (serviceId) => {
+    const service = serviceOptions.value.find((s) => s.id == serviceId) ?? null;
+    selectedService.value = service;
+    form.service_product_id = serviceId ?? null;
+    form.addons = []; // clear stale add-ons when the service changes
+    if (!requiresAddress.value) form.address = "";
+};
+
+const currency = computed(() =>
+    /^[A-Z]{3}$/.test(preferences("currency")) ? preferences("currency") : "SDG"
+);
+
+const submit = () => {
+    const onSuccess = () => {
+        const warnings = usePage().props.flash?.travel_buffer_warnings;
+        if (warnings && warnings.length) {
+            bufferWarnings.value = warnings;
+            return;
+        }
+        bufferWarnings.value = [];
+        form.reset();
+        emit("saved");
+    };
+
+    const options = { preserveScroll: true, preserveState: true, onSuccess };
+
+    if (isEditing.value) {
+        form.put(route("bookings.update", props.booking.id), options);
+    } else {
+        form.post(route("bookings.store"), options);
+    }
+};
+
+const confirmAndProceed = () => {
+    form.acknowledge_buffer = true;
+    bufferWarnings.value = [];
+    submit();
+};
+
+const close = () => {
+    bufferWarnings.value = [];
+    emit("close");
+};
+</script>
+
+<template>
+    <div class="relative z-50" role="dialog" aria-modal="true">
+        <transition
+            enter-from-class="opacity-0"
+            enter-active-class="duration-300 ease-out"
+            enter-to-class="opacity-100"
+            leave-from-class="opacity-100"
+            leave-active-class="duration-200 ease-in"
+            leave-to-class="opacity-0"
+        >
+            <div
+                v-show="show"
+                class="fixed inset-0 transition-opacity bg-gray-500/20 dark:bg-gray-900/60 backdrop-blur-sm"
+                @click="close"
+            ></div>
+        </transition>
+
+        <transition
+            enter-from-class="scale-95 opacity-0"
+            enter-active-class="duration-200 ease-out"
+            enter-to-class="scale-100 opacity-100"
+            leave-from-class="scale-100 opacity-100"
+            leave-active-class="duration-200 ease-in"
+            leave-to-class="scale-95 opacity-0"
+        >
+            <div v-show="show" class="fixed inset-0 z-50 overflow-y-auto">
+                <div class="flex items-end justify-center min-h-full p-4 text-center sm:items-center sm:p-0">
+                    <div
+                        :dir="modalDir"
+                        class="relative w-full px-6 pt-6 pb-6 text-start transition-all transform bg-white border border-gray-200 shadow-xl dark:bg-gray-900 dark:border-gray-700 rounded-xl sm:my-8 sm:max-w-2xl"
+                        @click.stop
+                    >
+                        <!-- Header -->
+                        <div class="flex items-start justify-between gap-x-4">
+                            <div>
+                                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+                                    {{ isEditing ? __("Edit Booking") : __("New Booking") }}
+                                </h3>
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                                    {{ __("Schedule an appointment for a service.") }}
+                                </p>
+                            </div>
+                            <button
+                                type="button"
+                                class="p-1 text-gray-400 transition-colors duration-200 rounded-lg shrink-0 hover:text-gray-600 hover:bg-gray-50 dark:text-gray-500 dark:hover:text-gray-300 dark:hover:bg-gray-800 focus:outline-none"
+                                @click="close"
+                                :title="__('Cancel')"
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+
+                        <form class="mt-6 space-y-5" @submit.prevent="submit">
+                            <!-- Service -->
+                            <div>
+                                <InputLabel :value="__('Service')" />
+                                <CustomSelect
+                                    :model-value="selectedService"
+                                    :options="serviceOptions"
+                                    label="name"
+                                    track-by="id"
+                                    :remote="true"
+                                    :loading="servicesLoading"
+                                    class="mt-1"
+                                    :placeholder="__('Search service...')"
+                                    @update:model-value="onServiceSelect"
+                                    @search-change="searchServices"
+                                    @scroll-end="loadMoreServices"
+                                />
+                                <InputError class="mt-1" :message="form.errors.service_product_id" />
+                            </div>
+
+                            <!-- Customer -->
+                            <div>
+                                <InputLabel :value="__('Customer')" />
+                                <CustomSelect
+                                    :model-value="selectedCustomer"
+                                    :options="customerOptions"
+                                    label="name"
+                                    track-by="id"
+                                    :remote="true"
+                                    :loading="customersLoading"
+                                    class="mt-1"
+                                    :placeholder="__('Search customer...')"
+                                    @update:model-value="onCustomerSelect"
+                                    @search-change="searchCustomers"
+                                    @scroll-end="loadMoreCustomers"
+                                >
+                                    <template #noResult>
+                                        <div class="p-2 space-y-2 text-center">
+                                            <p class="text-sm text-gray-500">{{ __("No elements found. Consider changing the search query.") }}</p>
+                                            <button type="button" @click="showQuickAddModal = true" class="text-emerald-600 hover:text-emerald-700 font-semibold text-sm">
+                                                + {{ __("Add New Customer") }}
+                                            </button>
+                                        </div>
+                                    </template>
+                                </CustomSelect>
+                                <InputError class="mt-1" :message="form.errors.customer_id" />
+                            </div>
+
+                            <!-- Date/time + derived end -->
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <InputLabel for="starts_at" :value="__('Starts at')" />
+                                    <input
+                                        id="starts_at"
+                                        v-model="form.starts_at"
+                                        type="datetime-local"
+                                        dir="ltr"
+                                        class="w-full px-3 py-2 mt-1 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                    />
+                                    <InputError class="mt-1" :message="form.errors.starts_at" />
+                                </div>
+                                <div>
+                                    <InputLabel :value="__('Ends at')" />
+                                    <div class="w-full px-3 py-2 mt-1 text-sm text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-700 rounded-lg">
+                                        <Ltr>{{ endsAt || "—" }}</Ltr>
+                                    </div>
+                                    <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">{{ __("Derived from the service duration.") }}</p>
+                                </div>
+                            </div>
+
+                            <!-- Address (on-site only) -->
+                            <div v-if="requiresAddress">
+                                <InputLabel for="address" :value="__('Address')" />
+                                <TextInput id="address" v-model="form.address" type="text" class="block w-full mt-1" :placeholder="__('Client address')" />
+                                <InputError class="mt-1" :message="form.errors.address" />
+                            </div>
+
+                            <!-- Add-ons -->
+                            <div v-if="serviceAddons.length">
+                                <InputLabel :value="__('Add-ons')" />
+                                <div class="mt-1 space-y-2">
+                                    <label
+                                        v-for="addon in serviceAddons"
+                                        :key="addon.id"
+                                        class="flex items-center justify-between px-3 py-2 border border-gray-200 dark:border-gray-700 rounded-lg cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                                    >
+                                        <span class="flex items-center gap-x-2 text-sm text-gray-700 dark:text-gray-300">
+                                            <input
+                                                type="checkbox"
+                                                :value="addon.id"
+                                                v-model="form.addons"
+                                                class="border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                            />
+                                            {{ addon.name }}
+                                        </span>
+                                        <Ltr class="text-sm font-medium text-gray-500 dark:text-gray-400">+{{ Number(addon.price_delta).toFixed(2) }}</Ltr>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <!-- Running total -->
+                            <div
+                                v-if="selectedService"
+                                class="flex items-center justify-between px-3 py-2 text-sm rounded-lg bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
+                            >
+                                <span class="font-medium">{{ __("Total") }}</span>
+                                <Ltr class="font-semibold">{{ bookingTotal.toFixed(2) }} {{ currency }}</Ltr>
+                            </div>
+
+                            <!-- Status + Notes -->
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <InputLabel for="status" :value="__('Status')" />
+                                    <select
+                                        id="status"
+                                        v-model="form.status"
+                                        class="block w-full px-3 py-2 mt-1 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                    >
+                                        <option value="confirmed">{{ __("Confirmed") }}</option>
+                                        <option value="completed">{{ __("Completed") }}</option>
+                                        <option value="cancelled">{{ __("Cancelled") }}</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <InputLabel for="notes" :value="__('Notes')" />
+                                    <TextInput id="notes" v-model="form.notes" type="text" class="block w-full mt-1" :placeholder="__('Optional')" />
+                                </div>
+                            </div>
+
+                            <!-- Travel-buffer soft warning -->
+                            <div
+                                v-if="bufferWarnings.length"
+                                class="p-4 border rounded-lg border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800"
+                            >
+                                <div class="flex items-start gap-x-2">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5 shrink-0 text-amber-600 dark:text-amber-400">
+                                        <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625l6.28-10.875zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+                                    </svg>
+                                    <div class="text-sm text-amber-800 dark:text-amber-300">
+                                        <p class="font-semibold">{{ __("Tight travel buffer") }}</p>
+                                        <p v-for="(w, i) in bufferWarnings" :key="i" class="mt-0.5">
+                                            {{ w.direction === 'before'
+                                                ? __("Only :gap min after the previous booking (buffer :buf min).", { gap: w.gap_minutes, buf: w.required_buffer_minutes })
+                                                : __("Only :gap min before the next booking (buffer :buf min).", { gap: w.gap_minutes, buf: w.required_buffer_minutes }) }}
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="flex justify-end mt-3">
+                                    <button
+                                        type="button"
+                                        @click="confirmAndProceed"
+                                        class="inline-flex items-center justify-center px-4 py-2 text-sm font-medium text-white rounded-lg bg-amber-600 hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 transition-colors duration-200"
+                                    >
+                                        {{ __("Confirm and proceed") }}
+                                    </button>
+                                </div>
+                            </div>
+
+                            <!-- Footer -->
+                            <div class="flex items-center justify-end pt-5 mt-5 border-t border-gray-200 dark:border-gray-700 gap-x-3">
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center justify-center px-4 py-2 text-sm font-normal text-gray-700 bg-white border border-gray-300 rounded-lg dark:text-gray-300 dark:bg-gray-800 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors duration-200"
+                                    @click="close"
+                                >
+                                    {{ __("Cancel") }}
+                                </button>
+                                <PrimaryButton :class="{ 'opacity-50': form.processing }" :disabled="form.processing">
+                                    {{ isEditing ? __("Save") : __("Create booking") }}
+                                </PrimaryButton>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </transition>
+
+        <QuickAddPartyModal
+            :show="showQuickAddModal"
+            type="customer"
+            @close="showQuickAddModal = false"
+            @created="onCustomerCreated"
+        />
+    </div>
+</template>

--- a/resources/js/Components/Bookings/BookingForm.vue
+++ b/resources/js/Components/Bookings/BookingForm.vue
@@ -38,6 +38,13 @@ const selectedService = ref(props.booking?.service ?? null);
 const showQuickAddModal = ref(false);
 const bufferWarnings = ref([]);
 
+// On edit, pre-check the add-ons that were snapshotted onto the booking (by
+// their source add-on id; add-ons whose source was deleted can't be re-picked).
+const initialAddonIds = () =>
+    (props.booking?.addons ?? [])
+        .map((addon) => addon.service_addon_id)
+        .filter((id) => id != null);
+
 const form = useForm({
     service_product_id: props.booking?.service_product_id ?? null,
     customer_id: props.booking?.customer_id ?? null,
@@ -47,7 +54,7 @@ const form = useForm({
     address: props.booking?.address ?? "",
     notes: props.booking?.notes ?? "",
     status: props.booking?.status ?? "confirmed",
-    addons: [],
+    addons: initialAddonIds(),
     acknowledge_buffer: false,
 });
 
@@ -68,7 +75,7 @@ watch(
             address: props.booking?.address ?? "",
             notes: props.booking?.notes ?? "",
             status: props.booking?.status ?? "confirmed",
-            addons: [],
+            addons: initialAddonIds(),
             acknowledge_buffer: false,
         });
         form.reset();

--- a/resources/js/Components/Invoicing/InvoiceForm.vue
+++ b/resources/js/Components/Invoicing/InvoiceForm.vue
@@ -54,7 +54,7 @@
         loading: productsLoading,
         loadMore: loadMoreProducts,
         onSearch: searchProduct,
-    } = useAsyncOptions(route('api.products.index'));
+    } = useAsyncOptions(route('api.products.index', { line_sale: 1 }));
 
     const lineItems = ref(
         props.prefill?.items?.length

--- a/resources/js/Components/Products/ProductForm.vue
+++ b/resources/js/Components/Products/ProductForm.vue
@@ -44,6 +44,7 @@
 
     const show = ref(false);
     const product = useForm({
+        type: props.product?.type || "physical",
         name: props.product?.name,
         cost: props.product?.cost ? String(props.product?.cost) : "",
         price: props.product?.price ? String(props.product?.price) : "",
@@ -58,6 +59,37 @@
             storage_id: storage.id,
             quantity: currentQuantityFor(storage.id),
         })),
+        // Service-only fields (ignored server-side for physical products).
+        duration_minutes: props.product?.duration_minutes || "",
+        requires_booking: props.product?.requires_booking ?? true,
+        on_site: props.product?.on_site ?? false,
+        allow_overlap: props.product?.allow_overlap ?? false,
+        travel_buffer_minutes: props.product?.travel_buffer_minutes || "",
+        addons: (props.product?.service_addons || []).map((a) => ({
+            id: a.id,
+            name: a.name,
+            price_delta: a.price_delta,
+        })),
+    });
+
+    const isService = computed(() => product.type === "service");
+
+    const addAddon = () => {
+        product.addons.push({ name: "", price_delta: "" });
+    };
+
+    const removeAddon = (index) => {
+        product.addons.splice(index, 1);
+    };
+
+    // Live preview of a booking's total (base price + all add-on deltas).
+    const serviceTotal = computed(() => {
+        const base = parseFloat(product.price) || 0;
+        const extras = product.addons.reduce(
+            (sum, a) => sum + (parseFloat(a.price_delta) || 0),
+            0
+        );
+        return base + extras;
     });
 
     const addUnit = () => {
@@ -223,6 +255,33 @@
                                 class="mt-6"
                                 @submit.prevent="save"
                             >
+                                <!-- Product type toggle -->
+                                <div class="mb-6">
+                                    <InputLabel :value="__('Product type')" class="mb-2" />
+                                    <div class="inline-flex p-1 bg-gray-100 dark:bg-gray-800 rounded-lg">
+                                        <button
+                                            type="button"
+                                            class="px-4 py-1.5 text-sm font-medium rounded-md transition-colors duration-200"
+                                            :class="!isService
+                                                ? 'bg-white dark:bg-gray-900 text-emerald-700 dark:text-emerald-400 shadow-sm'
+                                                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+                                            @click="product.type = 'physical'"
+                                        >
+                                            {{ __("Physical") }}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            class="px-4 py-1.5 text-sm font-medium rounded-md transition-colors duration-200"
+                                            :class="isService
+                                                ? 'bg-white dark:bg-gray-900 text-emerald-700 dark:text-emerald-400 shadow-sm'
+                                                : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+                                            @click="product.type = 'service'"
+                                        >
+                                            {{ __("Service") }}
+                                        </button>
+                                    </div>
+                                </div>
+
                                 <div class="grid gap-6 md:grid-cols-2">
                                     <!-- Left column: product details -->
                                     <div class="space-y-5">
@@ -250,8 +309,8 @@
                                             <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 rtl:text-right">
                                                 {{ __("Pricing") }}
                                             </p>
-                                            <div class="grid grid-cols-2 gap-4">
-                                                <div>
+                                            <div class="grid gap-4" :class="isService ? 'grid-cols-1' : 'grid-cols-2'">
+                                                <div v-if="!isService">
                                                     <InputLabel
                                                         for="cost"
                                                         :value="__('Cost')"
@@ -273,7 +332,7 @@
                                                 <div>
                                                     <InputLabel
                                                         for="price"
-                                                        :value="__('Price')"
+                                                        :value="isService ? __('Base price') : __('Price')"
                                                     />
                                                     <TextInput
                                                         id="price"
@@ -324,7 +383,7 @@
                                         </div>
 
                                         <!-- Stock & alerts group -->
-                                        <div class="grid grid-cols-2 gap-4">
+                                        <div v-if="!isService" class="grid grid-cols-2 gap-4">
                                             <div>
                                                 <InputLabel
                                                     for="expire_date"
@@ -367,7 +426,7 @@
                                         </div>
 
                                         <!-- Stock per location (add + edit) -->
-                                        <div v-if="props.storages.length">
+                                        <div v-if="!isService && props.storages.length">
                                             <div class="flex items-center justify-between gap-x-2">
                                                 <InputLabel :value="__('Stock per location')" />
                                                 <span
@@ -441,8 +500,8 @@
                                         </div>
                                     </div>
 
-                                    <!-- Right column: units (collapsible) -->
-                                    <div class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg self-start">
+                                    <!-- Right column: units (collapsible) — physical only -->
+                                    <div v-if="!isService" class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg self-start">
                                         <button
                                             type="button"
                                             class="flex items-center justify-between w-full"
@@ -553,6 +612,157 @@
                                             >
                                                 {{ __("Add Unit") }}
                                             </button>
+                                        </div>
+                                    </div>
+
+                                    <!-- Right column: service settings + add-ons — service only -->
+                                    <div v-if="isService" class="space-y-5 self-start">
+                                        <!-- Scheduling -->
+                                        <div class="p-4 space-y-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+                                            <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 rtl:text-right">
+                                                {{ __("Service settings") }}
+                                            </p>
+
+                                            <div>
+                                                <InputLabel for="duration_minutes" :value="__('Duration (minutes)')" />
+                                                <TextInput
+                                                    id="duration_minutes"
+                                                    v-model="product.duration_minutes"
+                                                    type="number" inputmode="numeric"
+                                                    min="1"
+                                                    dir="ltr"
+                                                    class="block w-full mt-1"
+                                                    :placeholder="__('30')"
+                                                />
+                                                <InputError class="mt-1" :message="product.errors.duration_minutes" />
+                                            </div>
+
+                                            <!-- Flags -->
+                                            <label class="flex items-start gap-x-3 cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    v-model="product.requires_booking"
+                                                    class="mt-0.5 border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                                />
+                                                <span class="text-sm text-gray-700 dark:text-gray-300">
+                                                    {{ __("Requires booking") }}
+                                                    <span class="block text-xs text-gray-400 dark:text-gray-500">
+                                                        {{ __("Selling this service creates a calendar booking.") }}
+                                                    </span>
+                                                </span>
+                                            </label>
+
+                                            <label class="flex items-start gap-x-3 cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    v-model="product.allow_overlap"
+                                                    class="mt-0.5 border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                                />
+                                                <span class="text-sm text-gray-700 dark:text-gray-300">
+                                                    {{ __("Allow overlapping bookings") }}
+                                                    <span class="block text-xs text-gray-400 dark:text-gray-500">
+                                                        {{ __("Permit double-booking this service.") }}
+                                                    </span>
+                                                </span>
+                                            </label>
+
+                                            <label class="flex items-start gap-x-3 cursor-pointer">
+                                                <input
+                                                    type="checkbox"
+                                                    v-model="product.on_site"
+                                                    class="mt-0.5 border-gray-300 dark:border-gray-600 rounded text-emerald-600 focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                                />
+                                                <span class="text-sm text-gray-700 dark:text-gray-300">
+                                                    {{ __("On-site service") }}
+                                                    <span class="block text-xs text-gray-400 dark:text-gray-500">
+                                                        {{ __("Staff travel to the client; a booking address is required.") }}
+                                                    </span>
+                                                </span>
+                                            </label>
+
+                                            <!-- Travel buffer, revealed only when on-site -->
+                                            <div v-if="product.on_site">
+                                                <InputLabel for="travel_buffer_minutes" :value="__('Travel buffer (minutes)')" />
+                                                <TextInput
+                                                    id="travel_buffer_minutes"
+                                                    v-model="product.travel_buffer_minutes"
+                                                    type="number" inputmode="numeric"
+                                                    min="0"
+                                                    dir="ltr"
+                                                    class="block w-full mt-1"
+                                                    :placeholder="__('30')"
+                                                />
+                                                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                                                    {{ __("Warns the scheduler when a booking starts too soon after the previous one.") }}
+                                                </p>
+                                                <InputError class="mt-1" :message="product.errors.travel_buffer_minutes" />
+                                            </div>
+                                        </div>
+
+                                        <!-- Add-ons editor -->
+                                        <div class="p-4 space-y-3 border border-gray-200 dark:border-gray-700 rounded-lg">
+                                            <div class="flex items-center justify-between">
+                                                <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 rtl:text-right">
+                                                    {{ __("Add-ons") }}
+                                                    <span v-if="product.addons.length" class="text-emerald-500">({{ product.addons.length }})</span>
+                                                </p>
+                                                <button
+                                                    type="button"
+                                                    class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 hover:text-emerald-700"
+                                                    @click="addAddon"
+                                                >
+                                                    + {{ __("Add") }}
+                                                </button>
+                                            </div>
+
+                                            <p v-if="!product.addons.length" class="text-xs text-gray-400 dark:text-gray-500">
+                                                {{ __("Optional extras a client can select on a booking; each adds its price to the base price.") }}
+                                            </p>
+
+                                            <div
+                                                v-for="(addon, index) in product.addons"
+                                                :key="`addon-` + index"
+                                                class="flex items-start gap-2"
+                                            >
+                                                <div class="flex-1 min-w-0">
+                                                    <TextInput
+                                                        v-model="addon.name"
+                                                        type="text"
+                                                        class="block w-full"
+                                                        :placeholder="__('Add-on name')"
+                                                    />
+                                                    <InputError class="mt-1" :message="product.errors[`addons.${index}.name`]" />
+                                                </div>
+                                                <div class="w-28 shrink-0">
+                                                    <TextInput
+                                                        v-model="addon.price_delta"
+                                                        type="number" inputmode="decimal"
+                                                        min="0" step="0.01"
+                                                        dir="ltr"
+                                                        class="block w-full"
+                                                        :placeholder="__('0.00')"
+                                                    />
+                                                    <InputError class="mt-1" :message="product.errors[`addons.${index}.price_delta`]" />
+                                                </div>
+                                                <button
+                                                    type="button"
+                                                    class="p-2 text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors shrink-0"
+                                                    @click="removeAddon(index)"
+                                                    :title="__('Remove')"
+                                                >
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
+                                                    </svg>
+                                                </button>
+                                            </div>
+
+                                            <div
+                                                v-if="product.addons.length"
+                                                class="flex items-center justify-between px-3 py-2 text-sm rounded-lg bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400"
+                                            >
+                                                <span class="font-medium">{{ __("Total with all add-ons") }}</span>
+                                                <Ltr class="font-semibold">{{ serviceTotal.toFixed(2) }} {{ product.currency }}</Ltr>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/resources/js/Components/Quotes/QuoteForm.vue
+++ b/resources/js/Components/Quotes/QuoteForm.vue
@@ -28,7 +28,7 @@ const {
     loading: productsLoading,
     loadMore: loadMoreProducts,
     onSearch: searchProducts,
-} = useAsyncOptions(route("api.products.index"));
+} = useAsyncOptions(route("api.products.index", { line_sale: 1 }));
 
 const selectedCustomer = ref(props.quote?.customer ?? null);
 const showQuickAddModal = ref(false);
@@ -205,9 +205,9 @@ const submit = () => {
                             <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-start">
                                 <div class="md:col-span-4">
                                     <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Product") }}</label>
-                                    <!-- TODO(B3.T3.6): this picker lists all products, so requires_booking=false
-                                         services sell as ordinary lines (backend skips their stock). A follow-up
-                                         could hide requires_booking=true services here so they are booked, not line-sold. -->
+                                    <!-- Bookable services are excluded from this picker (line_sale filter);
+                                         they are booked via the calendar. Physical goods and walk-in
+                                         (requires_booking=false) services remain sellable as line items. -->
                                     <CustomSelect
                                         :model-value="item.product"
                                         :options="productOptions"

--- a/resources/js/Components/Quotes/QuoteForm.vue
+++ b/resources/js/Components/Quotes/QuoteForm.vue
@@ -205,6 +205,9 @@ const submit = () => {
                             <div class="grid grid-cols-1 md:grid-cols-12 gap-3 items-start">
                                 <div class="md:col-span-4">
                                     <label class="md:hidden text-xs font-bold uppercase tracking-wider text-gray-400 mb-1 block">{{ __("Product") }}</label>
+                                    <!-- TODO(B3.T3.6): this picker lists all products, so requires_booking=false
+                                         services sell as ordinary lines (backend skips their stock). A follow-up
+                                         could hide requires_booking=true services here so they are booked, not line-sold. -->
                                     <CustomSelect
                                         :model-value="item.product"
                                         :options="productOptions"

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -186,6 +186,14 @@
                             </NavLink>
                         </SidebarGroup>
 
+                        <!-- Bookings -->
+                        <NavLink :href="route('bookings.index')" :active="route().current('bookings.*')">
+                            <svg class="h-5 w-5 shrink-0 text-current" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
+                            </svg>
+                            <span>{{ __('Bookings') }}</span>
+                        </NavLink>
+
                         <!-- Relations -->
                         <SidebarGroup
                             v-if="can('customers.view') || can('suppliers.view')"

--- a/resources/js/Pages/Bookings/Index.vue
+++ b/resources/js/Pages/Bookings/Index.vue
@@ -1,0 +1,147 @@
+<script setup>
+import AppLayout from "@/Layouts/AppLayout.vue";
+import Pagination from "@/Shared/Pagination.vue";
+import BookingCalendar from "@/Components/Bookings/BookingCalendar.vue";
+import BookingForm from "@/Components/Bookings/BookingForm.vue";
+import { ref } from "vue";
+import { router } from "@inertiajs/vue3";
+
+const props = defineProps({
+    bookings: { type: Object, required: true },
+});
+
+const showForm = ref(false);
+const editingBooking = ref(null);
+const prefillStart = ref(null);
+
+const openCreate = (dateKey = null) => {
+    editingBooking.value = null;
+    prefillStart.value = dateKey ? `${dateKey}T09:00` : null;
+    showForm.value = true;
+};
+
+const openEdit = (booking) => {
+    editingBooking.value = booking;
+    prefillStart.value = null;
+    showForm.value = true;
+};
+
+const onSaved = () => {
+    showForm.value = false;
+    router.reload({ only: ["bookings"] });
+};
+
+const cancelBooking = (booking) => {
+    if (!window.confirm(__("Cancel this booking?"))) return;
+    router.patch(route("bookings.cancel", booking.id), {}, { preserveScroll: true });
+};
+
+const locale = preferences("language", "en") === "ar" ? "ar" : "en";
+const formatWhen = (value) =>
+    value
+        ? new Date(value).toLocaleString(locale, {
+              dateStyle: "medium",
+              timeStyle: "short",
+          })
+        : "";
+
+const statusBadge = (status) =>
+    ({
+        confirmed: "text-emerald-700 bg-emerald-50 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400 dark:border-emerald-800",
+        completed: "text-gray-600 bg-gray-100 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700",
+        cancelled: "text-red-700 bg-red-50 border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800",
+    }[status] ?? "text-gray-600 bg-gray-100 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700");
+
+const statusLabel = (status) =>
+    ({ confirmed: __("Confirmed"), completed: __("Completed"), cancelled: __("Cancelled") }[status] ?? status);
+</script>
+
+<template>
+    <AppLayout :title="__('Bookings')">
+        <div class="w-full">
+            <!-- Header -->
+            <div class="w-full lg:flex lg:items-center lg:justify-between mb-6">
+                <div>
+                    <div class="flex items-center gap-x-3">
+                        <h2 class="text-xl font-semibold text-gray-800 dark:text-white">{{ __("Bookings") }}</h2>
+                        <span class="px-3 py-1 text-xs font-semibold rounded-full text-emerald-700 bg-emerald-100/60 dark:bg-gray-800 dark:text-emerald-400">
+                            {{ bookings.total }} {{ __("Bookings") }}
+                        </span>
+                    </div>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ __("Manage service appointments on one calendar.") }}</p>
+                </div>
+                <div class="mt-4 flex items-center justify-end gap-x-4 lg:mt-0">
+                    <button
+                        type="button"
+                        class="inline-flex items-center justify-center gap-x-2 px-4 py-2 text-sm font-normal text-white bg-emerald-600 border border-transparent rounded-lg hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition-colors duration-200"
+                        @click="openCreate()"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" /></svg>
+                        {{ __("New booking") }}
+                    </button>
+                </div>
+            </div>
+
+            <!-- Calendar -->
+            <BookingCalendar :bookings="bookings.data" @select="openEdit" @create="openCreate" />
+
+            <!-- List -->
+            <div class="mt-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                        <thead class="bg-gray-50/50 dark:bg-gray-800/40">
+                            <tr>
+                                <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __("When") }}</th>
+                                <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __("Service") }}</th>
+                                <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __("Customer") }}</th>
+                                <th class="px-6 py-4 text-start text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500">{{ __("Status") }}</th>
+                                <th class="px-6 py-4 text-end text-[10px] font-bold uppercase tracking-[0.1em] text-gray-400 dark:text-gray-500"><span class="sr-only">{{ __("Actions") }}</span></th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60 bg-white dark:bg-gray-900">
+                            <tr
+                                v-for="booking in bookings.data"
+                                :key="booking.id"
+                                class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200 cursor-pointer"
+                                @click="openEdit(booking)"
+                            >
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"><Ltr>{{ formatWhen(booking.starts_at) }}</Ltr></td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">{{ booking.service?.name }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ booking.customer?.name }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <span class="inline-flex items-center px-2.5 py-1 text-[11px] font-bold rounded-lg border" :class="statusBadge(booking.status)">
+                                        {{ statusLabel(booking.status) }}
+                                    </span>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-end" @click.stop>
+                                    <button
+                                        v-if="booking.status === 'confirmed'"
+                                        type="button"
+                                        class="px-3 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 bg-white dark:bg-gray-800 border border-red-200 dark:border-red-800 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                                        @click="cancelBooking(booking)"
+                                    >
+                                        {{ __("Cancel") }}
+                                    </button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div v-if="!bookings.data.length" class="py-12 text-center text-sm text-gray-400 dark:text-gray-500">
+                    {{ __("No bookings yet.") }}
+                </div>
+            </div>
+
+            <Pagination v-if="bookings.data.length" :links="bookings.links" class="mt-6" />
+        </div>
+
+        <BookingForm
+            :show="showForm"
+            :booking="editingBooking"
+            :prefill-start="prefillStart"
+            @close="showForm = false"
+            @saved="onSaved"
+        />
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Products/Index.vue
+++ b/resources/js/Pages/Products/Index.vue
@@ -42,6 +42,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
     const filters = ref({
         search: useQueryString("search").value,
         status: useQueryString("status").value,
+        type: useQueryString("type").value,
         category: useQueryString("category").value,
         min_cost: useQueryString("min_cost").value,
         max_cost: useQueryString("max_cost").value,
@@ -55,6 +56,7 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
         filters.value = {
             search: null,
             status: null,
+            type: null,
             category: null,
             min_cost: null,
             max_cost: null,
@@ -74,6 +76,15 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
             options: [
                 { value: "withTrash", label: __("With Trashed") },
                 { value: "trash", label: __("Trashed") },
+            ],
+        },
+        {
+            key: "type",
+            label: __("Type"),
+            default: "all",
+            options: [
+                { value: "physical", label: __("Physical") },
+                { value: "service", label: __("Service") },
             ],
         },
         { key: "category", label: __("Category"), options: props.categories, optionValue: "id", optionLabel: "name" },
@@ -440,6 +451,25 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
                     @reset="resetFilters"
                 >
                     <template #extra-filters>
+                        <!-- Type -->
+                        <div class="space-y-2">
+                            <label class="text-xs font-semibold text-gray-700 dark:text-gray-200">{{ __("Type") }}</label>
+                            <div class="flex p-1 bg-gray-100 dark:bg-gray-800 rounded-lg">
+                                <button
+                                    v-for="opt in [{ value: null, label: __('All') }, { value: 'physical', label: __('Physical') }, { value: 'service', label: __('Service') }]"
+                                    :key="opt.label"
+                                    type="button"
+                                    class="flex-1 px-2 py-1 text-xs font-medium rounded-md transition-colors duration-200"
+                                    :class="(filters.type ?? null) === opt.value
+                                        ? 'bg-white dark:bg-gray-900 text-emerald-700 dark:text-emerald-400 shadow-sm'
+                                        : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'"
+                                    @click="filters.type = opt.value"
+                                >
+                                    {{ opt.label }}
+                                </button>
+                            </div>
+                        </div>
+
                         <!-- Cost Range -->
                         <div class="space-y-2">
                             <label class="text-xs font-semibold text-gray-700 dark:text-gray-200">{{ __("Cost Range") }}</label>
@@ -510,7 +540,12 @@ import { useFilterSidebar } from "@/Composables/useFilterSidebar";
                                     </td>
                                     <td class="px-3 py-2.5 sm:sticky sm:start-0 bg-white dark:bg-gray-900 group-hover:bg-gray-50 dark:group-hover:bg-gray-800">
                                         <div class="min-w-0">
-                                            <div class="text-sm font-semibold text-gray-900 dark:text-white truncate group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors" :title="product.name">{{ product.name }}</div>
+                                            <div class="flex items-center gap-x-2 min-w-0">
+                                                <div class="text-sm font-semibold text-gray-900 dark:text-white truncate group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors" :title="product.name">{{ product.name }}</div>
+                                                <span v-if="product.type === 'service'" class="shrink-0 px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-wide rounded-md bg-emerald-50 text-emerald-600 dark:bg-emerald-900/20 dark:text-emerald-400">
+                                                    {{ __("Service") }}
+                                                </span>
+                                            </div>
                                             <div class="flex items-center gap-x-1.5 mt-0.5 text-[11px] text-gray-400 dark:text-gray-500 truncate">
                                                 <Ltr>#{{ product.id }}</Ltr>
                                                 <template v-if="product.categories.length">

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,13 @@
 <?php
 
+use App\Enums\BookingStatus;
 use App\Enums\ChequeStatus;
 use App\Models\BackupSetting;
+use App\Models\Booking;
 use App\Models\Cheque;
+use App\Models\Tenant;
 use App\Models\User;
+use App\Notifications\BookingReminderNotification;
 use App\Notifications\ChequeDueNotification;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -29,7 +33,30 @@ Artisan::command('cheques:notify-for-due', function () {
     });
 })->purpose('Notify platform admins of cheques due within the configured window');
 
+Artisan::command('bookings:notify-upcoming', function () {
+    // Runs without a tenant bound, so the tenant scope must be lifted; each
+    // booking's own tenant resolves the merchant recipients. Reminds once,
+    // deduped by `reminder_sent_at`.
+    $bookings = Booking::withoutGlobalScopes()
+        ->with(['service', 'customer'])
+        ->where('status', BookingStatus::Confirmed)
+        ->whereNull('reminder_sent_at')
+        ->where('starts_at', '>=', now())
+        ->where('starts_at', '<=', now()->addDay())
+        ->get();
+
+    $bookings->groupBy('tenant_id')->each(function ($group, $tenantId) {
+        $recipients = Tenant::find($tenantId)?->merchantUsers() ?? collect();
+
+        $group->each(function (Booking $booking) use ($recipients) {
+            $recipients->each(fn (User $user) => $user->notify(new BookingReminderNotification($booking)));
+            $booking->forceFill(['reminder_sent_at' => now()])->saveQuietly();
+        });
+    });
+})->purpose('Remind merchants of bookings starting within the next 24 hours');
+
 Schedule::command('cheques:notify-for-due')->daily();
+Schedule::command('bookings:notify-upcoming')->hourly();
 Schedule::call(fn () => DB::table('notifications')->where('created_at', '<', now()->subDays(90))->delete())
     ->daily()
     ->name('notifications:prune');

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\ImpersonationController;
 use App\Http\Controllers\Auth\MustChangePasswordController;
 use App\Http\Controllers\Auth\ResendVerificationController;
 use App\Http\Controllers\Auth\TenantLoginController;
+use App\Http\Controllers\BookingsController;
 use App\Http\Controllers\Catalog\ProductExportController;
 use App\Http\Controllers\Catalog\ProductGlobalFavoriteController;
 use App\Http\Controllers\Catalog\ProductImportController;
@@ -206,6 +207,16 @@ Route::middleware([ResolveTenant::class])->group(function () {
         Route::patch('/products/{product}/quick-update', [ProductsController::class, 'quickUpdate'])->name('products.quick-update');
         Route::patch('/products/{product}/global-favorite', [ProductGlobalFavoriteController::class, 'update'])->name('products.global-favorite');
         Route::resource('/products', ProductsController::class);
+
+        /*
+        |--------------------------------------------------------------------------
+        | Bookings
+        |--------------------------------------------------------------------------
+        | Merchant-side appointments for bookable service products: create/edit,
+        | a tenant-wide calendar, and merchant-only cancellation.
+        */
+        Route::patch('/bookings/{booking}/cancel', [BookingsController::class, 'cancel'])->name('bookings.cancel');
+        Route::resource('/bookings', BookingsController::class)->except(['show', 'create', 'edit', 'destroy']);
 
         /*
         |--------------------------------------------------------------------------

--- a/tests/Feature/Bookings/BookingControllerTest.php
+++ b/tests/Feature/Bookings/BookingControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\ServiceAddon;
+
+beforeEach(function () {
+    $this->signIn();
+    $this->service = Product::factory()->service()->create(['duration_minutes' => 60, 'price' => 100]);
+    $this->customer = Customer::factory()->create();
+});
+
+test('it creates a booking with snapshotted add-ons and a stored total', function () {
+    $addon = ServiceAddon::factory()->create(['product_id' => $this->service->id, 'price_delta' => 50]);
+
+    $this->post(route('bookings.store'), [
+        'service_product_id' => $this->service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:00:00',
+        'addons' => [$addon->id],
+    ])->assertRedirect(route('bookings.index'));
+
+    $booking = Booking::firstOrFail();
+
+    expect($booking->status)->toBe(BookingStatus::Confirmed)
+        ->and($booking->total)->toBe(150.0)
+        ->and($booking->addons)->toHaveCount(1);
+});
+
+test('a non-bookable service is rejected', function () {
+    $walkIn = Product::factory()->service()->create(['requires_booking' => false]);
+
+    $this->post(route('bookings.store'), [
+        'service_product_id' => $walkIn->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:00:00',
+    ])->assertSessionHasErrors('service_product_id');
+});
+
+test('an on-site booking requires an address', function () {
+    $onSite = Product::factory()->service()->onSite(30)->create(['duration_minutes' => 60]);
+
+    $this->post(route('bookings.store'), [
+        'service_product_id' => $onSite->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:00:00',
+    ])->assertSessionHasErrors('address');
+});
+
+test('an overlapping booking is hard-blocked with a 422 and nothing persists', function () {
+    Booking::factory()->create([
+        'service_product_id' => $this->service->id,
+        'starts_at' => '2026-08-01 10:00:00', // ends 11:00
+    ]);
+
+    $this->post(route('bookings.store'), [
+        'service_product_id' => $this->service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:30:00',
+    ])->assertSessionHasErrors('starts_at');
+
+    expect(Booking::count())->toBe(1);
+});
+
+test('allow_overlap services permit a colliding booking', function () {
+    $service = Product::factory()->service()->allowOverlap()->create(['duration_minutes' => 60]);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => '2026-08-01 10:00:00']);
+
+    $this->post(route('bookings.store'), [
+        'service_product_id' => $service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:30:00',
+    ])->assertRedirect(route('bookings.index'));
+
+    expect(Booking::count())->toBe(2);
+});
+
+test('a travel-buffer breach soft-warns and holds until acknowledged', function () {
+    $service = Product::factory()->service()->onSite(30)->create(['duration_minutes' => 60]);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => '2026-08-01 09:00:00']); // ends 10:00
+
+    $payload = [
+        'service_product_id' => $service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:20:00', // gap 20 < 30, no overlap
+        'address' => 'حي الرياض',
+    ];
+
+    // First submit: warned, not saved.
+    $this->post(route('bookings.store'), $payload)
+        ->assertRedirect()
+        ->assertSessionHas('travel_buffer_warnings');
+    expect(Booking::count())->toBe(1);
+
+    // Acknowledged submit: saved.
+    $this->post(route('bookings.store'), $payload + ['acknowledge_buffer' => true])
+        ->assertRedirect(route('bookings.index'));
+    expect(Booking::count())->toBe(2);
+});
+
+test('editing a booking excludes itself from the overlap check and re-snapshots add-ons', function () {
+    $booking = Booking::factory()->create([
+        'service_product_id' => $this->service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:00:00',
+        'base_price' => 100,
+    ]);
+    $addon = ServiceAddon::factory()->create(['product_id' => $this->service->id, 'price_delta' => 25]);
+
+    $this->put(route('bookings.update', $booking), [
+        'service_product_id' => $this->service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-02 09:00:00',
+        'addons' => [$addon->id],
+    ])->assertRedirect(route('bookings.index'));
+
+    $booking->refresh()->load('addons');
+
+    expect($booking->starts_at->format('Y-m-d H:i'))->toBe('2026-08-02 09:00')
+        ->and($booking->addons)->toHaveCount(1)
+        ->and($booking->total)->toBe(125.0);
+});
+
+test('cancelling a booking frees its slot', function () {
+    $booking = Booking::factory()->create(['service_product_id' => $this->service->id, 'starts_at' => '2026-08-01 10:00:00']);
+
+    $this->patch(route('bookings.cancel', $booking))->assertRedirect();
+
+    expect($booking->fresh()->status)->toBe(BookingStatus::Cancelled);
+
+    // The slot is now rebookable.
+    $this->post(route('bookings.store'), [
+        'service_product_id' => $this->service->id,
+        'customer_id' => $this->customer->id,
+        'starts_at' => '2026-08-01 10:00:00',
+    ])->assertRedirect(route('bookings.index'));
+
+    expect(Booking::confirmed()->count())->toBe(1);
+});
+
+// NOTE: the Bookings/Index render + calendar payload assertions live in the B3
+// UI commit, once resources/js/Pages/Bookings/Index.vue exists in the Vite
+// manifest. B3a covers the controller's write paths and engine wiring above.

--- a/tests/Feature/Bookings/BookingModelTest.php
+++ b/tests/Feature/Bookings/BookingModelTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\Customer;
+use App\Models\Product;
+use Carbon\Carbon;
+
+test('a booking persists a derived ends_at from the service duration', function () {
+    $service = Product::factory()->service()->create(['duration_minutes' => 60]);
+    $start = Carbon::parse('2026-08-01 10:00:00');
+
+    $booking = Booking::factory()->create([
+        'service_product_id' => $service->id,
+        'starts_at' => $start,
+    ]);
+
+    expect($booking->refresh()->ends_at->equalTo($start->copy()->addMinutes(60)))->toBeTrue();
+});
+
+test('moving the start recomputes the persisted end', function () {
+    $service = Product::factory()->service()->create(['duration_minutes' => 30]);
+    $booking = Booking::factory()->create([
+        'service_product_id' => $service->id,
+        'starts_at' => Carbon::parse('2026-08-01 09:00:00'),
+    ]);
+
+    $newStart = Carbon::parse('2026-08-02 14:00:00');
+    $booking->update(['starts_at' => $newStart]);
+
+    expect($booking->refresh()->ends_at->equalTo($newStart->copy()->addMinutes(30)))->toBeTrue();
+});
+
+test('a null service duration yields ends_at equal to starts_at', function () {
+    $service = Product::factory()->service()->create(['duration_minutes' => null]);
+    $start = Carbon::parse('2026-08-01 10:00:00');
+
+    $booking = Booking::factory()->create([
+        'service_product_id' => $service->id,
+        'starts_at' => $start,
+    ]);
+
+    expect($booking->refresh()->ends_at->equalTo($start))->toBeTrue();
+});
+
+test('a booking casts its relationships, status and money', function () {
+    $booking = Booking::factory()->create(['base_price' => 120]);
+
+    expect($booking->refresh()->status)->toBe(BookingStatus::Confirmed)
+        ->and($booking->base_price)->toBe(120.0)
+        ->and($booking->service)->toBeInstanceOf(Product::class)
+        ->and($booking->customer)->toBeInstanceOf(Customer::class);
+});
+
+test('the confirmed and status scopes filter by status', function () {
+    Booking::factory()->count(2)->create();
+    Booking::factory()->cancelled()->create();
+    Booking::factory()->completed()->create();
+
+    expect(Booking::confirmed()->count())->toBe(2)
+        ->and(Booking::status(BookingStatus::Cancelled)->count())->toBe(1)
+        ->and(Booking::status(BookingStatus::Completed)->count())->toBe(1);
+});
+
+test('a booking is tenant scoped and soft-deletable', function () {
+    $booking = Booking::factory()->create();
+
+    expect($booking->tenant_id)->not->toBeNull();
+
+    $booking->delete();
+
+    expect(Booking::whereKey($booking->id)->exists())->toBeFalse()
+        ->and(Booking::withTrashed()->whereKey($booking->id)->exists())->toBeTrue();
+});

--- a/tests/Feature/Bookings/BookingNotificationTest.php
+++ b/tests/Feature/Bookings/BookingNotificationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\Product;
+use App\Models\User;
+use App\Notifications\BookingCancelledNotification;
+use App\Notifications\BookingReminderNotification;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Notification::fake();
+    $this->owner = User::factory()->create();
+    $this->actingAs($this->owner); // attaches the acting user as tenant owner
+    $this->service = Product::factory()->service()->create(['duration_minutes' => 60]);
+});
+
+function bookingAt(Product $service, $startsAt, BookingStatus $status = BookingStatus::Confirmed): Booking
+{
+    return Booking::factory()->create([
+        'service_product_id' => $service->id,
+        'starts_at' => $startsAt,
+        'status' => $status,
+    ]);
+}
+
+test('the reminder scan notifies the merchant for a booking within 24h and stamps it', function () {
+    $booking = bookingAt($this->service, now()->addHours(10));
+
+    Artisan::call('bookings:notify-upcoming');
+
+    Notification::assertSentTo($this->owner, BookingReminderNotification::class);
+    expect($booking->fresh()->reminder_sent_at)->not->toBeNull();
+});
+
+test('bookings outside the 24h window are not reminded', function () {
+    bookingAt($this->service, now()->addDays(3)); // too far out
+    bookingAt($this->service, now()->subHour());   // already past
+
+    Artisan::call('bookings:notify-upcoming');
+
+    Notification::assertNothingSent();
+});
+
+test('cancelled and completed bookings are not reminded', function () {
+    bookingAt($this->service, now()->addHours(5), BookingStatus::Cancelled);
+    bookingAt($this->service, now()->addHours(5), BookingStatus::Completed);
+
+    Artisan::call('bookings:notify-upcoming');
+
+    Notification::assertNothingSent();
+});
+
+test('the reminder is sent exactly once across repeated scans', function () {
+    bookingAt($this->service, now()->addHours(10));
+
+    Artisan::call('bookings:notify-upcoming');
+    Artisan::call('bookings:notify-upcoming');
+
+    Notification::assertSentToTimes($this->owner, BookingReminderNotification::class, 1);
+});
+
+test('cancelling a booking notifies the merchant', function () {
+    $booking = bookingAt($this->service, now()->addDays(2));
+
+    $this->patch(route('bookings.cancel', $booking))->assertRedirect();
+
+    Notification::assertSentTo($this->owner, BookingCancelledNotification::class);
+});

--- a/tests/Feature/Bookings/BookingSchedulerTest.php
+++ b/tests/Feature/Bookings/BookingSchedulerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Exceptions\BookingOverlapException;
+use App\Models\Booking;
+use App\Models\Product;
+use App\Services\Bookings\BookingScheduler;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    $this->scheduler = app(BookingScheduler::class);
+});
+
+function schedulerCandidate(Product $service, string $start): Booking
+{
+    $booking = new Booking(['service_product_id' => $service->id, 'starts_at' => Carbon::parse($start)]);
+    $booking->setRelation('service', $service);
+
+    return $booking;
+}
+
+test('it throws on overlap before considering the buffer', function () {
+    $service = Product::factory()->service()->onSite(30)->create(['duration_minutes' => 60]);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 10:00')]);
+
+    expect(fn () => $this->scheduler->assertBookable(schedulerCandidate($service, '2026-08-01 10:30')))
+        ->toThrow(BookingOverlapException::class);
+});
+
+test('a clean placement returns no warnings', function () {
+    $service = Product::factory()->service()->create(['duration_minutes' => 60]);
+
+    expect($this->scheduler->assertBookable(schedulerCandidate($service, '2026-08-01 10:00')))->toBe([]);
+});
+
+test('a placement that clears overlap but breaches the buffer returns warnings without throwing', function () {
+    $service = Product::factory()->service()->onSite(30)->create(['duration_minutes' => 60]);
+    // Neighbour ends 10:00; candidate at 10:20 does not overlap but is within the 30-min buffer.
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:00')]);
+
+    $warnings = $this->scheduler->assertBookable(schedulerCandidate($service, '2026-08-01 10:20'));
+
+    expect($warnings)->toHaveCount(1)
+        ->and($warnings[0]->direction)->toBe('before');
+});

--- a/tests/Feature/Bookings/BookingsUiTest.php
+++ b/tests/Feature/Bookings/BookingsUiTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Booking;
+use App\Models\Product;
+use App\Models\ServiceAddon;
+
+test('the bookings index renders with its bookings', function () {
+    $this->signIn();
+    $service = Product::factory()->service()->create(['duration_minutes' => 60]);
+    Booking::factory()->count(2)->create(['service_product_id' => $service->id]);
+
+    $this->get(route('bookings.index'))
+        ->assertInertia(fn ($page) => $page->component('Bookings/Index')->has('bookings.data', 2));
+});
+
+test('the products index filters by type', function () {
+    $this->signIn();
+    Product::factory()->count(2)->create();
+    Product::factory()->service()->count(3)->create();
+
+    $this->get(route('products.index', ['type' => 'service']))
+        ->assertInertia(fn ($page) => $page->component('Products/Index')->has('products.data', 3));
+});
+
+test('the products API eager-loads add-ons for services', function () {
+    $this->signIn();
+    $service = Product::factory()->service()->create();
+    ServiceAddon::factory()->create(['product_id' => $service->id]);
+
+    $response = $this->getJson(route('api.products.index', ['type' => 'service']));
+
+    $response->assertOk();
+    expect($response->json('data.0.service_addons'))->toHaveCount(1);
+});

--- a/tests/Feature/Bookings/CreateBookingActionTest.php
+++ b/tests/Feature/Bookings/CreateBookingActionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Actions\Bookings\CreateBookingAction;
+use App\Enums\BookingStatus;
+use App\Models\Booking;
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\ServiceAddon;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    $this->action = app(CreateBookingAction::class);
+});
+
+test('it snapshots the base price and selected add-on deltas into the stored total', function () {
+    $service = Product::factory()->service()->create(['price' => 100, 'duration_minutes' => 45]);
+    $customer = Customer::factory()->create();
+    $addonA = ServiceAddon::factory()->create(['product_id' => $service->id, 'price_delta' => 30]);
+    $addonB = ServiceAddon::factory()->create(['product_id' => $service->id, 'price_delta' => 20]);
+
+    $booking = $this->action->handle(
+        $service,
+        $customer,
+        Carbon::parse('2026-08-01 10:00:00'),
+        [$addonA->id, $addonB->id],
+    );
+
+    expect($booking->base_price)->toBe(100.0)
+        ->and($booking->total)->toBe(150.0)
+        ->and($booking->addons)->toHaveCount(2)
+        ->and($booking->status)->toBe(BookingStatus::Confirmed)
+        ->and($booking->ends_at->equalTo(Carbon::parse('2026-08-01 10:45:00')))->toBeTrue();
+});
+
+test('selecting no add-ons yields a total equal to the base price', function () {
+    $service = Product::factory()->service()->create(['price' => 80]);
+    $customer = Customer::factory()->create();
+
+    $booking = $this->action->handle($service, $customer, Carbon::parse('2026-08-01 10:00:00'));
+
+    expect($booking->addons)->toHaveCount(0)
+        ->and($booking->total)->toBe(80.0);
+});
+
+test('re-pricing the service or its add-ons never mutates a historical booking', function () {
+    $service = Product::factory()->service()->create(['price' => 100]);
+    $customer = Customer::factory()->create();
+    $addon = ServiceAddon::factory()->create(['product_id' => $service->id, 'price_delta' => 50, 'name' => 'كشف إضافي']);
+
+    $booking = $this->action->handle($service, $customer, Carbon::parse('2026-08-01 10:00:00'), [$addon->id]);
+
+    // Mutate the sources after the fact.
+    $service->update(['price' => 999]);
+    $addon->update(['price_delta' => 999, 'name' => 'تغيير']);
+
+    $booking->refresh()->load('addons');
+
+    expect($booking->base_price)->toBe(100.0)
+        ->and($booking->total)->toBe(150.0)
+        ->and($booking->addons->first()->price_delta)->toBe(50.0)
+        ->and($booking->addons->first()->name)->toBe('كشف إضافي');
+});
+
+test('deleting a source add-on preserves the booking snapshot', function () {
+    $service = Product::factory()->service()->create(['price' => 100]);
+    $customer = Customer::factory()->create();
+    $addon = ServiceAddon::factory()->create(['product_id' => $service->id, 'price_delta' => 40, 'name' => 'متابعة']);
+
+    $booking = $this->action->handle($service, $customer, Carbon::parse('2026-08-01 10:00:00'), [$addon->id]);
+
+    $addon->forceDelete();
+
+    $line = $booking->refresh()->addons->first();
+
+    expect($line->service_addon_id)->toBeNull()
+        ->and($line->name)->toBe('متابعة')
+        ->and($line->price_delta)->toBe(40.0)
+        ->and($booking->total)->toBe(140.0);
+});
+
+test('an add-on from another service is rejected', function () {
+    $service = Product::factory()->service()->create(['price' => 100]);
+    $otherService = Product::factory()->service()->create();
+    $customer = Customer::factory()->create();
+    $foreignAddon = ServiceAddon::factory()->create(['product_id' => $otherService->id]);
+
+    expect(fn () => $this->action->handle(
+        $service,
+        $customer,
+        Carbon::parse('2026-08-01 10:00:00'),
+        [$foreignAddon->id],
+    ))->toThrow(InvalidArgumentException::class);
+
+    expect(Booking::count())->toBe(0);
+});

--- a/tests/Feature/Bookings/OverlapDetectorTest.php
+++ b/tests/Feature/Bookings/OverlapDetectorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use App\Exceptions\BookingOverlapException;
+use App\Models\Booking;
+use App\Models\Product;
+use App\Services\Bookings\OverlapDetector;
+use App\ValueObjects\TimeRange;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    $this->detector = app(OverlapDetector::class);
+    $this->service = Product::factory()->service()->create(['duration_minutes' => 60, 'allow_overlap' => false]);
+});
+
+function candidate(Product $service, string $start): Booking
+{
+    $booking = new Booking(['service_product_id' => $service->id, 'starts_at' => Carbon::parse($start)]);
+    $booking->setRelation('service', $service);
+
+    return $booking;
+}
+
+test('it hard-blocks a booking overlapping a confirmed booking of the same service', function () {
+    Booking::factory()->create([
+        'service_product_id' => $this->service->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'),
+    ]);
+
+    expect(fn () => $this->detector->assertNoConflict(candidate($this->service, '2026-08-01 10:30')))
+        ->toThrow(BookingOverlapException::class);
+});
+
+test('it allows exactly back-to-back bookings', function () {
+    Booking::factory()->create([
+        'service_product_id' => $this->service->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'), // ends 11:00
+    ]);
+
+    $this->detector->assertNoConflict(candidate($this->service, '2026-08-01 11:00'));
+
+    expect(true)->toBeTrue(); // no exception thrown
+});
+
+test('allow_overlap on the service silently permits a collision', function () {
+    $service = Product::factory()->service()->allowOverlap()->create(['duration_minutes' => 60]);
+    Booking::factory()->create([
+        'service_product_id' => $service->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'),
+    ]);
+
+    $this->detector->assertNoConflict(candidate($service, '2026-08-01 10:30'));
+
+    expect(true)->toBeTrue();
+});
+
+test('a cancelled booking frees its slot for rebooking', function () {
+    Booking::factory()->cancelled()->create([
+        'service_product_id' => $this->service->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'),
+    ]);
+
+    $this->detector->assertNoConflict(candidate($this->service, '2026-08-01 10:30'));
+
+    expect(true)->toBeTrue();
+});
+
+test('a completed booking does not block overlap', function () {
+    Booking::factory()->completed()->create([
+        'service_product_id' => $this->service->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'),
+    ]);
+
+    $this->detector->assertNoConflict(candidate($this->service, '2026-08-01 10:30'));
+
+    expect(true)->toBeTrue();
+});
+
+test('a booking for another service never conflicts', function () {
+    $other = Product::factory()->service()->create(['duration_minutes' => 60]);
+    Booking::factory()->create([
+        'service_product_id' => $other->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'),
+    ]);
+
+    $this->detector->assertNoConflict(candidate($this->service, '2026-08-01 10:30'));
+
+    expect(true)->toBeTrue();
+});
+
+test('editing a booking excludes itself from its own overlap check', function () {
+    $booking = Booking::factory()->create([
+        'service_product_id' => $this->service->id,
+        'starts_at' => Carbon::parse('2026-08-01 10:00'),
+    ]);
+
+    $this->detector->assertNoConflict($booking->load('service'), ignoreId: $booking->id);
+
+    expect(true)->toBeTrue();
+});
+
+test('an empty calendar passes', function () {
+    $this->detector->assertNoConflict(candidate($this->service, '2026-08-01 10:30'));
+
+    expect(true)->toBeTrue();
+});
+
+test('the SQL predicate matches the in-memory TimeRange primitive', function () {
+    // Fixtures at varied offsets around a candidate [10:00, 11:00).
+    $offsets = ['2026-08-01 08:30', '2026-08-01 09:30', '2026-08-01 10:30', '2026-08-01 11:00', '2026-08-01 11:30'];
+    foreach ($offsets as $start) {
+        Booking::factory()->create([
+            'service_product_id' => $this->service->id,
+            'starts_at' => Carbon::parse($start),
+        ]);
+    }
+
+    $candidate = candidate($this->service, '2026-08-01 10:00'); // ends 11:00
+    $candidateRange = new TimeRange($candidate->starts_at, $candidate->deriveEndsAt());
+
+    $expectedIds = Booking::all()->filter(fn (Booking $b) => $candidateRange->overlaps(new TimeRange($b->starts_at, $b->ends_at)))
+        ->pluck('id')->sort()->values()->all();
+
+    $actualIds = $this->detector->conflicts($candidate)->pluck('id')->sort()->values()->all();
+
+    expect($actualIds)->toBe($expectedIds)->not->toBeEmpty();
+});

--- a/tests/Feature/Bookings/ServiceAddonTest.php
+++ b/tests/Feature/Bookings/ServiceAddonTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Product;
+use App\Models\ServiceAddon;
+
+test('an add-on belongs to its service and round-trips its money delta', function () {
+    $service = Product::factory()->service()->create();
+    $addon = ServiceAddon::factory()->create([
+        'product_id' => $service->id,
+        'price_delta' => 75,
+    ]);
+
+    expect($addon->refresh()->price_delta)->toBe(75.0)
+        ->and($addon->product->is($service))->toBeTrue();
+});
+
+test('a zero price delta is a valid (free) add-on', function () {
+    $addon = ServiceAddon::factory()->create(['price_delta' => 0]);
+
+    expect($addon->refresh()->price_delta)->toBe(0.0);
+});
+
+test('add-ons cascade when their product is deleted', function () {
+    $service = Product::factory()->service()->create();
+    $addon = ServiceAddon::factory()->create(['product_id' => $service->id]);
+
+    $service->forceDelete();
+
+    expect(ServiceAddon::withTrashed()->whereKey($addon->id)->exists())->toBeFalse();
+});
+
+test('add-ons are tenant scoped', function () {
+    $addon = ServiceAddon::factory()->create();
+
+    expect($addon->tenant_id)->not->toBeNull();
+});

--- a/tests/Feature/Bookings/ServiceLineItemDeliveryTest.php
+++ b/tests/Feature/Bookings/ServiceLineItemDeliveryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Actions\Stock\DeliverTransactionAction;
+use App\Models\Invoice;
+use App\Models\Product;
+use App\Models\Storage;
+use App\Models\Transaction;
+use App\Models\User;
+
+test('delivering a service line item does not deduct stock or write a movement', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $service = Product::factory()->service()->create();
+    $storage = Storage::factory()->create();
+    $invoice = Invoice::factory()->create();
+    $transaction = Transaction::factory()->create([
+        'invoice_id' => $invoice->id,
+        'product_id' => $service->id,
+        'storage_id' => $storage->id,
+        'base_quantity' => 5,
+        'delivered' => false,
+    ]);
+
+    app(DeliverTransactionAction::class)->handle($transaction, $user);
+
+    expect($transaction->fresh()->delivered)->toBeTrue();
+
+    $this->assertDatabaseMissing('stock_movements', [
+        'product_id' => $service->id,
+        'reason' => 'sale_delivery',
+    ]);
+});

--- a/tests/Feature/Bookings/ServiceLineSaleFilterTest.php
+++ b/tests/Feature/Bookings/ServiceLineSaleFilterTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\Product;
+
+test('sellableAsLineItem excludes bookable services but keeps physical and walk-in services', function () {
+    $physical = Product::factory()->create();
+    $walkIn = Product::factory()->service()->create(['requires_booking' => false]);
+    $bookable = Product::factory()->service()->create(['requires_booking' => true]);
+
+    $ids = Product::sellableAsLineItem()->pluck('id');
+
+    expect($ids)->toContain($physical->id)
+        ->toContain($walkIn->id)
+        ->not->toContain($bookable->id);
+});
+
+test('the products API line_sale filter hides bookable services', function () {
+    $this->signIn();
+    Product::factory()->create();                                        // physical
+    Product::factory()->service()->create(['requires_booking' => false]); // walk-in
+    Product::factory()->service()->create(['requires_booking' => true]);  // bookable
+
+    $response = $this->getJson(route('api.products.index', ['line_sale' => 1]));
+
+    $response->assertOk();
+    expect($response->json('data'))->toHaveCount(2); // physical + walk-in, not the bookable
+});

--- a/tests/Feature/Bookings/ServiceProductControllerTest.php
+++ b/tests/Feature/Bookings/ServiceProductControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Models\Product;
+
+test('a service product is created with add-ons and no stock/units', function () {
+    $this->signIn();
+
+    $this->post(route('products.index'), [
+        'type' => 'service',
+        'name' => 'استشارة طبية',
+        'price' => 150,
+        'duration_minutes' => 30,
+        'requires_booking' => true,
+        'on_site' => false,
+        'allow_overlap' => false,
+        'addons' => [
+            ['name' => 'كشف إضافي', 'price_delta' => 40],
+            ['name' => 'تقرير', 'price_delta' => 20],
+        ],
+    ])->assertRedirect(route('products.index'));
+
+    $service = Product::services()->firstOrFail();
+
+    expect($service->isService())->toBeTrue()
+        ->and($service->price)->toBe(150.0)
+        ->and($service->duration_minutes)->toBe(30)
+        ->and($service->serviceAddons)->toHaveCount(2)
+        ->and($service->units)->toHaveCount(0);
+});
+
+test('a zero-cost service passes validation (cost > 0 does not apply)', function () {
+    $this->signIn();
+
+    $this->post(route('products.index'), [
+        'type' => 'service',
+        'name' => 'خدمة مجانية',
+        'price' => 0,
+        'duration_minutes' => 15,
+        'requires_booking' => true,
+    ])->assertSessionHasNoErrors();
+
+    expect(Product::services()->count())->toBe(1);
+});
+
+test('a bookable service requires a positive duration', function () {
+    $this->signIn();
+
+    $this->post(route('products.index'), [
+        'type' => 'service',
+        'name' => 'بدون مدة',
+        'price' => 100,
+        'requires_booking' => true,
+    ])->assertSessionHasErrors('duration_minutes');
+});
+
+test('an on-site service requires a travel buffer', function () {
+    $this->signIn();
+
+    $this->post(route('products.index'), [
+        'type' => 'service',
+        'name' => 'زيارة منزلية',
+        'price' => 100,
+        'duration_minutes' => 60,
+        'requires_booking' => true,
+        'on_site' => true,
+    ])->assertSessionHasErrors('travel_buffer_minutes');
+});
+
+test('editing a service syncs its add-ons without touching historical bookings', function () {
+    $this->signIn();
+    $service = Product::factory()->service()->create();
+    $kept = $service->serviceAddons()->create(['name' => 'قديم', 'price_delta' => 10]);
+
+    $this->put(route('products.update', $service), [
+        'type' => 'service',
+        'name' => $service->name,
+        'price' => $service->price,
+        'duration_minutes' => $service->duration_minutes,
+        'requires_booking' => true,
+        'addons' => [
+            ['id' => $kept->id, 'name' => 'محدّث', 'price_delta' => 15],
+            ['name' => 'جديد', 'price_delta' => 30],
+        ],
+    ])->assertRedirect();
+
+    $service->refresh()->load('serviceAddons');
+
+    expect($service->serviceAddons)->toHaveCount(2)
+        ->and($service->serviceAddons->firstWhere('id', $kept->id)->name)->toBe('محدّث');
+});
+
+test('physical product creation is unchanged', function () {
+    $this->signIn();
+
+    $this->post(route('products.index'), [
+        'name' => 'منتج عادي',
+        'cost' => 100,
+        'price' => 120,
+    ])->assertRedirect(route('products.index'));
+
+    $product = Product::physical()->firstOrFail();
+
+    expect($product->isService())->toBeFalse()
+        ->and($product->units)->toHaveCount(1); // base unit created
+});
+
+test('the products API filters by type', function () {
+    $this->signIn();
+    Product::factory()->count(2)->create();
+    Product::factory()->service()->count(3)->create();
+
+    $response = $this->getJson(route('api.products.index', ['type' => 'service']));
+
+    $response->assertOk();
+    expect($response->json('data'))->toHaveCount(3);
+});

--- a/tests/Feature/Bookings/ServiceProductTest.php
+++ b/tests/Feature/Bookings/ServiceProductTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Enums\ProductType;
+use App\Models\Product;
+use App\Models\ServiceAddon;
+
+test('a plain product defaults to the physical type (backfill/default meaning)', function () {
+    $product = Product::factory()->create();
+
+    expect($product->refresh()->type)->toBe(ProductType::Physical)
+        ->and($product->isService())->toBeFalse()
+        ->and($product->requires_booking)->toBeFalse()
+        ->and($product->on_site)->toBeFalse()
+        ->and($product->allow_overlap)->toBeFalse()
+        ->and($product->duration_minutes)->toBeNull()
+        ->and($product->travel_buffer_minutes)->toBeNull();
+});
+
+test('the service factory state produces a bookable service', function () {
+    $service = Product::factory()->service()->create();
+
+    expect($service->refresh()->type)->toBe(ProductType::Service)
+        ->and($service->isService())->toBeTrue()
+        ->and($service->requires_booking)->toBeTrue()
+        ->and($service->duration_minutes)->toBeGreaterThan(0);
+});
+
+test('the on-site service state sets a travel buffer', function () {
+    $service = Product::factory()->service()->onSite(45)->create();
+
+    expect($service->refresh()->on_site)->toBeTrue()
+        ->and($service->travel_buffer_minutes)->toBe(45);
+});
+
+test('services and physical scopes partition the catalog', function () {
+    Product::factory()->count(2)->create();
+    Product::factory()->service()->count(3)->create();
+
+    expect(Product::physical()->count())->toBe(2)
+        ->and(Product::services()->count())->toBe(3);
+});
+
+test('a service has many add-ons', function () {
+    $service = Product::factory()->service()->create();
+    ServiceAddon::factory()->count(2)->create(['product_id' => $service->id]);
+
+    expect($service->serviceAddons)->toHaveCount(2)
+        ->and($service->serviceAddons->first())->toBeInstanceOf(ServiceAddon::class);
+});

--- a/tests/Feature/Bookings/TravelBufferCheckerTest.php
+++ b/tests/Feature/Bookings/TravelBufferCheckerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\Booking;
+use App\Models\Product;
+use App\Services\Bookings\TravelBufferChecker;
+use Carbon\Carbon;
+
+beforeEach(function () {
+    $this->checker = app(TravelBufferChecker::class);
+});
+
+function onSiteService(int $buffer = 30, int $duration = 60): Product
+{
+    return Product::factory()->service()->onSite($buffer)->create(['duration_minutes' => $duration]);
+}
+
+function bufferCandidate(Product $service, string $start): Booking
+{
+    $booking = new Booking(['service_product_id' => $service->id, 'starts_at' => Carbon::parse($start)]);
+    $booking->setRelation('service', $service);
+
+    return $booking;
+}
+
+test('a preceding booking closer than the buffer produces a before-warning', function () {
+    $service = onSiteService(buffer: 30);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:00')]); // ends 10:00
+
+    $warnings = $this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:20')); // gap 20 < 30
+
+    expect($warnings)->toHaveCount(1)
+        ->and($warnings[0]->direction)->toBe('before')
+        ->and($warnings[0]->gapMinutes)->toBe(20)
+        ->and($warnings[0]->requiredBufferMinutes)->toBe(30);
+});
+
+test('a gap exactly equal to the buffer yields no warning', function () {
+    $service = onSiteService(buffer: 30);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:00')]); // ends 10:00
+
+    $warnings = $this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:30')); // gap 30
+
+    expect($warnings)->toBeEmpty();
+});
+
+test('a gap larger than the buffer yields no warning', function () {
+    $service = onSiteService(buffer: 30);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:00')]);
+
+    expect($this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:45')))->toBeEmpty();
+});
+
+test('a following booking closer than the buffer produces an after-warning', function () {
+    $service = onSiteService(buffer: 30);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 11:20')]);
+
+    $warnings = $this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:00')); // ends 11:00, gap 20
+
+    expect($warnings)->toHaveCount(1)
+        ->and($warnings[0]->direction)->toBe('after')
+        ->and($warnings[0]->gapMinutes)->toBe(20);
+});
+
+test('a booking wedged between two close neighbours warns twice', function () {
+    $service = onSiteService(buffer: 30);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 08:50')]); // ends 09:50
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 11:15')]);
+
+    $warnings = $this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:00')); // ends 11:00
+
+    expect($warnings)->toHaveCount(2)
+        ->and(collect($warnings)->pluck('direction')->all())->toEqualCanonicalizing(['before', 'after']);
+});
+
+test('non-on-site services never warn', function () {
+    $service = Product::factory()->service()->create(['duration_minutes' => 60]); // on_site false
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:59')]);
+
+    expect($this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:00')))->toBeEmpty();
+});
+
+test('a zero or null buffer yields no warning', function () {
+    $service = Product::factory()->service()->create(['duration_minutes' => 60, 'on_site' => true, 'travel_buffer_minutes' => 0]);
+    Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:59')]);
+
+    expect($this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:00')))->toBeEmpty();
+});
+
+test('a cancelled neighbour never triggers a warning', function () {
+    $service = onSiteService(buffer: 30);
+    Booking::factory()->cancelled()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 09:50')]);
+
+    expect($this->checker->warningsFor(bufferCandidate($service, '2026-08-01 10:00')))->toBeEmpty();
+});
+
+test('the edited booking excludes itself from the buffer check', function () {
+    $service = onSiteService(buffer: 30);
+    $booking = Booking::factory()->create(['service_product_id' => $service->id, 'starts_at' => Carbon::parse('2026-08-01 10:00')]);
+
+    expect($this->checker->warningsFor($booking->load('service'), ignoreId: $booking->id))->toBeEmpty();
+});

--- a/tests/Unit/Enums/BookingStatusTest.php
+++ b/tests/Unit/Enums/BookingStatusTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Enums\BookingStatus;
+
+test('booking status has the three v1 cases with string values', function () {
+    expect(BookingStatus::Confirmed->value)->toBe('confirmed')
+        ->and(BookingStatus::Cancelled->value)->toBe('cancelled')
+        ->and(BookingStatus::Completed->value)->toBe('completed')
+        ->and(BookingStatus::cases())->toHaveCount(3);
+});
+
+test('booking status exposes a label for each case', function () {
+    expect(BookingStatus::Confirmed->label())->toBe('Confirmed')
+        ->and(BookingStatus::Cancelled->label())->toBe('Cancelled')
+        ->and(BookingStatus::Completed->label())->toBe('Completed');
+});

--- a/tests/Unit/Enums/ProductTypeTest.php
+++ b/tests/Unit/Enums/ProductTypeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Enums\ProductType;
+
+test('product type has physical and service cases with string values', function () {
+    expect(ProductType::Physical->value)->toBe('physical')
+        ->and(ProductType::Service->value)->toBe('service')
+        ->and(ProductType::cases())->toHaveCount(2);
+});
+
+test('product type resolves from its backing value', function () {
+    expect(ProductType::from('physical'))->toBe(ProductType::Physical)
+        ->and(ProductType::from('service'))->toBe(ProductType::Service);
+});
+
+test('product type exposes a label for each case', function () {
+    expect(ProductType::Physical->label())->toBe('Physical')
+        ->and(ProductType::Service->label())->toBe('Service');
+});

--- a/tests/Unit/ValueObjects/TimeRangeTest.php
+++ b/tests/Unit/ValueObjects/TimeRangeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\ValueObjects\TimeRange;
+use Carbon\Carbon;
+
+function timeRange(string $start, string $end): TimeRange
+{
+    return new TimeRange(Carbon::parse($start), Carbon::parse($end));
+}
+
+test('overlapping ranges are detected', function () {
+    expect(timeRange('2026-08-01 10:00', '2026-08-01 11:00')
+        ->overlaps(timeRange('2026-08-01 10:30', '2026-08-01 11:30')))->toBeTrue();
+});
+
+test('a fully contained range overlaps', function () {
+    expect(timeRange('2026-08-01 10:00', '2026-08-01 12:00')
+        ->overlaps(timeRange('2026-08-01 10:30', '2026-08-01 11:00')))->toBeTrue();
+});
+
+test('identical ranges overlap', function () {
+    expect(timeRange('2026-08-01 10:00', '2026-08-01 11:00')
+        ->overlaps(timeRange('2026-08-01 10:00', '2026-08-01 11:00')))->toBeTrue();
+});
+
+test('exactly abutting ranges do NOT overlap (half-open)', function () {
+    expect(timeRange('2026-08-01 10:00', '2026-08-01 11:00')
+        ->overlaps(timeRange('2026-08-01 11:00', '2026-08-01 12:00')))->toBeFalse();
+});
+
+test('disjoint ranges do not overlap', function () {
+    expect(timeRange('2026-08-01 10:00', '2026-08-01 11:00')
+        ->overlaps(timeRange('2026-08-01 11:30', '2026-08-01 12:00')))->toBeFalse();
+});
+
+test('same-instant zero-duration ranges do not overlap', function () {
+    expect(timeRange('2026-08-01 10:00', '2026-08-01 10:00')
+        ->overlaps(timeRange('2026-08-01 10:00', '2026-08-01 10:00')))->toBeFalse();
+});


### PR DESCRIPTION
## Service Product Type & Bookings (v1)

Introduces a second product type — **service** — alongside the existing **physical** product, so merchants who sell time (clinics, mobile/outfield clinics, home-service providers) can sell bookable services through the same POS, with a merchant-side calendar to manage appointments.

Merchant-side only — **no client-facing portal**. Existing `physical` products are unchanged (strict backwards-compatibility; every regression suite stays green).

PRDs live in `docs/service-bookings/`.

## What's included

**Data layer**
- `ProductType` (`physical` | `service`) + `BookingStatus` enums; `products.type` discriminator (indexed, existing rows backfilled to `physical`).
- Service attributes on `products`: `duration_minutes`, `requires_booking`, `on_site`, `allow_overlap`, `travel_buffer_minutes` (base price reuses `price`).
- `service_addons`, `bookings`, `booking_addons` tables + models. `CreateBookingAction` is the single snapshot choke point — base price and each add-on's name/delta are copied at booking time (stored `total`), so re-pricing a service never mutates historical bookings.

**Booking engine (pure domain)**
- `OverlapDetector` — half-open `[start, end)` intervals (back-to-back bookings don't collide), scoped per-service, blocks only against `Confirmed` bookings, honours `allow_overlap`; SQL predicate parity-tested against the in-memory primitive.
- `TravelBufferChecker` — on-site services only, both-neighbour soft warnings, never throws.
- `BookingScheduler` seam: assert overlap, then return buffer warnings.

**Merchant UI**
- Product form: `physical | service` toggle; service hides cost/stock/units/expiry and shows base price, duration, the three flags, an add-ons editor, and the travel buffer (revealed only when on-site).
- Bookings page: hand-built RTL/dark month calendar (no new dependencies; localized names, locale-correct week-start), list with cancel, and a booking form (customer + service pickers, derived end time, add-on selector with running total, on-site-conditional address, overlap error inline, travel-buffer confirm-and-proceed).
- Top-level **Bookings** nav item; Products list gains a type badge + All/Physical/Service filter.

**Line-item sales (walk-in services)**
- `requires_booking = false` services sell as ordinary invoice/POS line items — delivery skips stock for service lines. Bookable services are excluded from the invoice/quote/POS pickers (`Product::sellableAsLineItem`) so they're booked, not line-sold.

**Notifications**
- `BookingReminderNotification` (fixed 24h) + `BookingCancelledNotification`, on the existing pipeline (`mail` + `database` + `broadcast`, lighting the notification bell). Hourly `bookings:notify-upcoming` command scans confirmed bookings starting within 24h, resolves each tenant's owner + admins, notifies once (`reminder_sent_at` dedupe). SMS/WhatsApp is a documented TODO seam (no working provider exists in the codebase).

## Testing

- New Pest coverage for enums, models, the snapshot-immutability invariant, the booking engine edge cases (abutting, cancelled frees slot, completed excluded, self-exclusion on edit, buffer gap under/equal/over, timezone-correct math), controller/validation/API paths, the line-sale filter, and notifications (`Notification::fake`).
- Full suite green in parallel (874 tests). `npm run build` clean. Pint clean.

## Explicitly out of scope (v1)

Staff/resource assignment, recurring appointments, configurable reminder timing, client self-service, route/distance calculation, waitlists, deposits, no-show tracking.

## Reviewer notes

- Worth a visual pass: the calendar's Arabic week-start/numerals/RTL and the travel-buffer confirm-and-proceed round-trip (built to spec but not browser-verified).
- Migrations are additive and reversible.
