### PR TITLE
fix(pos): treasury movements, POS settings, session details, timestamps & walk-in i18n

### DIFF
--- a/app/Actions/Pos/ProcessPosCheckoutAction.php
+++ b/app/Actions/Pos/ProcessPosCheckoutAction.php
@@ -88,9 +88,12 @@ class ProcessPosCheckoutAction
             $customerType = $data->get('customer_type', Customer::class);
 
             if (! $customerId && $customerType === Customer::class) {
+                // Match the walk-in by the stable is_system flag, not its display
+                // name — otherwise a translated name (e.g. Arabic) forks a second
+                // walk-in customer that never matches the seeded one.
                 $customerId = Customer::firstOrCreate(
-                    ['name' => 'Walk-in Customer', 'tenant_id' => $session->tenant_id],
-                    ['address' => 'N/A', 'phone_number' => 'N/A', 'is_system' => true]
+                    ['tenant_id' => $session->tenant_id, 'is_system' => true],
+                    ['name' => __('Walk-in Customer'), 'address' => 'N/A', 'phone_number' => 'N/A']
                 )->id;
             }
 

--- a/app/Actions/Pos/ProcessPosCheckoutAction.php
+++ b/app/Actions/Pos/ProcessPosCheckoutAction.php
@@ -138,12 +138,11 @@ class ProcessPosCheckoutAction
 
             // 5. Record payment only for methods that collect money at checkout
             if ($this->recordsImmediatePayment($paymentMethod)) {
-                $cashDrawer = $paymentMethod === PaymentMethod::Cash
-                    ? TreasuryAccount::where('sale_point_id', $session->storage_id)
-                        ->ofType(TreasuryAccountType::Cash)
-                        ->active()
-                        ->first()
-                    : null;
+                $accountId = $this->resolveCheckoutAccountId(
+                    $paymentMethod,
+                    $session,
+                    $data->get('treasury_account_id'),
+                );
 
                 $this->recordPayment->handle(
                     invoice: $invoice,
@@ -153,7 +152,7 @@ class ProcessPosCheckoutAction
                     direction: PaymentDirection::In,
                     options: [
                         'notes' => 'POS sale',
-                        'treasury_account_id' => $cashDrawer?->id,
+                        'treasury_account_id' => $accountId,
                     ]
                 );
             }
@@ -169,6 +168,51 @@ class ProcessPosCheckoutAction
             PaymentMethod::Cheque,
             PaymentMethod::BankTransfer,
         ], true);
+    }
+
+    /**
+     * The treasury account id a checkout payment lands in. Cash uses the
+     * sale-point drawer, falling back to the shared default cash account (and,
+     * failing that, null — RecordPaymentAction still routes cash to the default,
+     * so cash-only tenants with no account keep working). Bank transfers must
+     * land somewhere: the account picked at checkout or the configured POS
+     * default, otherwise the sale is blocked so bank revenue never goes unbanked.
+     */
+    private function resolveCheckoutAccountId(
+        PaymentMethod $method,
+        PosSession $session,
+        int|string|null $requestedAccountId,
+    ): ?int {
+        if ($method === PaymentMethod::Cash) {
+            $drawer = TreasuryAccount::where('sale_point_id', $session->storage_id)
+                ->ofType(TreasuryAccountType::Cash)
+                ->active()
+                ->first()
+                ?? TreasuryAccount::defaultCash();
+
+            return $drawer?->id;
+        }
+
+        $account = $this->resolveBankAccount($requestedAccountId);
+
+        if (! $account) {
+            throw new DomainException(__('No treasury account is available for :method payments. Choose an account or set a POS default in settings.', [
+                'method' => $method->label(),
+            ]));
+        }
+
+        return $account->id;
+    }
+
+    private function resolveBankAccount(int|string|null $requestedAccountId): ?TreasuryAccount
+    {
+        if ($requestedAccountId) {
+            return TreasuryAccount::active()->find($requestedAccountId);
+        }
+
+        $defaultId = preference('pos_default_bank_account_id');
+
+        return $defaultId ? TreasuryAccount::active()->find($defaultId) : null;
     }
 
     private function replenish(Storage $salePoint, int $productId, int $quantityNeeded, User $actor): void

--- a/app/Actions/StoreExpenseAction.php
+++ b/app/Actions/StoreExpenseAction.php
@@ -24,17 +24,23 @@ class StoreExpenseAction
     public function handle(array $data, User $actor): Expense
     {
         return DB::transaction(function () use ($data, $actor) {
+            // An expense is money leaving the business, so it must hit the ledger.
+            // Honour the chosen account, otherwise fall back to the default cash
+            // account so the treasury reflects the outflow without extra clicks.
+            $account = ! empty($data['treasury_account_id'])
+                ? TreasuryAccount::findOrFail($data['treasury_account_id'])
+                : TreasuryAccount::defaultCash();
+
             $expense = Expense::create([
                 'title' => $data['title'],
                 'amount' => $data['amount'],
                 'expensed_at' => $data['expensed_at'],
                 'notes' => $data['notes'] ?? null,
                 'receipt_path' => $data['receipt_path'] ?? null,
-                'treasury_account_id' => $data['treasury_account_id'] ?? null,
+                'treasury_account_id' => $account?->id,
             ]);
 
-            if (! empty($data['treasury_account_id'])) {
-                $account = TreasuryAccount::findOrFail($data['treasury_account_id']);
+            if ($account) {
                 $amountInCents = Money::fromMajor($data['amount'])->minor();
 
                 $this->recordMovement->handle(

--- a/app/Http/Controllers/Core/PreferenceController.php
+++ b/app/Http/Controllers/Core/PreferenceController.php
@@ -3,8 +3,12 @@
 namespace App\Http\Controllers\Core;
 
 use App\Actions\UpdatePreferences;
+use App\Enums\TreasuryAccountType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\PreferenceRequest;
+use App\Models\Storage;
+use App\Models\TreasuryAccount;
+use Illuminate\Support\Collection;
 use Inertia\Response;
 
 class PreferenceController extends Controller
@@ -17,7 +21,34 @@ class PreferenceController extends Controller
         // shares one, with the logo path resolved to a URL. A page prop of the same
         // name overrides the shared one, which would hand the raw disk path back to
         // ApplicationLogo and 404 the sidebar logo on this page only.
-        return inertia('Preferences/Show');
+        return inertia('Preferences/Show', [
+            'cash_accounts' => $this->accountOptions(TreasuryAccountType::Cash),
+            'bank_accounts' => $this->accountOptions(TreasuryAccountType::Bank),
+            'sale_points' => Storage::salePoints()
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(fn (Storage $salePoint) => [
+                    'id' => $salePoint->id,
+                    'name' => $salePoint->name,
+                ]),
+        ]);
+    }
+
+    /**
+     * Active treasury accounts of the given type, shaped for a settings select.
+     *
+     * @return Collection<int, array{id: int, name: string}>
+     */
+    private function accountOptions(TreasuryAccountType $type): Collection
+    {
+        return TreasuryAccount::active()
+            ->ofType($type)
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (TreasuryAccount $account) => [
+                'id' => $account->id,
+                'name' => $account->name,
+            ]);
     }
 
     public function update(PreferenceRequest $request, UpdatePreferences $action)

--- a/app/Http/Controllers/Expenses/ExpensesController.php
+++ b/app/Http/Controllers/Expenses/ExpensesController.php
@@ -47,6 +47,7 @@ class ExpensesController extends Controller
                 'type_label' => $a->type->label(),
                 'current_balance' => $a->currentBalance(),
             ]),
+            'default_treasury_account_id' => TreasuryAccount::defaultCash()?->id,
         ]);
     }
 

--- a/app/Http/Controllers/Sales/PosCheckoutController.php
+++ b/app/Http/Controllers/Sales/PosCheckoutController.php
@@ -7,6 +7,7 @@ use App\Exceptions\InsufficientStockException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\PosCheckoutRequest;
 use App\Models\PosSession;
+use DomainException;
 
 class PosCheckoutController extends Controller
 {
@@ -23,7 +24,7 @@ class PosCheckoutController extends Controller
                 $request->idempotency_key,
                 $request->boolean('acknowledge_transfers')
             );
-        } catch (InsufficientStockException $e) {
+        } catch (InsufficientStockException|DomainException $e) {
             return back()->with('error', $e->getMessage());
         }
 

--- a/app/Http/Controllers/Sales/PosInvoicesController.php
+++ b/app/Http/Controllers/Sales/PosInvoicesController.php
@@ -44,6 +44,18 @@ class PosInvoicesController extends Controller
                     'variance' => $session->closing_float !== null ? $session->variance() / 100 : null,
                     'invoice_count' => $session->invoices()->count(),
                     'is_open' => $session->isOpen(),
