### PR TITLE
fix: production 500s, RTL and mobile defects found in the UX audit

### DIFF
--- a/app/Http/Controllers/Core/PreferenceController.php
+++ b/app/Http/Controllers/Core/PreferenceController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Core;
 use App\Actions\UpdatePreferences;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\PreferenceRequest;
-use App\Models\Preference;
 use Inertia\Response;
 
 class PreferenceController extends Controller
@@ -14,9 +13,11 @@ class PreferenceController extends Controller
     {
         abort_unless(auth()->user()->hasRole('owner', 'admin'), 403);
 
-        return inertia('Preferences/Show', [
-            'preferences' => Preference::asPairs(),
-        ]);
+        // Deliberately passes no 'preferences' prop: HandleInertiaRequests already
+        // shares one, with the logo path resolved to a URL. A page prop of the same
+        // name overrides the shared one, which would hand the raw disk path back to
+        // ApplicationLogo and 404 the sidebar logo on this page only.
+        return inertia('Preferences/Show');
     }
 
     public function update(PreferenceRequest $request, UpdatePreferences $action)

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -19,6 +19,24 @@
 }
 
 
+/*
+ * Bottom-anchored floating UI (the operations pill, the export pill) sits at
+ * 1rem from the bottom by default. A page that puts its own full-width bar in
+ * that band — the POS cart bar, for instance — adds .has-bottom-bar to <html>,
+ * and the floating UI stacks above it instead of covering it. The bar only
+ * exists in the stacked layout, so the offset is scoped to below md.
+ */
+:root {
+    --floating-stack-offset: 0px;
+}
+
+@media (max-width: 767px) {
+    .has-bottom-bar {
+        /* 56px bar (min-h-[56px]) + 16px gap */
+        --floating-stack-offset: 4.5rem;
+    }
+}
+
 /* Let native form controls (select option lists, number spinners, date inputs,
    scrollbars) follow the OS theme — which is how this app's dark mode is driven. */
 :root {

--- a/resources/js/Components/OperationsCenter.vue
+++ b/resources/js/Components/OperationsCenter.vue
@@ -160,7 +160,7 @@ const ringCircumference = 2 * Math.PI * 13;
             <div
                 v-if="panelOpen"
                 data-testid="operations-panel"
-                class="fixed bottom-[calc(4rem+env(safe-area-inset-bottom))] z-50 w-80 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-sm overflow-hidden"
+                class="fixed bottom-[calc(4rem+env(safe-area-inset-bottom)+var(--floating-stack-offset))] z-50 w-80 max-w-[calc(100vw-2rem)] bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-sm overflow-hidden"
                 :class="[isRtl ? 'left-4' : 'right-4']"
             >
                 <!-- Header -->
@@ -289,7 +289,7 @@ const ringCircumference = 2 * Math.PI * 13;
                 v-if="!panelOpen && pillState !== 'idle'"
                 @click="panelOpen = true"
                 data-testid="operations-pill"
-                class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 inline-flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2.5 shadow-sm hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
+                class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom)+var(--floating-stack-offset))] z-50 inline-flex items-center gap-3 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-full px-4 py-2.5 shadow-sm hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
                 :class="[isRtl ? 'left-4' : 'right-4']"
             >
                 <span class="relative w-[30px] h-[30px] flex-shrink-0">
@@ -311,7 +311,7 @@ const ringCircumference = 2 * Math.PI * 13;
                     </span>
                 </span>
                 <span class="text-sm font-semibold text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                    <template v-if="pillState === 'active'">{{ active.length }} {{ __('in progress') }}</template>
+                    <template v-if="pillState === 'active'">{{ __('in progress') }}</template>
                     <template v-else>{{ __('Done') }}</template>
                 </span>
             </button>

--- a/resources/js/Components/Pos/FavoriteStar.vue
+++ b/resources/js/Components/Pos/FavoriteStar.vue
@@ -13,7 +13,7 @@ const emit = defineEmits(['toggle']);
         :disabled="disabled"
         :aria-pressed="active"
         :aria-label="active ? __('Remove from favourites') : __('Add to favourites')"
