### PR TITLE
fix(entitlements): seed default plan on deploy; honor overrides when unconfigured

### DIFF
--- a/app/Features/TenantEntitlements.php
+++ b/app/Features/TenantEntitlements.php
@@ -33,25 +33,39 @@ class TenantEntitlements
     {
         $this->assertType($feature, FeatureType::Boolean);
 
-        if (! $this->configured) {
-            return true;
+        // An explicit override always wins, even before any plan is configured.
+        if (array_key_exists($feature->value, $this->overrides)) {
+            return filter_var($this->overrides[$feature->value], FILTER_VALIDATE_BOOL);
         }
 
         // Strict: any falsy encoding (0, "0", false, null, "") resolves to off.
-        return filter_var($this->raw($feature), FILTER_VALIDATE_BOOL);
+        if (array_key_exists($feature->value, $this->planValues)) {
+            return filter_var($this->planValues[$feature->value], FILTER_VALIDATE_BOOL);
+        }
+
+        // Neither override nor plan specifies it: use the feature default when a
+        // plan governs the tenant, otherwise grant (gating not configured yet).
+        return $this->configured ? filter_var($feature->default(), FILTER_VALIDATE_BOOL) : true;
     }
 
     public function limit(Feature $feature): ?int
     {
         $this->assertType($feature, FeatureType::Limit);
 
-        if (! $this->configured) {
-            return null; // unlimited until plans are configured
+        if (array_key_exists($feature->value, $this->overrides)) {
+            $raw = $this->overrides[$feature->value];
+
+            return $raw === null ? null : (int) $raw;
         }
 
-        $raw = $this->raw($feature);
+        if (array_key_exists($feature->value, $this->planValues)) {
+            $raw = $this->planValues[$feature->value];
 
-        return $raw === null ? null : (int) $raw;
+            return $raw === null ? null : (int) $raw;
+        }
+
+        // Unlimited until a plan governs the tenant; then the feature default.
+        return $this->configured ? (int) $feature->default() : null;
     }
 
     public function usage(Feature $feature): int
@@ -97,22 +111,6 @@ class TenantEntitlements
         }
 
         return ['features' => $features, 'limits' => $limits];
-    }
-
-    /**
-     * The effective raw value: live override, else plan value, else default.
-     */
-    private function raw(Feature $feature): mixed
-    {
-        if (array_key_exists($feature->value, $this->overrides)) {
-            return $this->overrides[$feature->value];
-        }
-
-        if (array_key_exists($feature->value, $this->planValues)) {
-            return $this->planValues[$feature->value];
-        }
-
-        return $feature->default();
     }
 
     private function assertType(Feature $feature, FeatureType $expected): void

--- a/database/migrations/2026_07_21_090000_seed_default_plans.php
+++ b/database/migrations/2026_07_21_090000_seed_default_plans.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Plan;
+use Database\Seeders\PlanSeeder;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Ensure the starter plans (incl. the default free plan) exist in every
+     * deployed environment. Without a governing plan the entitlement resolver
+     * runs in permissive mode and nothing is gated.
+     *
+     * Skipped in tests (each test arranges its own plans) and only seeds when
+     * no plans exist yet, so it never clobbers admin-configured plans.
+     */
+    public function up(): void
+    {
+        if (app()->environment('testing')) {
+            return;
+        }
+
+        if (Plan::count() === 0) {
+            (new PlanSeeder)->run();
+        }
+    }
+
+    public function down(): void
+    {
+        // Intentionally irreversible: keep plans on rollback.
+    }
+};

--- a/tests/Feature/Features/EntitlementResolutionTest.php
+++ b/tests/Feature/Features/EntitlementResolutionTest.php
@@ -87,6 +87,27 @@ it('resolves truthy encodings of a boolean feature to on', function (mixed $stor
     'string one' => ['1'],
 ]);
 
+it('honors a disabling override even when no plan is configured', function () {
+    $tenant = Tenant::factory()->create(); // no subscription, no default plan
+
+    // Permissive by default...
+    expect(Entitlements::for($tenant)->enabled(Feature::Bookings))->toBeTrue();
+    Entitlements::flush($tenant);
+
+    // ...but an explicit override to disable must win.
+    TenantFeatureOverride::factory()->forFeature(Feature::Bookings, false)->create(['tenant_id' => $tenant->id]);
+
+    expect(Entitlements::for($tenant)->enabled(Feature::Bookings))->toBeFalse();
+});
+
+it('honors a limit override even when no plan is configured', function () {
+    $tenant = Tenant::factory()->create();
+
+    TenantFeatureOverride::factory()->forFeature(Feature::MaxProducts, 3)->create(['tenant_id' => $tenant->id]);
+
+    expect(Entitlements::for($tenant)->limit(Feature::MaxProducts))->toBe(3);
+});
+
 it('falls back to the default plan when the tenant has no subscription', function () {
     entPlanWith([Feature::Bookings->value => true], default: true);
     $tenant = Tenant::factory()->create();


### PR DESCRIPTION
Follow-up to #83. After merging, disabling features for a tenant had no effect and no default plan existed. Both trace to one root cause plus one gap.

### 1. No default plan is seeded on deploy (root cause)
`PlanSeeder` was only registered in `DatabaseSeeder`, which isn't run on deploy — so **no plan existed in production**. With no plan governing a tenant, the resolver runs in its permissive-when-unconfigured mode and grants everything, so nothing is gated and disabling appears to do nothing.

**Fix:** a data migration seeds the starter plans (including the default free plan) — idempotent (`Plan::count() === 0` guard, never clobbers admin-configured plans) and skipped under `APP_ENV=testing` so it doesn't pollute the test baseline.

### 2. Permissive mode ignored explicit overrides (gap)
`enabled()` / `limit()` short-circuited to "grant" *before* consulting per-tenant overrides, so an explicit override to disable a feature was ignored until a plan existed. Resolution now goes **override → plan value → (configured ? feature default : grant)**, so an explicit override always wins.

### ⚠️ Deploy note
Once this migration runs, tenants **with no subscription** are governed by the **default (free) plan** — they immediately drop from "everything" (permissive) to the free tier. Assign real/active tenants an appropriate plan in `/__admin`, or make the default plan generous, so no active merchant loses access. Also ensure the built frontend assets from #83 are deployed, or the nav won't reflect entitlements.

### Tests
Added: an override disables a feature / sets a limit even with no plan configured. Full feature-gating suite green.