+                    'sales_by_method' => $session->salesByPaymentMethod()
+                        ->map(fn (array $row) => [
+                            'method' => $row['method'],
+                            'total' => $row['total'] / 100,
+                            'count' => $row['count'],
+                        ])->values(),
+                    'sales_by_account' => $session->salesByTreasuryAccount()
+                        ->map(fn (array $row) => [
+                            'account_name' => $row['account_name'],
+                            'total' => $row['total'] / 100,
+                            'count' => $row['count'],
+                        ])->values(),
                 ])
                 ->withQueryString(),
 

--- a/app/Http/Controllers/Sales/PosSessionController.php
+++ b/app/Http/Controllers/Sales/PosSessionController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers\Sales;
 
 use App\Actions\Pos\ClosePosSessionAction;
 use App\Actions\Pos\OpenPosSessionAction;
+use App\Enums\TreasuryAccountType;
 use App\Http\Controllers\Controller;
 use App\Models\PosSession;
 use App\Models\Product;
 use App\Models\Storage;
+use App\Models\TreasuryAccount;
 use App\Queries\DashboardStatsQuery;
 use App\Queries\PosFavoriteProductsQuery;
 use Illuminate\Database\Eloquent\Collection;
@@ -77,6 +79,17 @@ class PosSessionController extends Controller
                 'cash_sales_total' => $session->cashSalesTotal() / 100,
                 'expected_closing_float' => $session->expectedClosingFloat() / 100,
             ],
+            'bankAccounts' => TreasuryAccount::active()
+                ->ofType(TreasuryAccountType::Bank)
+                ->orderBy('name')
+                ->get(['id', 'name'])
+                ->map(fn (TreasuryAccount $account) => [
+                    'id' => $account->id,
+                    'name' => $account->name,
+                ]),
+            'defaultBankAccountId' => preference('pos_default_bank_account_id')
+                ? (int) preference('pos_default_bank_account_id')
+                : null,
         ]);
     }
 

--- a/app/Http/Requests/PosCheckoutRequest.php
+++ b/app/Http/Requests/PosCheckoutRequest.php
@@ -32,6 +32,12 @@ class PosCheckoutRequest extends FormRequest
             'items.*.unit_id' => ['nullable', Rule::exists('units', 'id')->where('tenant_id', $tenantId)],
             'total' => 'required|numeric',
             'payment_method' => ['nullable', new Enum(PaymentMethod::class)],
+            'treasury_account_id' => [
+                'nullable',
+                Rule::exists('treasury_accounts', 'id')
+                    ->where('tenant_id', $tenantId)
+                    ->where('is_active', true),
+            ],
             'customer_type' => ['nullable', Rule::in([Customer::class])],
             'idempotency_key' => 'nullable|string',
             'acknowledge_transfers' => 'nullable|boolean',

--- a/app/Http/Requests/PreferenceRequest.php
+++ b/app/Http/Requests/PreferenceRequest.php
@@ -4,6 +4,8 @@ namespace App\Http\Requests;
 
 use App\Enums\InventoryStrategyType;
 use App\Enums\NumeralSystem;
+use App\Enums\StorageType;
+use App\Enums\TreasuryAccountType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -19,6 +21,8 @@ class PreferenceRequest extends FormRequest
      */
     public function rules(): array
     {
+        $tenantId = app('currentTenant')->id;
+
         return [
             'logo' => 'nullable|image|max:2048',
             'invoicesHeadline' => 'nullable|string|max:500',
@@ -28,6 +32,24 @@ class PreferenceRequest extends FormRequest
             'pecentage' => 'nullable|numeric|min:0|max:100',
             'inventory_strategy' => ['nullable', Rule::enum(InventoryStrategyType::class)],
             'allow_overselling' => 'nullable|boolean',
+            'pos_default_cash_account_id' => [
+                'nullable',
+                Rule::exists('treasury_accounts', 'id')
+                    ->where('tenant_id', $tenantId)
+                    ->where('type', TreasuryAccountType::Cash->value),
+            ],
+            'pos_default_bank_account_id' => [
+                'nullable',
+                Rule::exists('treasury_accounts', 'id')
+                    ->where('tenant_id', $tenantId)
+                    ->where('type', TreasuryAccountType::Bank->value),
+            ],
+            'pos_default_sale_point_id' => [
+                'nullable',
+                Rule::exists('storages', 'id')
+                    ->where('tenant_id', $tenantId)
+                    ->where('type', StorageType::SALE_POINT->value),
+            ],
         ];
     }
 }

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -7,6 +7,7 @@ use App\Enums\ExpenseStatus;
 use App\Traits\WithTrashScope;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -73,6 +74,14 @@ class Expense extends BaseModel
     public function recurringExpense(): BelongsTo
     {
         return $this->belongsTo(RecurringExpense::class, 'recurring_expense_id');
+    }
+
+    /**
+     * The treasury movements this expense produced.
+     */
+    public function treasuryMovements(): MorphMany
+    {
+        return $this->morphMany(TreasuryMovement::class, 'movable');
     }
 
     /**

--- a/app/Models/PosSession.php
+++ b/app/Models/PosSession.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\PaymentMethod;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 
 class PosSession extends BaseModel
 {
@@ -64,5 +66,52 @@ class PosSession extends BaseModel
     public function isOpen(): bool
     {
         return $this->closed_at === null;
+    }
+
+    /**
+     * Total sold in this session grouped by payment method, in minor units.
+     *
+     * @return Collection<int, array{method: string, total: int, count: int}>
+     */
+    public function salesByPaymentMethod(): Collection
+    {
+        return $this->invoices()
+            ->selectRaw('payment_method, SUM(total) as total, COUNT(*) as count')
+            ->groupBy('payment_method')
+            ->orderByRaw('SUM(total) DESC')
+            ->get()
+            ->map(fn ($row) => [
+                'method' => $row->payment_method instanceof PaymentMethod
+                    ? $row->payment_method->value
+                    : (string) $row->payment_method,
+                'total' => (int) $row->total,
+                'count' => (int) $row->count,
+            ]);
+    }
+
+    /**
+     * Payments collected in this session grouped by treasury account, in minor units.
+     *
+     * @return Collection<int, array{account_id: int, account_name: string, total: int, count: int}>
+     */
+    public function salesByTreasuryAccount(): Collection
+    {
+        // Attribute each invoice's total to the account its payment landed in.
+        // Summing invoices.total (not payments.amount) keeps this on the same
+        // minor-unit scale as cashSalesTotal() so the figures reconcile.
+        return $this->invoices()
+            ->join('payments', 'payments.invoice_id', '=', 'invoices.id')
+            ->join('treasury_accounts', 'treasury_accounts.id', '=', 'payments.treasury_account_id')
+            ->whereNotNull('payments.treasury_account_id')
+            ->groupBy('treasury_accounts.id', 'treasury_accounts.name')
+            ->orderByRaw('SUM(invoices.total) DESC')
+            ->selectRaw('treasury_accounts.id as account_id, treasury_accounts.name as account_name, SUM(invoices.total) as total, COUNT(DISTINCT invoices.id) as count')
+            ->get()
+            ->map(fn ($row) => [
+                'account_id' => (int) $row->account_id,
+                'account_name' => $row->account_name,
+                'total' => (int) $row->total,
+                'count' => (int) $row->count,
+            ]);
     }
 }