-        class="inline-flex items-center justify-center p-1.5 rounded-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-amber-400 disabled:opacity-40 disabled:cursor-not-allowed"
+        class="relative inline-flex items-center justify-center p-1.5 rounded-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border border-gray-200 dark:border-gray-700 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-amber-400 disabled:opacity-40 disabled:cursor-not-allowed before:absolute before:-inset-2 before:content-['']"
         :class="active
             ? 'text-amber-500 hover:text-amber-600'
             : 'text-gray-300 dark:text-gray-600 hover:text-amber-400'"

--- a/resources/js/Components/Pos/PosFavorites.vue
+++ b/resources/js/Components/Pos/PosFavorites.vue
@@ -60,7 +60,7 @@ const isAvailable = (product) => oversellingEnabled || product.sale_point_qty > 
 
                     <div class="flex items-center justify-between mt-2">
                         <span class="text-sm font-bold text-emerald-600"><Ltr>{{ fmt(product.price || 0) }}</Ltr></span>
-                        <span v-if="isAvailable(product)" class="text-[10px] font-medium text-gray-400">{{ product.sale_point_qty }}</span>
+                        <span v-if="isAvailable(product)" class="text-[10px] font-medium text-gray-400"><Ltr>{{ product.sale_point_qty }}</Ltr></span>
                         <span v-else class="text-[10px] font-bold uppercase tracking-wider text-red-500 dark:text-red-400">{{ __('Out of Stock') }}</span>
                     </div>
                 </button>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -100,7 +100,7 @@
                     </Link>
                     <button
                         type="button"
-                        class="inline-flex h-10 w-10 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 lg:hidden"
+                        class="inline-flex h-11 w-11 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 lg:hidden"
                         @click="showingSidebar = false"
                     >
                         <span class="sr-only">{{ __('Close navigation') }}</span>
@@ -490,7 +490,7 @@
                 <div class="flex h-14 lg:h-16 shrink-0 items-center gap-x-3 border-b border-gray-100 bg-white px-4 dark:border-gray-700 dark:bg-gray-900 sm:px-6 lg:px-8">
                     <button
                         type="button"
-                        class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 lg:hidden"
+                        class="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors duration-200 hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 lg:hidden"
                         @click="showingSidebar = true"
                     >
                         <span class="sr-only">{{ __('Open navigation') }}</span>

--- a/resources/js/Pages/Pos/Session.vue
+++ b/resources/js/Pages/Pos/Session.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, watchEffect, onUnmounted } from "vue";
 import { router, useForm, usePage } from "@inertiajs/vue3";
 import axios from "axios";
 import AppLayout from "@/Layouts/AppLayout.vue";
@@ -127,6 +127,16 @@ const unavailableProducts = ref([]);
 const completedSale = ref({ invoiceId: null, total: 0, paymentMethod: 'cash', change: null });
 const showingCloseModal = ref(false);
 const showingCart = ref(false);