--- a/database/migrations/2026_07_21_011010_backfill_pos_bank_transfer_treasury_movements.php
+++ b/database/migrations/2026_07_21_011010_backfill_pos_bank_transfer_treasury_movements.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Actions\Treasury\RecordTreasuryMovementAction;
+use App\Enums\PaymentMethod;
+use App\Enums\TreasuryAccountType;
+use App\Enums\TreasuryMovementReason;
+use App\Models\Payment;
+use App\Models\Tenant;
+use App\Models\TreasuryAccount;
+use App\Models\User;
+use App\ValueObjects\Money;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * Bank-transfer POS sales historically recorded a Payment but no treasury
+     * movement, so treasury balances under-report bank revenue. Backfill the
+     * missing movements against each tenant's configured (or oldest) bank
+     * account. Idempotent: payments that already produced a movement are skipped.
+     */
+    public function up(): void
+    {
+        $action = app(RecordTreasuryMovementAction::class);
+        $original = app()->bound('currentTenant') ? app('currentTenant') : null;
+
+        try {
+            Tenant::query()->each(function (Tenant $tenant) use ($action) {
+                app()->instance('currentTenant', $tenant);
+
+                $target = $this->targetBankAccount();
+
+                if (! $target) {
+                    Log::warning('POS bank-transfer backfill skipped: no bank account', ['tenant_id' => $tenant->id]);
+
+                    return;
+                }
+
+                Payment::query()
+                    ->where('payment_method', PaymentMethod::BankTransfer->value)
+                    ->whereHas('invoice', fn ($invoices) => $invoices->whereNotNull('pos_session_id'))
+                    ->with('treasuryMovements')
+                    ->orderBy('paid_at')
+                    ->each(function (Payment $payment) use ($action, $target) {
+                        if ($payment->treasuryMovements->isNotEmpty()) {
+                            return;
+                        }
+
+                        $account = $payment->treasury_account_id
+                            ? TreasuryAccount::find($payment->treasury_account_id) ?? $target
+                            : $target;
+
+                        $actor = $this->actorFor($payment);
+
+                        if (! $actor) {
+                            Log::warning('POS bank-transfer backfill skipped: no actor', ['payment_id' => $payment->id]);
+
+                            return;
+                        }
+
+                        $action->handle(
+                            account: $account,
+                            amount: Money::fromMajor((float) $payment->amount)->minor(),
+                            reason: TreasuryMovementReason::PaymentReceived,
+                            movable: $payment,
+                            actor: $actor,
+                            notes: 'Backfilled POS bank transfer',
+                            occurredAt: $payment->paid_at,
+                        );
+
+                        $payment->update(['treasury_account_id' => $account->id]);
+                    });
+            });
+        } finally {
+            // Restore whatever tenant context (if any) was bound before the loop
+            // so callers — including migration-runner tests — keep their binding.
+            if ($original) {
+                app()->instance('currentTenant', $original);
+            } else {
+                app()->forgetInstance('currentTenant');
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Backfilled movements are not reversible without data loss; no-op.
+    }
+
+    private function targetBankAccount(): ?TreasuryAccount
+    {
+        $configuredId = preference('pos_default_bank_account_id');
+
+        if ($configuredId && $account = TreasuryAccount::active()->find($configuredId)) {
+            return $account;
+        }
+
+        return TreasuryAccount::active()
+            ->ofType(TreasuryAccountType::Bank)
+            ->oldest('id')
+            ->first();
+    }
+
+    private function actorFor(Payment $payment): ?User
+    {
+        if ($payment->created_by) {
+            return User::withoutGlobalScopes()->find($payment->created_by);
+        }
+
+        return User::withoutGlobalScopes()
+            ->whereHas('tenants', fn ($tenants) => $tenants->where('tenants.id', app('currentTenant')->id))
+            ->first();
+    }
+};

--- a/database/migrations/2026_07_21_011625_backfill_expense_treasury_movements.php
+++ b/database/migrations/2026_07_21_011625_backfill_expense_treasury_movements.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Actions\Treasury\RecordTreasuryMovementAction;
+use App\Enums\TreasuryMovementReason;
+use App\Models\Expense;
+use App\Models\Tenant;
+use App\Models\TreasuryAccount;
+use App\Models\User;
+use App\ValueObjects\Money;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * Expenses recorded without a treasury account produced no movement, so the
+     * treasury never reflected the outflow. Backfill a negative movement for
+     * each such expense, against its own account or the tenant's default cash
+     * account. Idempotent: expenses that already produced a movement are skipped.
+     */
+    public function up(): void
+    {
+        $action = app(RecordTreasuryMovementAction::class);
+        $original = app()->bound('currentTenant') ? app('currentTenant') : null;
+
+        try {
+            Tenant::query()->each(function (Tenant $tenant) use ($action) {
+                app()->instance('currentTenant', $tenant);
+
+                $defaultCash = TreasuryAccount::defaultCash();
+
+                Expense::query()
+                    ->with('treasuryMovements')
+                    ->orderBy('expensed_at')
+                    ->each(function (Expense $expense) use ($action, $defaultCash) {
+                        if ($expense->treasuryMovements->isNotEmpty()) {
+                            return;
+                        }
+
+                        $account = $expense->treasury_account_id
+                            ? TreasuryAccount::find($expense->treasury_account_id) ?? $defaultCash
+                            : $defaultCash;
+
+                        if (! $account) {
+                            return;
+                        }
+
+                        $actor = $this->actorFor($expense);
+
+                        if (! $actor) {
+                            Log::warning('Expense treasury backfill skipped: no actor', ['expense_id' => $expense->id]);
+
+                            return;
+                        }
+
+                        $action->handle(
+                            account: $account,
+                            amount: -Money::fromMajor((float) $expense->amount)->minor(),
+                            reason: TreasuryMovementReason::ExpensePaid,
+                            movable: $expense,
+                            actor: $actor,
+                            notes: 'Backfilled expense',
+                            occurredAt: $expense->expensed_at,
+                        );
+
+                        if (! $expense->treasury_account_id) {
+                            $expense->update(['treasury_account_id' => $account->id]);
+                        }
+                    });
+            });
+        } finally {
+            if ($original) {
+                app()->instance('currentTenant', $original);
+            } else {
+                app()->forgetInstance('currentTenant');
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Backfilled movements are not reversible without data loss; no-op.
+    }
+
+    private function actorFor(Expense $expense): ?User
+    {
+        if ($expense->created_by) {
+            return User::withoutGlobalScopes()->find($expense->created_by);
+        }
+
+        return User::withoutGlobalScopes()
+            ->whereHas('tenants', fn ($tenants) => $tenants->where('tenants.id', app('currentTenant')->id))
+            ->first();
+    }
+};

--- a/database/migrations/2026_07_21_012358_dedupe_walk_in_customers.php
+++ b/database/migrations/2026_07_21_012358_dedupe_walk_in_customers.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Tenant;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Checkout used to match the walk-in customer by its display name, so a
+     * translated tenant ended up with two system walk-ins: the seeded (localized)
+     * one and a literal "Walk-in Customer" created at checkout. Collapse them:
+     * keep the oldest system customer per tenant, move invoices onto it, and
+     * soft-delete the duplicates. Idempotent — tenants with a single walk-in are
+     * left untouched.
+     */
+    public function up(): void
+    {
+        $original = app()->bound('currentTenant') ? app('currentTenant') : null;
+
+        try {
+            Tenant::query()->each(function (Tenant $tenant) {
+                app()->instance('currentTenant', $tenant);
+
+                $walkIns = Customer::where('is_system', true)->orderBy('id')->get();
+
+                if ($walkIns->count() < 2) {
+                    return;
+                }
+
+                $canonical = $walkIns->shift();
+
+                foreach ($walkIns as $duplicate) {
+                    Invoice::where('invocable_type', Customer::class)
+                        ->where('invocable_id', $duplicate->id)
+                        ->update(['invocable_id' => $canonical->id]);
+
+                    $duplicate->delete();
+                }
+            });
+        } finally {
+            if ($original) {
+                app()->instance('currentTenant', $original);
+            } else {
+                app()->forgetInstance('currentTenant');
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Merged customers cannot be reconstructed; no-op.
+    }
+};

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,4 +1,9 @@
 {
+    "Sales by payment method": "المبيعات حسب طريقة الدفع",
+    "Collected by account": "المحصّل حسب الحساب",
+    "No sales yet.": "لا توجد مبيعات بعد.",
+    "No treasury movements recorded.": "لم تُسجَّل أي حركات خزينة.",
+    "Advance": "دفعة مقدمة",
     "Deposit To": "الإيداع في",
     "No bank account is set up. Add one in POS settings before taking bank transfers.": "لا يوجد حساب بنكي مُعد. أضف حسابًا في إعدادات نقطة البيع قبل قبول التحويلات البنكية.",
     "No treasury account is available for :method payments. Choose an account or set a POS default in settings.": "لا يوجد حساب خزينة متاح لمدفوعات :method. اختر حسابًا أو عيّن حسابًا افتراضيًا في إعدادات نقطة البيع.",

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,4 +1,13 @@
 {
+    "Default cash account": "الحساب النقدي الافتراضي",
+    "Default bank account": "الحساب البنكي الافتراضي",
+    "Default sale point": "نقطة البيع الافتراضية",
+    "Select an account": "اختر حسابًا",
+    "Select a sale point": "اختر نقطة بيع",
+    "Cash sales with no sale-point drawer fall back to this account.": "المبيعات النقدية التي لا يوجد لها درج نقدي لنقطة البيع تُسجَّل في هذا الحساب.",
+    "Bank-transfer sales are recorded against this account when none is picked at checkout.": "مبيعات التحويل البنكي تُسجَّل في هذا الحساب عند عدم اختيار حساب أثناء الدفع.",
+    "The sale point pre-selected when opening a POS session.": "نقطة البيع المحددة مسبقًا عند فتح جلسة نقطة البيع.",
+    "Defaults applied at the register — where money lands and which sale point is used.": "الإعدادات الافتراضية المطبقة في نقطة البيع — أين تُودَع الأموال وأي نقطة بيع تُستخدم.",
     "Plans": "الخطط",
     "New plan": "خطة جديدة",
     "Edit plan": "تعديل الخطة",

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,4 +1,7 @@
 {
+    "Deposit To": "الإيداع في",
+    "No bank account is set up. Add one in POS settings before taking bank transfers.": "لا يوجد حساب بنكي مُعد. أضف حسابًا في إعدادات نقطة البيع قبل قبول التحويلات البنكية.",
+    "No treasury account is available for :method payments. Choose an account or set a POS default in settings.": "لا يوجد حساب خزينة متاح لمدفوعات :method. اختر حسابًا أو عيّن حسابًا افتراضيًا في إعدادات نقطة البيع.",
     "Default cash account": "الحساب النقدي الافتراضي",
     "Default bank account": "الحساب البنكي الافتراضي",
     "Default sale point": "نقطة البيع الافتراضية",

--- a/resources/js/Components/Pos/PosCheckoutModal.vue
+++ b/resources/js/Components/Pos/PosCheckoutModal.vue
@@ -7,6 +7,8 @@ const props = defineProps({
     discountAmount: Number,
     processing: Boolean,
     currency: String,
+    bankAccounts: { type: Array, default: () => [] },
+    defaultBankAccountId: { type: [Number, null], default: null },
 });
 
 const emit = defineEmits(['close', 'confirm']);
@@ -15,6 +17,13 @@ const fmt = (val) => window.formatMoney(val);
 
 const selectedPaymentMethod = ref('cash');
 const cashTendered = ref('');
+const selectedBankAccountId = ref(props.defaultBankAccountId);
+
+// Bank transfer needs a destination account. Block confirmation when the method
+// is selected but no bank account is available (none configured yet).
+const bankAccountMissing = computed(
+    () => selectedPaymentMethod.value === 'bank_transfer' && !selectedBankAccountId.value,
+);
 
 const changeAmount = computed(() => {
     if (selectedPaymentMethod.value !== 'cash') return null;
@@ -53,12 +62,16 @@ const confirm = () => {
     emit('confirm', {
         paymentMethod: selectedPaymentMethod.value,
         change: changeAmount.value,
+        treasuryAccountId: selectedPaymentMethod.value === 'bank_transfer'
+            ? selectedBankAccountId.value
+            : null,
     });
 };
 
 const reset = () => {
     cashTendered.value = '';
     selectedPaymentMethod.value = 'cash';
+    selectedBankAccountId.value = props.defaultBankAccountId;
 };
 
 defineExpose({ reset, selectedPaymentMethod, changeAmount });
@@ -108,9 +121,24 @@ defineExpose({ reset, selectedPaymentMethod, changeAmount });
                                 </div>
                             </div>
                         </Transition>
+                        <Transition enter-active-class="transition-all duration-200" enter-from-class="opacity-0 -translate-y-2" enter-to-class="opacity-100 translate-y-0">
+                            <div v-if="selectedPaymentMethod === 'bank_transfer'" class="mb-5">
+                                <label class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1.5 block">{{ __('Deposit To') }}</label>
+                                <select
+                                    v-if="bankAccounts.length"
+                                    v-model="selectedBankAccountId"
+                                    class="w-full px-4 py-3 text-sm text-gray-900 dark:text-white bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl focus:border-emerald-300 focus:ring focus:ring-emerald-200 focus:ring-opacity-50"
+                                >
+                                    <option v-for="account in bankAccounts" :key="account.id" :value="account.id">{{ account.name }}</option>
+                                </select>
+                                <p v-else class="px-4 py-3 text-sm rounded-xl bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400">
+                                    {{ __('No bank account is set up. Add one in POS settings before taking bank transfers.') }}
+                                </p>
+                            </div>
+                        </Transition>
                         <div class="flex gap-x-3">
                             <button type="button" class="flex-1 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors" @click="emit('close')">{{ __('Cancel') }}</button>
-                            <button type="button" class="flex-1 py-3 text-sm font-semibold text-white bg-emerald-600 rounded-xl hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2" :disabled="processing" @click="confirm">
+                            <button type="button" class="flex-1 py-3 text-sm font-semibold text-white bg-emerald-600 rounded-xl hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2" :disabled="processing || bankAccountMissing" @click="confirm">
                                 <span v-if="processing" class="flex items-center justify-center gap-x-2">
                                     <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
                                     {{ __('Processing...') }}

--- a/resources/js/Composables/useDate.js
+++ b/resources/js/Composables/useDate.js
@@ -66,8 +66,28 @@ export function useDate() {
         }
     };
 
+    // Compact, human-friendly stamp like "2 Jun 12:00 PM" for dense lists.
+    // Ignores the numeric dateFormat preference on purpose, but still honours
+    // the viewer's locale and timezone.
+    const formatDateTimeShort = (dateString) => {
+        if (!dateString) return '—';
+
+        try {
+            return new Intl.DateTimeFormat(getLocale(), {
+                day: 'numeric',
+                month: 'short',
+                hour: '2-digit',
+                minute: '2-digit',
+                timeZone: getTimeZone(),
+            }).format(new Date(dateString));
+        } catch {
+            return dateString;
+        }
+    };
+
     return {
         formatDate,
         formatDateTime,
+        formatDateTimeShort,
     };
 }

--- a/resources/js/Pages/Expenses/Create.vue
+++ b/resources/js/Pages/Expenses/Create.vue
@@ -7,9 +7,10 @@ import FileUploader from "@/Components/FileUploader.vue";
 import { useForm } from "@inertiajs/vue3";
 import { ref } from "vue";
 
-defineProps({
+const props = defineProps({
     categories: Array,
     treasury_accounts: Array,
+    default_treasury_account_id: { type: [Number, null], default: null },
 });
 
 const form = useForm({
@@ -18,7 +19,9 @@ const form = useForm({
     expensed_at: new Date().toISOString().substr(0, 10),
     category_ids: [],
     category_objects: [],
-    treasury_account_id: null,
+    // Default to the tenant's cash account so the expense reaches the treasury
+    // even when the cashier doesn't pick one; still overridable below.
+    treasury_account_id: props.default_treasury_account_id,
     notes: "",
     receipt: null,
     is_recurring: false,
@@ -27,7 +30,7 @@ const form = useForm({
     ends_at: null,
 });
 
-const selectedTreasuryAccount = ref(null);
+const selectedTreasuryAccount = ref(props.default_treasury_account_id);
 
 const formatCurrency = (amount, currency = null) => window.formatMoney(amount, currency);
 

--- a/resources/js/Pages/Pos/Invoices.vue
+++ b/resources/js/Pages/Pos/Invoices.vue
@@ -3,7 +3,10 @@ import { ref, watch } from "vue";
 import { Link, router } from "@inertiajs/vue3";
 import AppLayout from "@/Layouts/AppLayout.vue";
 import Pagination from "@/Shared/Pagination.vue";
+import { useDate } from "@/Composables/useDate";
 import debounce from "lodash/debounce";
+
+const { formatDateTimeShort } = useDate();
 
 const props = defineProps({
     invoices: Object,
@@ -217,7 +220,7 @@ const methodLabel = (method) => methodLabels[method] ?? method;
                             </thead>
                             <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60 bg-white dark:bg-gray-900">
                                 <tr v-for="invoice in invoices.data" :key="invoice.id" class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ invoice.created_at_human ?? invoice.created_at }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ formatDateTimeShort(invoice.created_at) }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm font-semibold text-gray-700 dark:text-gray-300">#{{ invoice.serial_number ?? invoice.id }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
                                         <div class="flex items-center gap-x-2">
@@ -276,7 +279,7 @@ const methodLabel = (method) => methodLabels[method] ?? method;
                                             <svg class="h-4 w-4 text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': expandedSessionId === session.id }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
                                             </svg>
-                                            <span>{{ session.opened_at }}</span>
+                                            <span>{{ formatDateTimeShort(session.opened_at) }}</span>
                                         </div>
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ session.cashier_name ?? __('Unknown') }}</td>

--- a/resources/js/Pages/Pos/Invoices.vue
+++ b/resources/js/Pages/Pos/Invoices.vue
@@ -56,6 +56,24 @@ const variancePrefix = (variance) => {
     if (variance > 0) return `+${fmt(variance)}`;
     return fmt(variance);
 };
+
+// Session detail expansion — reveals per-method and per-account breakdowns.
+const expandedSessionId = ref(null);
+
+const toggleSession = (id) => {
+    expandedSessionId.value = expandedSessionId.value === id ? null : id;
+};
+
+const methodLabels = {
+    cash: __('Cash'),
+    bank_transfer: __('Bank Transfer'),
+    credit: __('Credit'),
+    cheque: __('Cheque'),
+    mixed: __('Mixed'),
+    advance: __('Advance'),
+};
+
+const methodLabel = (method) => methodLabels[method] ?? method;
 </script>
 
 <template>
@@ -251,8 +269,16 @@ const variancePrefix = (variance) => {
                                 </tr>
                             </thead>
                             <tbody class="divide-y divide-gray-200/60 dark:divide-gray-700/60 bg-white dark:bg-gray-900">
-                                <tr v-for="session in sessions.data" :key="session.id" class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200">
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ session.opened_at }}</td>
+                                <template v-for="session in sessions.data" :key="session.id">
+                                <tr class="group hover:bg-gray-50 dark:hover:bg-gray-800 transition-all duration-200 cursor-pointer" @click="toggleSession(session.id)">
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
+                                        <div class="flex items-center gap-x-2">
+                                            <svg class="h-4 w-4 text-gray-400 transition-transform duration-200" :class="{ 'rotate-90': expandedSessionId === session.id }" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                            </svg>
+                                            <span>{{ session.opened_at }}</span>
+                                        </div>
+                                    </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ session.cashier_name ?? __('Unknown') }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ session.storage_name ?? '—' }}</td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{{ session.invoice_count }}</td>
@@ -276,6 +302,35 @@ const variancePrefix = (variance) => {
                                         </span>
                                     </td>
                                 </tr>
+                                <tr v-if="expandedSessionId === session.id" class="bg-gray-50/50 dark:bg-gray-800/40">
+                                    <td colspan="10" class="px-6 py-5">
+                                        <div class="grid gap-6 sm:grid-cols-2">
+                                            <!-- Sales by payment method -->
+                                            <div>
+                                                <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3">{{ __('Sales by payment method') }}</p>
+                                                <div v-if="session.sales_by_method?.length" class="space-y-2">
+                                                    <div v-for="row in session.sales_by_method" :key="row.method" class="flex items-center justify-between text-sm">
+                                                        <span class="text-gray-600 dark:text-gray-400">{{ methodLabel(row.method) }} <span class="text-xs text-gray-400 dark:text-gray-500">({{ row.count }})</span></span>
+                                                        <span class="font-semibold text-gray-700 dark:text-gray-300">{{ fmt(row.total) }}</span>
+                                                    </div>
+                                                </div>
+                                                <p v-else class="text-sm text-gray-400 dark:text-gray-500">{{ __('No sales yet.') }}</p>
+                                            </div>
+                                            <!-- Sales by account -->
+                                            <div>
+                                                <p class="text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-3">{{ __('Collected by account') }}</p>
+                                                <div v-if="session.sales_by_account?.length" class="space-y-2">
+                                                    <div v-for="row in session.sales_by_account" :key="row.account_name" class="flex items-center justify-between text-sm">
+                                                        <span class="text-gray-600 dark:text-gray-400">{{ row.account_name }} <span class="text-xs text-gray-400 dark:text-gray-500">({{ row.count }})</span></span>
+                                                        <span class="font-semibold text-gray-700 dark:text-gray-300">{{ fmt(row.total) }}</span>
+                                                    </div>
+                                                </div>
+                                                <p v-else class="text-sm text-gray-400 dark:text-gray-500">{{ __('No treasury movements recorded.') }}</p>
+                                            </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                                </template>
                             </tbody>
                         </table>
                     </div>

--- a/resources/js/Pages/Pos/Session.vue
+++ b/resources/js/Pages/Pos/Session.vue
@@ -33,6 +33,14 @@ const props = defineProps({
     },
     selectedStorageId: [Number, String],
     session_stats: Object,
+    bankAccounts: {
+        type: Array,
+        default: () => [],
+    },
+    defaultBankAccountId: {
+        type: [Number, null],
+        default: null,
+    },
     flash: Object,
 });
 
@@ -144,6 +152,7 @@ const checkoutForm = useForm({
     items: [],
     total: 0,
     payment_method: 'cash',
+    treasury_account_id: null,
     idempotency_key: '',
     acknowledge_transfers: false,
 });
@@ -154,11 +163,12 @@ const openCheckoutModal = () => {
     showingCheckoutModal.value = true;
 };
 
-const checkout = async ({ paymentMethod, change }) => {
+const checkout = async ({ paymentMethod, change, treasuryAccountId }) => {
     cartErrorMessage.value = '';
     checkoutForm.items = cart.value;
     checkoutForm.total = total.value;
     checkoutForm.payment_method = paymentMethod;
+    checkoutForm.treasury_account_id = treasuryAccountId ?? null;
 
     if (!checkoutForm.idempotency_key) {
         checkoutForm.idempotency_key = Date.now().toString();
@@ -389,7 +399,7 @@ const paymentMethodLabels = [
         <!-- Modals -->
         <QuickAddPartyModal :show="showingAddCustomerModal" type="customer" @close="showingAddCustomerModal = false" @created="onCustomerCreated" />
 
-        <PosCheckoutModal ref="checkoutModalRef" :show="showingCheckoutModal" :total="total" :discount-amount="discountAmount" :processing="checkoutForm.processing" :currency="currency" @close="showingCheckoutModal = false" @confirm="checkout" />
+        <PosCheckoutModal ref="checkoutModalRef" :show="showingCheckoutModal" :total="total" :discount-amount="discountAmount" :processing="checkoutForm.processing" :currency="currency" :bank-accounts="bankAccounts" :default-bank-account-id="defaultBankAccountId" @close="showingCheckoutModal = false" @confirm="checkout" />
 
         <PosSaleCompleteModal :show="showingSaleCompleteModal" :sale="completedSale" :currency="currency" :payment-methods="paymentMethodLabels" @new-sale="startNewSale" @print="printLastReceipt" />
 

--- a/resources/js/Pages/Preferences/Partials/UpdatePosSettingsForm.vue
+++ b/resources/js/Pages/Preferences/Partials/UpdatePosSettingsForm.vue
@@ -1,0 +1,119 @@
+<script setup>
+    import { inject } from "vue";
+    import CustomSelect from "@/Components/CustomSelect.vue";
+    import InputError from "@/Components/InputError.vue";
+    import InputLabel from "@/Components/InputLabel.vue";
+    import SettingsSection from "@/Components/SettingsSection.vue";
+
+    defineProps({
+        cashAccounts: { type: Array, default: () => [] },
+        bankAccounts: { type: Array, default: () => [] },
+        salePoints: { type: Array, default: () => [] },
+    });
+
+    // Form is owned by the page (Show.vue) so Save can live in the sticky header.
+    const form = inject("settingsForm");
+</script>
+
+<template>
+    <SettingsSection
+        id="pos"
+        :title="__('Point of Sale')"
+        :description="__('Defaults applied at the register — where money lands and which sale point is used.')"
+    >
+        <div class="space-y-6">
+            <!-- Default cash account -->
+            <div>
+                <div class="flex items-center justify-between">
+                    <InputLabel :value="__('Default cash account')" />
+                    <button
+                        v-if="form.pos_default_cash_account_id"
+                        type="button"
+                        class="text-xs text-secondary hover:text-primary"
+                        @click="form.pos_default_cash_account_id = null"
+                    >
+                        {{ __('Clear') }}
+                    </button>
+                </div>
+                <p class="mt-1 text-xs text-secondary">
+                    {{ __('Cash sales with no sale-point drawer fall back to this account.') }}
+                </p>
+                <div class="mt-2 sm:max-w-md">
+                    <CustomSelect
+                        v-model="form.pos_default_cash_account_id"
+                        :options="cashAccounts"
+                        label="name"
+                        track-by="id"
+                        :placeholder="__('Select an account')"
+                    />
+                </div>
+                <InputError
+                    :message="form.errors.pos_default_cash_account_id"
+                    class="mt-2"
+                />
+            </div>
+
+            <!-- Default bank account -->
+            <div>
+                <div class="flex items-center justify-between">
+                    <InputLabel :value="__('Default bank account')" />
+                    <button
+                        v-if="form.pos_default_bank_account_id"
+                        type="button"
+                        class="text-xs text-secondary hover:text-primary"
+                        @click="form.pos_default_bank_account_id = null"
+                    >
+                        {{ __('Clear') }}
+                    </button>
+                </div>
+                <p class="mt-1 text-xs text-secondary">
+                    {{ __('Bank-transfer sales are recorded against this account when none is picked at checkout.') }}
+                </p>
+                <div class="mt-2 sm:max-w-md">
+                    <CustomSelect
+                        v-model="form.pos_default_bank_account_id"
+                        :options="bankAccounts"
+                        label="name"
+                        track-by="id"
+                        :placeholder="__('Select an account')"
+                    />
+                </div>
+                <InputError
+                    :message="form.errors.pos_default_bank_account_id"
+                    class="mt-2"
+                />
+            </div>
+
+            <!-- Default sale point -->
+            <div>
+                <div class="flex items-center justify-between">
+                    <InputLabel :value="__('Default sale point')" />
+                    <button
+                        v-if="form.pos_default_sale_point_id"
+                        type="button"
+                        class="text-xs text-secondary hover:text-primary"
+                        @click="form.pos_default_sale_point_id = null"
+                    >
+                        {{ __('Clear') }}
+                    </button>
+                </div>
+                <p class="mt-1 text-xs text-secondary">
+                    {{ __('The sale point pre-selected when opening a POS session.') }}
+                </p>
+                <div class="mt-2 sm:max-w-md">
+                    <CustomSelect
+                        v-model="form.pos_default_sale_point_id"
+                        :options="salePoints"
+                        label="name"
+                        track-by="id"
+                        :placeholder="__('Select a sale point')"
+                    />
+                </div>
+                <InputError
+                    :message="form.errors.pos_default_sale_point_id"
+                    class="mt-2"
+                />
+            </div>
+        </div>
+    </SettingsSection>
+</template>

--- a/resources/js/Pages/Preferences/Show.vue
+++ b/resources/js/Pages/Preferences/Show.vue
@@ -4,10 +4,22 @@
     import AppLayout from "@/Layouts/AppLayout.vue";
     import SettingsLayout from "@/Layouts/SettingsLayout.vue";
     import UpdateApplicationInformationForm from "@/Pages/Preferences/Partials/UpdateApplicationInformationForm.vue";
+    import UpdatePosSettingsForm from "@/Pages/Preferences/Partials/UpdatePosSettingsForm.vue";
     import ActionMessage from "@/Components/ActionMessage.vue";
     import PrimaryButton from "@/Components/PrimaryButton.vue";
 
+    const props = defineProps({
+        cash_accounts: { type: Array, default: () => [] },
+        bank_accounts: { type: Array, default: () => [] },
+        sale_points: { type: Array, default: () => [] },
+    });
+
     const truthy = (value) => [true, 1, "1", "true"].includes(value);
+
+    // POS default selects store an id (or null). Coerce the stored string
+    // preference back to a number so the select matches its option, and keep an
+    // empty preference as null so "no default" round-trips cleanly.
+    const asId = (value) => (value === null || value === "" || value === undefined ? null : Number(value));
 
     // Provided to the fields partial so it can bind to the shared form without
     // mutating a prop (the page keeps ownership for the header Save + dirty state).
@@ -27,6 +39,9 @@
         pecentage: preferences("pecentage", 60),
         inventory_strategy: preferences("inventory_strategy", "purchase_driven"),
         allow_overselling: truthy(preferences("allow_overselling", false)),
+        pos_default_cash_account_id: asId(preferences("pos_default_cash_account_id")),
+        pos_default_bank_account_id: asId(preferences("pos_default_bank_account_id")),
+        pos_default_sale_point_id: asId(preferences("pos_default_sale_point_id")),
     });
 
     provide("settingsForm", form);
@@ -50,6 +65,7 @@
         { id: "identity", label: __("Identity") },
         { id: "pricing", label: __("Pricing & currency") },
         { id: "inventory", label: __("Inventory policy") },
+        { id: "pos", label: __("Point of Sale") },
         { id: "notifications", label: __("Notifications") },
     ];
 </script>
@@ -107,6 +123,11 @@
 
                 <!-- Fields read the shared form via inject("settingsForm"). -->
                 <UpdateApplicationInformationForm />
+                <UpdatePosSettingsForm
+                    :cash-accounts="props.cash_accounts"
+                    :bank-accounts="props.bank_accounts"
+                    :sale-points="props.sale_points"
+                />
             </SettingsLayout>
         </form>
     </AppLayout>

--- a/tests/Feature/ExpenseTrackingTest.php
+++ b/tests/Feature/ExpenseTrackingTest.php
@@ -3,12 +3,31 @@
 use App\Enums\ExpenseStatus;
 use App\Models\Category;
 use App\Models\Expense;
+use App\Models\TreasuryAccount;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
+
+test('an expense hits the treasury via the default cash account when none is chosen', function () {
+    $user = User::factory()->create();
+    $cash = TreasuryAccount::factory()->cash()->create(); // shared default cash
+
+    $this->actingAs($user)
+        ->post(route('expenses.store'), [
+            'title' => 'Cleaning',
+            'amount' => 300,
+            'expensed_at' => now()->format('Y-m-d'),
+        ])->assertRedirect(route('expenses.index'));
+
+    $expense = Expense::first();
+    expect($expense->treasury_account_id)->toBe($cash->id)
+        ->and($expense->treasuryMovements)->toHaveCount(1)
+        ->and((int) $expense->treasuryMovements->first()->amount)->toBe(-30000);
+    expect((int) $cash->fresh()->currentBalance())->toBe(-30000);
+});
 
 test('user can record an expense', function () {
     $user = User::factory()->create();

--- a/tests/Feature/ExpenseTreasuryBackfillTest.php
+++ b/tests/Feature/ExpenseTreasuryBackfillTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\Expense;
+use App\Models\Tenant;
+use App\Models\TreasuryAccount;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->tenant = Tenant::factory()->create();
+    app()->instance('currentTenant', $this->tenant);
+
+    $this->user = User::factory()->create(['current_tenant_id' => $this->tenant->id]);
+    $this->tenant->users()->attach($this->user, ['role' => 'owner', 'is_active' => true]);
+
+    $this->cash = TreasuryAccount::factory()->cash()->create(['tenant_id' => $this->tenant->id]);
+
+    // Corrupted historical state: an expense with no treasury account or movement.
+    $this->expense = Expense::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'created_by' => $this->user->id,
+        'amount' => 500,
+        'treasury_account_id' => null,
+        'expensed_at' => now(),
+    ]);
+});
+
+function runExpenseBackfill(): void
+{
+    (require database_path('migrations/2026_07_21_011625_backfill_expense_treasury_movements.php'))->up();
+}
+
+test('it backfills the missing negative movement to the default cash account', function () {
+    expect($this->expense->treasuryMovements()->count())->toBe(0);
+
+    runExpenseBackfill();
+
+    $this->expense->refresh();
+    expect($this->expense->treasury_account_id)->toBe($this->cash->id)
+        ->and($this->expense->treasuryMovements()->count())->toBe(1);
+    expect((int) $this->cash->fresh()->currentBalance())->toBe(-50000);
+});
+
+test('the expense backfill is idempotent', function () {
+    runExpenseBackfill();
+    runExpenseBackfill();
+
+    expect($this->expense->treasuryMovements()->count())->toBe(1);
+    expect((int) $this->cash->fresh()->currentBalance())->toBe(-50000);
+});

--- a/tests/Feature/PosBankTransferBackfillTest.php
+++ b/tests/Feature/PosBankTransferBackfillTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Enums\PaymentDirection;
+use App\Enums\PaymentMethod;
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PosSession;
+use App\Models\Preference;
+use App\Models\Storage;
+use App\Models\Tenant;
+use App\Models\TreasuryAccount;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->tenant = Tenant::factory()->create();
+    app()->instance('currentTenant', $this->tenant);
+
+    $this->user = User::factory()->create(['current_tenant_id' => $this->tenant->id]);
+    $this->tenant->users()->attach($this->user, ['role' => 'owner', 'is_active' => true]);
+
+    $this->bank = TreasuryAccount::factory()->bank()->create(['tenant_id' => $this->tenant->id]);
+    Preference::create(['tenant_id' => $this->tenant->id, 'key' => 'pos_default_bank_account_id', 'value' => $this->bank->id]);
+
+    $storage = Storage::factory()->create(['tenant_id' => $this->tenant->id]);
+    $session = PosSession::factory()->create(['tenant_id' => $this->tenant->id, 'storage_id' => $storage->id, 'opened_by' => $this->user->id]);
+    $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+
+    // Corrupted historical state: a POS bank-transfer payment with no movement.
+    $invoice = Invoice::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'pos_session_id' => $session->id,
+        'invocable_id' => $customer->id,
+        'invocable_type' => Customer::class,
+        'payment_method' => PaymentMethod::BankTransfer,
+        'total' => 2000,
+    ]);
+
+    $this->payment = Payment::create([
+        'tenant_id' => $this->tenant->id,
+        'invoice_id' => $invoice->id,
+        'amount' => 2000,
+        'payment_method' => PaymentMethod::BankTransfer,
+        'direction' => PaymentDirection::In,
+        'paid_at' => now(),
+        'created_by' => $this->user->id,
+    ]);
+});
+
+function runBackfill(): void
+{
+    (require database_path('migrations/2026_07_21_011010_backfill_pos_bank_transfer_treasury_movements.php'))->up();
+}
+
+test('it backfills the missing treasury movement to the default bank account', function () {
+    expect($this->payment->treasuryMovements()->count())->toBe(0);
+
+    runBackfill();
+
+    $this->payment->refresh();
+    expect($this->payment->treasury_account_id)->toBe($this->bank->id)
+        ->and($this->payment->treasuryMovements()->count())->toBe(1);
+    expect((int) $this->bank->fresh()->currentBalance())->toBe(200000);
+});
+
+test('the backfill is idempotent', function () {
+    runBackfill();
+    runBackfill();
+
+    expect($this->payment->treasuryMovements()->count())->toBe(1);
+    expect((int) $this->bank->fresh()->currentBalance())->toBe(200000);
+});

--- a/tests/Feature/PosCheckoutTest.php
+++ b/tests/Feature/PosCheckoutTest.php
@@ -116,7 +116,7 @@ test('it can checkout as a walk-in customer (null customer_id)', function () {
     $invoice = app(ProcessPosCheckoutAction::class)->handle($this->session, $data, $this->cashier);
 
     expect($invoice->invocable_id)->not->toBeNull();
-    expect($invoice->invocable->name)->toBe('Walk-in Customer');
+    expect($invoice->invocable->name)->toBe(__('Walk-in Customer'));
     expect($invoice->invocable->is_system)->toBeTrue();
     expect($this->storage->fresh()->quantityOf($this->product))->toBe(99);
 });
@@ -199,6 +199,27 @@ test('cash checkout still records payment and treasury movement', function () {
         ->and($invoice->payments->first()->direction->value)->toBe('in');
 });
 
+test('walk-in checkout reuses the seeded system customer regardless of its name', function () {
+    // Simulates an Arabic tenant whose seeded walk-in is not the English literal.
+    $seeded = Customer::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'name' => 'عميل عابر',
+        'is_system' => true,
+    ]);
+
+    $data = collect([
+        'customer_id' => null,
+        'total' => 1000,
+        'payment_method' => 'cash',
+        'items' => [['product_id' => $this->product->id, 'quantity' => 1, 'price' => 1000]],
+    ]);
+
+    $invoice = app(ProcessPosCheckoutAction::class)->handle($this->session, $data, $this->cashier);
+
+    expect($invoice->invocable_id)->toBe($seeded->id);
+    expect(Customer::where('is_system', true)->count())->toBe(1);
+});
+
 test('bank transfer checkout records a treasury movement to the chosen account', function () {
     $this->actingAs($this->cashier);
     $bank = TreasuryAccount::factory()->bank()->create(['tenant_id' => $this->tenant->id]);
@@ -268,7 +289,7 @@ test('it can checkout as a walk-in customer via controller', function () {
     $response->assertRedirect(route('pos.index'));
 
     $invoice = Invoice::latest()->first();
-    expect($invoice->invocable->name)->toBe('Walk-in Customer');
+    expect($invoice->invocable->name)->toBe(__('Walk-in Customer'));
     expect($invoice->invocable->is_system)->toBeTrue();
 });
 

--- a/tests/Feature/PosCheckoutTest.php
+++ b/tests/Feature/PosCheckoutTest.php
@@ -5,10 +5,12 @@ use App\Actions\Pos\ProcessPosCheckoutAction;
 use App\Exceptions\InsufficientStockException;
 use App\Models\Customer;
 use App\Models\Invoice;
+use App\Models\Preference;
 use App\Models\Product;
 use App\Models\Role;
 use App\Models\Storage;
 use App\Models\Tenant;
+use App\Models\TreasuryAccount;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -195,6 +197,59 @@ test('cash checkout still records payment and treasury movement', function () {
         ->and((int) $invoice->paid_amount)->toBe(2000)
         ->and($invoice->payments)->toHaveCount(1)
         ->and($invoice->payments->first()->direction->value)->toBe('in');
+});
+
+test('bank transfer checkout records a treasury movement to the chosen account', function () {
+    $this->actingAs($this->cashier);
+    $bank = TreasuryAccount::factory()->bank()->create(['tenant_id' => $this->tenant->id]);
+
+    $data = collect([
+        'customer_id' => $this->customer->id,
+        'total' => 2000,
+        'payment_method' => 'bank_transfer',
+        'treasury_account_id' => $bank->id,
+        'items' => [['product_id' => $this->product->id, 'quantity' => 2, 'price' => 1000]],
+    ]);
+
+    $invoice = app(ProcessPosCheckoutAction::class)->handle($this->session, $data, $this->cashier);
+
+    $payment = $invoice->payments->first();
+    expect($payment->treasury_account_id)->toBe($bank->id)
+        ->and($payment->treasuryMovements)->toHaveCount(1);
+    expect((int) $bank->fresh()->currentBalance())->toBe(200000);
+});
+
+test('bank transfer checkout falls back to the configured POS default account', function () {
+    $this->actingAs($this->cashier);
+    $bank = TreasuryAccount::factory()->bank()->create(['tenant_id' => $this->tenant->id]);
+    Preference::create(['tenant_id' => $this->tenant->id, 'key' => 'pos_default_bank_account_id', 'value' => $bank->id]);
+
+    $data = collect([
+        'customer_id' => $this->customer->id,
+        'total' => 1500,
+        'payment_method' => 'bank_transfer',
+        'items' => [['product_id' => $this->product->id, 'quantity' => 1, 'price' => 1500]],
+    ]);
+
+    $invoice = app(ProcessPosCheckoutAction::class)->handle($this->session, $data, $this->cashier);
+
+    expect($invoice->payments->first()->treasury_account_id)->toBe($bank->id)
+        ->and($invoice->payments->first()->treasuryMovements)->toHaveCount(1);
+});
+
+test('bank transfer checkout is blocked when no account resolves', function () {
+    $data = collect([
+        'customer_id' => $this->customer->id,
+        'total' => 1000,
+        'payment_method' => 'bank_transfer',
+        'items' => [['product_id' => $this->product->id, 'quantity' => 1, 'price' => 1000]],
+    ]);
+
+    expect(fn () => app(ProcessPosCheckoutAction::class)->handle($this->session, $data, $this->cashier))
+        ->toThrow(DomainException::class);
+
+    // Sale rolled back — stock untouched.
+    expect($this->storage->fresh()->quantityOf($this->product))->toBe(100);
 });
 
 test('it can checkout as a walk-in customer via controller', function () {

--- a/tests/Feature/PosInvoicesPageTest.php
+++ b/tests/Feature/PosInvoicesPageTest.php
@@ -61,6 +61,9 @@ it('shows only pos invoices on the pos invoices page', function () {
     $response->assertInertia(fn (Assert $page) => $page
         ->component('Pos/Invoices')
         ->where('invoices.data.0.id', $posInvoice->id)
+        // Raw timestamps must reach the client, which formats them for display.
+        ->has('invoices.data.0.created_at')
+        ->has('sessions.data.0.opened_at')
         ->where('summary.total_sales', 1)
         ->where('summary.walk_in_sales', 1)
     );

--- a/tests/Feature/PosInvoicesPageTest.php
+++ b/tests/Feature/PosInvoicesPageTest.php
@@ -105,8 +105,10 @@ it('flags walk-in customer as system during pos checkout', function () {
 
     $response->assertRedirect(route('pos.index'));
 
-    $walkIn = Customer::query()->where('name', 'Walk-in Customer')->first();
+    // Identify the walk-in by its system flag; the name is localized.
+    $walkIn = Customer::query()->where('is_system', true)->first();
 
     expect($walkIn)->not->toBeNull();
-    expect($walkIn->is_system)->toBeTrue();
+    expect($walkIn->is_system)->toBeTrue()
+        ->and($walkIn->name)->toBe(__('Walk-in Customer'));
 });

--- a/tests/Feature/PosSessionBreakdownTest.php
+++ b/tests/Feature/PosSessionBreakdownTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Actions\Pos\OpenPosSessionAction;
+use App\Actions\Pos\ProcessPosCheckoutAction;
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\Storage;
+use App\Models\Tenant;
+use App\Models\TreasuryAccount;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->tenant = Tenant::factory()->create();
+    app()->instance('currentTenant', $this->tenant);
+
+    $this->cashier = User::factory()->create(['current_tenant_id' => $this->tenant->id]);
+    $this->tenant->users()->attach($this->cashier, ['role' => 'owner', 'is_active' => true]);
+    $this->actingAs($this->cashier);
+
+    $this->storage = Storage::factory()->create(['tenant_id' => $this->tenant->id]);
+    $this->product = Product::factory()->create(['tenant_id' => $this->tenant->id]);
+    $this->storage->addStock($this->product, 100, 'initial_stock', actor: $this->cashier);
+    $this->customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+
+    $this->cash = TreasuryAccount::factory()->cash()->create(['tenant_id' => $this->tenant->id, 'name' => 'Cash Box']);
+    $this->bank = TreasuryAccount::factory()->bank()->create(['tenant_id' => $this->tenant->id, 'name' => 'Main Bank']);
+
+    $this->session = app(OpenPosSessionAction::class)->handle($this->storage, 0, $this->cashier);
+
+    $checkout = app(ProcessPosCheckoutAction::class);
+    $checkout->handle($this->session, collect([
+        'customer_id' => $this->customer->id,
+        'total' => 2000,
+        'payment_method' => 'cash',
+        'items' => [['product_id' => $this->product->id, 'quantity' => 1, 'price' => 2000]],
+    ]), $this->cashier);
+    $checkout->handle($this->session, collect([
+        'customer_id' => $this->customer->id,
+        'total' => 3000,
+        'payment_method' => 'bank_transfer',
+        'treasury_account_id' => $this->bank->id,
+        'items' => [['product_id' => $this->product->id, 'quantity' => 1, 'price' => 3000]],
+    ]), $this->cashier);
+});
+
+test('it breaks down session sales by payment method', function () {
+    $byMethod = $this->session->salesByPaymentMethod()->keyBy('method');
+
+    expect((int) $byMethod['cash']['total'])->toBe(2000)
+        ->and((int) $byMethod['bank_transfer']['total'])->toBe(3000)
+        ->and($byMethod['cash']['count'])->toBe(1);
+});
+
+test('it breaks down session sales by treasury account', function () {
+    $byAccount = $this->session->salesByTreasuryAccount()->keyBy('account_name');
+
+    expect((int) $byAccount['Cash Box']['total'])->toBe(2000)
+        ->and((int) $byAccount['Main Bank']['total'])->toBe(3000);
+});

--- a/tests/Feature/PosWalkInDedupeTest.php
+++ b/tests/Feature/PosWalkInDedupeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->tenant = Tenant::factory()->create();
+    app()->instance('currentTenant', $this->tenant);
+
+    // Two system walk-ins — the seeded (localized) one and a checkout-created duplicate.
+    $this->canonical = Customer::factory()->create(['tenant_id' => $this->tenant->id, 'name' => 'عميل عابر', 'is_system' => true]);
+    $this->duplicate = Customer::factory()->create(['tenant_id' => $this->tenant->id, 'name' => 'Walk-in Customer', 'is_system' => true]);
+
+    $this->invoice = Invoice::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'invocable_id' => $this->duplicate->id,
+        'invocable_type' => Customer::class,
+    ]);
+});
+
+function runWalkInDedupe(): void
+{
+    (require database_path('migrations/2026_07_21_012358_dedupe_walk_in_customers.php'))->up();
+}
+
+test('it merges duplicate walk-in customers and reassigns their invoices', function () {
+    runWalkInDedupe();
+
+    expect(Customer::where('is_system', true)->count())->toBe(1)
+        ->and(Customer::where('is_system', true)->first()->id)->toBe($this->canonical->id)
+        ->and($this->invoice->fresh()->invocable_id)->toBe($this->canonical->id);
+});
+
+test('it leaves a single walk-in untouched and is idempotent', function () {
+    runWalkInDedupe();
+    runWalkInDedupe();
+
+    expect(Customer::where('is_system', true)->count())->toBe(1)
+        ->and($this->invoice->fresh()->invocable_id)->toBe($this->canonical->id);
+});

--- a/tests/Feature/PreferenceControllerTest.php
+++ b/tests/Feature/PreferenceControllerTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Enums\StorageType;
 use App\Models\Preference;
+use App\Models\Storage;
 use App\Models\Tenant;
+use App\Models\TreasuryAccount;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\URL;
@@ -65,6 +68,53 @@ test('preferences cache and locale are isolated per tenant', function () {
     $this->actingAs($userTwo)
         ->get('http://tenant-two.'.config('app.domain').'/dashboard')
         ->assertInertia(fn ($page) => $page->where('locale', 'en'));
+});
+
+test('the settings page exposes treasury accounts and sale points for the POS section', function () {
+    $cash = TreasuryAccount::factory()->cash()->create(['name' => 'Front Drawer']);
+    $bank = TreasuryAccount::factory()->bank()->create(['name' => 'Main Bank']);
+    $salePoint = Storage::factory()->create(['type' => StorageType::SALE_POINT]);
+
+    $this->get(route('preferences.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('Preferences/Show')
+            ->where('cash_accounts.0.id', $cash->id)
+            ->where('bank_accounts.0.id', $bank->id)
+            ->where('sale_points.0.id', $salePoint->id)
+        );
+});
+
+test('it updates POS default account preferences', function () {
+    $bank = TreasuryAccount::factory()->bank()->create();
+    $salePoint = Storage::factory()->create(['type' => StorageType::SALE_POINT]);
+
+    $this->post(route('preferences.update'), [
+        'pos_default_bank_account_id' => $bank->id,
+        'pos_default_sale_point_id' => $salePoint->id,
+    ])->assertRedirect();
+
+    $this->assertDatabaseHas('preferences', ['key' => 'pos_default_bank_account_id', 'value' => $bank->id]);
+    $this->assertDatabaseHas('preferences', ['key' => 'pos_default_sale_point_id', 'value' => $salePoint->id]);
+});
+
+test('it rejects a bank preference pointing at a non-bank account', function () {
+    $cash = TreasuryAccount::factory()->cash()->create();
+
+    $this->post(route('preferences.update'), [
+        'pos_default_bank_account_id' => $cash->id,
+    ])->assertSessionHasErrors('pos_default_bank_account_id');
+
+    $this->assertDatabaseMissing('preferences', ['key' => 'pos_default_bank_account_id']);
+});
+
+test('it rejects a POS account preference from another tenant', function () {
+    $otherTenant = Tenant::create(['name' => 'Other', 'slug' => 'other', 'is_active' => true]);
+    $foreignBank = TreasuryAccount::factory()->bank()->create(['tenant_id' => $otherTenant->id]);
+
+    $this->post(route('preferences.update'), [
+        'pos_default_bank_account_id' => $foreignBank->id,
+    ])->assertSessionHasErrors('pos_default_bank_account_id');
 });
 
 test('the settings page exposes the logo as a url, not the raw disk path', function () {


### PR DESCRIPTION
Fixes a cluster of POS + treasury correctness and UX bugs. One commit per issue.

## Commits
1. **feat(pos): global POS settings** — new *Point of Sale* section in Organization Settings (default cash account, default bank account, default sale point). Backed by the existing key/value `preferences`; foundation for the money fixes below.
2. **fix(pos): bank-transfer treasury movement** — bank-transfer sales wrote a `Payment` but no `TreasuryMovement`, so treasury balances under-reported bank revenue. Checkout now resolves a bank account (picked at checkout or the configured POS default) for every collected non-cash method and blocks the sale when none resolves. Includes a **backfill migration** for historical data. Cash keeps its lenient `defaultCash()` fallback.
3. **fix(expenses): treasury movement** — expenses with no chosen account produced no movement. They now fall back to the tenant's default cash account and hit the ledger; create form preselects it. Includes a **backfill migration**.
4. **feat(pos): session breakdown** — session rows are expandable, showing sales per payment method and amounts collected per treasury account.
5. **fix(pos): readable timestamps** — invoice/session times rendered as raw UTC ISO strings; now shown as a compact `2 Jun 12:00 PM` via a locale/timezone-aware `useDate().formatDateTimeShort`.
6. **fix(pos): walk-in customer by is_system** — checkout matched the walk-in on the literal `"Walk-in Customer"` string while the seeder stores a localized name, forking a duplicate on Arabic tenants. Now matched on the stable `is_system` flag; **dedup migration** merges existing duplicates.

## Testing
- 79 tests / 413 assertions green across the affected POS, expenses, treasury, and preferences suites.
- New tests: POS settings validation, bank-transfer movement + backfill, expense movement + backfill, session breakdowns, walk-in reuse + dedup.
- Pint clean on all changed PHP files.

## Notes for review
- **Money-unit inconsistency (pre-existing, out of scope):** `invoices.total` and `payments.amount` are on different scales — the POS passes a `total` that `RecordPaymentAction` treats as major units (stored 100× larger). The session breakdown works *with* this by summing `invoices.total` so figures reconcile, but the underlying total/payment-amount mismatch deserves its own PR.
- **Three existing tests were updated (not deleted)** to identify the walk-in by `is_system` and expect the localized name — the test locale is `ar`, so the old English-literal assertions were asserting the buggy behavior.
- **Backfill migrations** are idempotent (covered by tests) but mutate money data across tenants — worth a real run + re-run against a staging copy before shipping.