+
+// The floating cart bar occupies the same bottom band as the app's floating
+// pills, which outrank it on z-index and would cover the running total. Flag the
+// band as taken while the bar is up so they stack above it instead; app.css
+// scopes the offset to the stacked layout, where the bar actually renders.
+watchEffect(() => {
+    document.documentElement.classList.toggle("has-bottom-bar", !showingCart.value);
+});
+
+onUnmounted(() => document.documentElement.classList.remove("has-bottom-bar"));
 
 const checkoutForm = useForm({
     session_id: props.session.id,

--- a/resources/js/Pages/Preferences/Show.vue
+++ b/resources/js/Pages/Preferences/Show.vue
@@ -7,14 +7,6 @@
     import ActionMessage from "@/Components/ActionMessage.vue";
     import PrimaryButton from "@/Components/PrimaryButton.vue";
 
-    const props = defineProps({
-        preferences: {
-            type: Object,
-        },
-    });
-
-    provide("preferences", props.preferences);
-
     const truthy = (value) => [true, 1, "1", "true"].includes(value);
 
     // Provided to the fields partial so it can bind to the shared form without

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,5 +1,8 @@
+@php
+    $dir = app()->getLocale() === 'ar' ? 'rtl' : 'ltr';
+@endphp
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" dir="{{ $dir }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/routes/tenant.php
+++ b/routes/tenant.php
@@ -173,7 +173,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         Route::get('/customers/export', [CustomerExportController::class, 'store'])->name('customers.export');
         Route::post('/customers/import', [CustomerImportController::class, 'store'])->name('customers.import');
         Route::get('/customers/import/sample', [CustomerImportController::class, 'show'])->name('customers.import.sample');
-        Route::resource('/customers', CustomersController::class);
+        Route::resource('/customers', CustomersController::class)->except(['create', 'show', 'edit']);
         Route::get('/customers/{customer}/account', [CustomerAccountController::class, 'show'])->name('customers.account');
         Route::get('/customers/{customer}/statement', [CustomerStatementController::class, 'show'])->name('customers.statement');
         Route::get('/customers/{customer}/statement/print', [CustomerStatementController::class, 'store'])->name('customers.print-statement');
@@ -190,7 +190,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         Route::get('/suppliers/export', [SupplierExportController::class, 'store'])->name('suppliers.export');
         Route::post('/suppliers/import', [SupplierImportController::class, 'store'])->name('suppliers.import');
         Route::get('/suppliers/import/sample', [SupplierImportController::class, 'show'])->name('suppliers.import.sample');
-        Route::resource('/suppliers', SuppliersController::class);
+        Route::resource('/suppliers', SuppliersController::class)->except(['create', 'show', 'edit']);
         Route::get('/suppliers/{supplier}/account', [SupplierAccountController::class, 'show'])->name('suppliers.account');
         Route::get('/suppliers/{supplier}/statement', [SupplierStatementController::class, 'show'])->name('suppliers.statement');
         Route::get('/suppliers/{supplier}/statement/print', [SupplierStatementController::class, 'store'])->name('suppliers.print-statement');
@@ -206,7 +206,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         Route::get('/products/import/sample', [ProductImportController::class, 'show'])->name('products.import.sample');
         Route::patch('/products/{product}/quick-update', [ProductsController::class, 'quickUpdate'])->name('products.quick-update');
         Route::patch('/products/{product}/global-favorite', [ProductGlobalFavoriteController::class, 'update'])->name('products.global-favorite');
-        Route::resource('/products', ProductsController::class);
+        Route::resource('/products', ProductsController::class)->except(['create', 'edit']);
 
         /*
         |--------------------------------------------------------------------------
@@ -225,7 +225,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         | Storage locations, manual stock adjustments, add/deduct stock operations,
         | and inter-storage stock transfers.
         */
-        Route::resource('/storages', StoragesController::class);
+        Route::resource('/storages', StoragesController::class)->except(['create', 'edit']);
         Route::post('/storages/{storage}/adjust/{product}', [StockAdjustmentController::class, 'store'])->name('storages.adjust');
         Route::put('/stock/{storage}/add', [StockAdditionController::class, 'store'])->name('stock.add');
         Route::put('/stock/{storage}/deduct', [StockDeductionController::class, 'store'])->name('stock.deduct');
@@ -242,7 +242,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         |--------------------------------------------------------------------------
         | Purchase invoices, goods receiving, and purchase return (credit notes).
         */
-        Route::resource('/purchases', PurchasesController::class)->parameters(['purchases' => 'invoice']);
+        Route::resource('/purchases', PurchasesController::class)->except(['show', 'destroy'])->parameters(['purchases' => 'invoice']);
         Route::post('/purchases/receive/{transaction}', [PurchaseReceiptController::class, 'store'])->name('purchases.receive');
         Route::get('/purchases/{invoice}/return', [PurchaseReturnController::class, 'create'])->name('purchases.return.create');
         Route::post('/purchases/{invoice}/return', [PurchaseReturnController::class, 'store'])->name('purchases.return.store');
@@ -254,7 +254,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         | Sales invoices, POS session management (open/checkout/close),
         | and sale return (credit notes).
         */
-        Route::resource('/sales', SalesController::class)->parameters(['sales' => 'invoice']);
+        Route::resource('/sales', SalesController::class)->except(['show', 'destroy'])->parameters(['sales' => 'invoice']);
         Route::get('/pos', [PosSessionController::class, 'show'])->name('pos.index');
         Route::get('/pos/invoices', [PosInvoicesController::class, 'index'])->name('pos.invoices');
         Route::post('/pos/products/{product}/favorite', [PosFavoriteController::class, 'toggle'])->name('pos.favorites.toggle');
@@ -301,8 +301,8 @@ Route::middleware([ResolveTenant::class])->group(function () {
         | Payment records, cheque management, payee invoice lookup,
         | and cheque status updates.
         */
-        Route::resource('/payments', PaymentsController::class);
-        Route::resource('/cheques', ChequesController::class);
+        Route::resource('/payments', PaymentsController::class)->except(['edit', 'update', 'destroy']);
+        Route::resource('/cheques', ChequesController::class)->except(['show']);
         Route::get('/payee-invoices', [ChequePayeeInvoiceController::class, 'index'])->name('cheques.payee-invoices');
         Route::put('/cheques/{cheque}/status', [ChequeStatusController::class, 'update'])->name('cheques.update-status');
 
@@ -313,7 +313,7 @@ Route::middleware([ResolveTenant::class])->group(function () {
         | One-time and recurring expense management, expense approval workflow,
         | receipt viewing, and bulk export.
         */
-        Route::resource('/recurring-expenses', RecurringExpensesController::class);
+        Route::resource('/recurring-expenses', RecurringExpensesController::class)->except(['show']);
         Route::put('/recurring-expenses/{recurring_expense}/toggle', [RecurringExpenseStatusController::class, 'update'])->name('recurring-expenses.toggle');
         Route::get('/expenses/export', [ExpenseExportController::class, 'store'])->name('expenses.export');
         Route::resource('/expenses', ExpensesController::class);

--- a/tests/Feature/HtmlDirectionTest.php
+++ b/tests/Feature/HtmlDirectionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Preference;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * RTL must be established on <html>, not on a nested div. Anything rendered
+ * outside the Vue layout — body-level teleports, the native scrollbar, text
+ * selection — resolves its direction against the root element.
+ */
+test('the document root is rtl under the arabic locale', function () {
+    Preference::create(['key' => 'language', 'value' => 'ar']);
+    $this->actingAs(User::factory()->create());
+
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    expect($response->getContent())
+        ->toContain('<html lang="ar" dir="rtl"');
+});
+
+test('the document root is ltr under the english locale', function () {
+    Preference::create(['key' => 'language', 'value' => 'en']);
+    $this->actingAs(User::factory()->create());
+
+    $response = $this->get(route('dashboard'));
+
+    $response->assertOk();
+    expect($response->getContent())
+        ->toContain('<html lang="en" dir="ltr"');
+});

--- a/tests/Feature/PreferenceControllerTest.php
+++ b/tests/Feature/PreferenceControllerTest.php
@@ -66,3 +66,18 @@ test('preferences cache and locale are isolated per tenant', function () {
         ->get('http://tenant-two.'.config('app.domain').'/dashboard')
         ->assertInertia(fn ($page) => $page->where('locale', 'en'));
 });
+
+test('the settings page exposes the logo as a url, not the raw disk path', function () {
+    // The sidebar's <ApplicationLogo> reads preferences('logo') straight into an
+    // <img src>. HandleInertiaRequests resolves the stored disk path to a URL, but
+    // a page prop named 'preferences' would override that shared prop and 404 the
+    // logo on this page only.
+    Preference::create(['key' => 'logo', 'value' => 'logos/acme.png']);
+
+    $this->get(route('preferences.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Preferences/Show')
+            ->where('preferences.logo', asset('storage/logos/acme.png'))
+        );
+});

--- a/tests/Feature/RouteIntegrityTest.php
+++ b/tests/Feature/RouteIntegrityTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Route::resource() registers create/edit routes whether or not the controller
+ * implements them. A route pointing at a missing method throws
+ * BadMethodCallException at dispatch — a 500 that no amount of local clicking
+ * finds, because nothing in the UI links to the dead route.
+ */
+it('registers no route pointing at a missing controller method', function () {
+    $broken = collect(Route::getRoutes()->getRoutes())
+        ->map(fn ($route) => $route->getActionName())
+        ->filter(fn ($action) => str_contains($action, '@'))
+        ->filter(fn ($action) => str_starts_with($action, 'App\\'))
+        ->unique()
+        ->reject(function ($action) {
+            [$class, $method] = explode('@', $action, 2);
+
+            return ! class_exists($class) || method_exists($class, $method);
+        })
+        ->values();
+
+    expect($broken->all())->toBe([]);
+});


### PR DESCRIPTION
Fixes found by auditing the live tenant. Six commits, each independently
reviewable — read them one at a time rather than the squashed diff.

## The headline: 19 routes answered 500, not one

The audit found `GET /products/create` returning 500 in production. The cause
turned out to be systemic: `Route::resource` registers `create`/`edit` (and the
rest) whether or not the controller implements them, and dispatching to a
missing method throws `BadMethodCallException`.

That was **19 registered routes** across customers, suppliers, products,
storages, purchases, sales, payments, cheques and recurring-expenses.

Nothing in the UI links to any of them — the add/edit flows are modals — so they
were only reachable by typing a URL, which is why they went unnoticed. The
dot-named references that look like route names (`can('products.create')`) are
RBAC **permission** names, not routes.

Each resource now excludes exactly the methods its controller lacks, following
the pattern the `bookings` resource already used. They answer 404 instead of 500.

`RouteIntegrityTest` fails if any registered route ever points at a missing
controller method again.

## The rest

| Commit | Defect |
|---|---|
| `fix(rtl)` | `<html>` had `lang="ar"` but no `dir`, so the root computed `direction: ltr`. RTL came from a nested div, so anything outside it (body-level teleports, scrollbar side, text selection) inherited LTR. Also makes CLAUDE.md's documented contract true. **Additive** — the nested div still works, so nothing can regress; removing it is a follow-up. |
| `fix(pos)` | `-20` rendered as `20-`. The leading hyphen is bidi-neutral and reorders in an RTL run. The line directly above already wrapped the price in `<Ltr>`; the isolation just wasn't carried to the adjacent span. |
| `fix(preferences)` | The settings page 404'd the sidebar logo — on the page you visit to upload it. `PreferenceController@index` passed a page prop named `preferences` built from raw `asPairs()`, overriding the shared prop that resolves the disk path to a URL. |
| `fix(operations-center)` | The floating pill and the POS cart bar are anchored to the identical band, and the pill's `z-50` beat the bar's `z-30` — a measured 149x52 overlap directly over the cart total. Also drops a duplicated count from the pill label. |
| `fix(mobile)` | 29 of 94 interactive elements were under 44x44 on POS. The two highest-traffic ones are fixed: the favourite star keeps its 30px visual and gains the hit area via `::before`, so density is unchanged. |

## Verification

Every fix was checked against the actual failure rather than assumed:

- **Logo**: the regression test reproduces the exact production value
  (`logos/acme.png` instead of the asset URL) when the fix is reverted.
- **`<html dir>`**: both tests fail without the change.
- **Pill overlap**: reproduced at 390px — the current geometry overlaps by
  exactly **149x52**, matching the live measurement, and the fix takes it to 0.
- **`-20`**: reproduced in-browser — a bare span renders `20-` and a
  `dir="ltr"` + `unicode-bidi:isolate` span renders `-20`.
- **Tap target**: hit-tested with `elementFromPoint` — clickable width goes
  30px -> 44px with the visual box still 30px. (`inset` resolves against the
  padding box, so the 1px border makes `-inset-2`, not `-inset-[7px]`, the value
  that lands on 44.)

Tests green across every affected area: routes, preferences, customers,
suppliers, products, sales, purchases, payments, cheques, storages, bookings,
POS. The full suite OOMs on this machine, but that reproduces on pristine
`master` and is a missing Vite manifest in a fresh worktree, not these changes.

## Not included

- **Configurable numerals** — deliberately held back. `Intl`'s `ar-SA` output
  carries its own bidi controls (`U+061C`, `U+200F`), so `<Ltr>` is *required*
  for Latin money and *must not* wrap Arabic-Indic. Isolation has to become
  conditional on the setting, which is a bigger change than it looked and wants
  its own review.
- **The 175 untranslated `__()` keys** — needs a native Arabic pass first.

## No test coverage

`fix(pos)` and `fix(mobile)` are template-only changes and this project has no
Vue unit-test tooling (Cypress and Dusk only); adding vitest would be a
dependency change. Both were verified in-browser instead, as described above.