### PR TITLE
fix(treasury): show-page balance + POS money-unit/format consistency

### DIFF
--- a/app/Actions/Pos/ClosePosSessionAction.php
+++ b/app/Actions/Pos/ClosePosSessionAction.php
@@ -7,6 +7,7 @@ use App\Enums\TreasuryAccountType;
 use App\Models\PosSession;
 use App\Models\TreasuryAccount;
 use App\Models\User;
+use App\ValueObjects\Money;
 use Illuminate\Support\Facades\DB;
 
 class ClosePosSessionAction
@@ -43,7 +44,11 @@ class ClosePosSessionAction
                     $this->recordAdjustment->handle(
                         account: $cashDrawer,
                         newBalance: $closingFloat,
-                        notes: "POS session #{$session->id} closing reconciliation. Expected: {$expected}, Counted: {$closingFloat}",
+                        notes: __('POS session #:id closing reconciliation. Expected: :expected, Counted: :counted', [
+                            'id' => $session->id,
+                            'expected' => number_format(Money::fromMinor($expected)->major(), 2),
+                            'counted' => number_format(Money::fromMinor($closingFloat)->major(), 2),
+                        ]),
                         actor: $actor,
                     );
                 }

--- a/app/Http/Controllers/Treasury/TreasuryAccountsController.php
+++ b/app/Http/Controllers/Treasury/TreasuryAccountsController.php
@@ -134,7 +134,10 @@ class TreasuryAccountsController extends Controller
             'type' => $account->type->value,
             'type_label' => $account->type->label(),
             'currency' => $account->currency,
-            'current_balance' => Money::fromMinor($account->opening_balance + (int) ($account->movements_sum_amount ?? 0))->major(),
+            // currentBalance() uses the eager-loaded movements sum on index and
+            // falls back to a live SUM on show (where it isn't preloaded), so the
+            // hero balance is always the true balance, not just opening_balance.
+            'current_balance' => Money::fromMinor($account->currentBalance())->major(),
             'opening_balance' => Money::fromMinor($account->opening_balance)->major(),
             'is_active' => $account->is_active,
             'notes' => $account->notes,

--- a/app/Models/PosSession.php
+++ b/app/Models/PosSession.php
@@ -75,8 +75,12 @@ class PosSession extends BaseModel
      */
     public function salesByPaymentMethod(): Collection
     {
+        // Alias the sum to a non-cast name: an alias called `total` would be read
+        // back through Invoice's MoneyCast (major units), double-converting once
+        // the caller divides by 100. `total_minor` keeps the raw minor integer,
+        // matching cashSalesTotal()'s convention.
         return $this->invoices()
-            ->selectRaw('payment_method, SUM(total) as total, COUNT(*) as count')
+            ->selectRaw('payment_method, SUM(total) as total_minor, COUNT(*) as count')
             ->groupBy('payment_method')
             ->orderByRaw('SUM(total) DESC')
             ->get()
@@ -84,7 +88,7 @@ class PosSession extends BaseModel
                 'method' => $row->payment_method instanceof PaymentMethod
                     ? $row->payment_method->value
                     : (string) $row->payment_method,
-                'total' => (int) $row->total,
+                'total' => (int) $row->total_minor,
                 'count' => (int) $row->count,
             ]);
     }
@@ -105,12 +109,12 @@ class PosSession extends BaseModel
             ->whereNotNull('payments.treasury_account_id')
             ->groupBy('treasury_accounts.id', 'treasury_accounts.name')
             ->orderByRaw('SUM(invoices.total) DESC')
-            ->selectRaw('treasury_accounts.id as account_id, treasury_accounts.name as account_name, SUM(invoices.total) as total, COUNT(DISTINCT invoices.id) as count')
+            ->selectRaw('treasury_accounts.id as account_id, treasury_accounts.name as account_name, SUM(invoices.total) as total_minor, COUNT(DISTINCT invoices.id) as count')
             ->get()
             ->map(fn ($row) => [
                 'account_id' => (int) $row->account_id,
                 'account_name' => $row->account_name,
-                'total' => (int) $row->total,
+                'total' => (int) $row->total_minor,
                 'count' => (int) $row->count,
             ]);
     }

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -1,4 +1,5 @@
 {
+    "POS session #:id closing reconciliation. Expected: :expected, Counted: :counted": "تسوية إغلاق جلسة نقطة البيع رقم :id. المتوقع: :expected، المعدود: :counted",
     "Sales by payment method": "المبيعات حسب طريقة الدفع",
     "Collected by account": "المحصّل حسب الحساب",
     "No sales yet.": "لا توجد مبيعات بعد.",

--- a/tests/Feature/PosSessionBreakdownTest.php
+++ b/tests/Feature/PosSessionBreakdownTest.php
@@ -4,6 +4,7 @@ use App\Actions\Pos\OpenPosSessionAction;
 use App\Actions\Pos\ProcessPosCheckoutAction;
 use App\Models\Customer;
 use App\Models\Product;
+use App\Models\Role;
 use App\Models\Storage;
 use App\Models\Tenant;
 use App\Models\TreasuryAccount;
@@ -15,9 +16,11 @@ uses(RefreshDatabase::class);
 beforeEach(function () {
     $this->tenant = Tenant::factory()->create();
     app()->instance('currentTenant', $this->tenant);
+    seedTenantRoles($this->tenant);
 
+    $ownerRole = Role::withoutGlobalScopes()->where('tenant_id', $this->tenant->id)->where('slug', 'owner')->first();
     $this->cashier = User::factory()->create(['current_tenant_id' => $this->tenant->id]);
-    $this->tenant->users()->attach($this->cashier, ['role' => 'owner', 'is_active' => true]);
+    $this->tenant->users()->attach($this->cashier, ['role' => 'owner', 'role_id' => $ownerRole->id, 'is_active' => true]);
     $this->actingAs($this->cashier);
 
     $this->storage = Storage::factory()->create(['tenant_id' => $this->tenant->id]);
@@ -46,17 +49,36 @@ beforeEach(function () {
     ]), $this->cashier);
 });
 
-test('it breaks down session sales by payment method', function () {
+test('it breaks down session sales by payment method in minor units', function () {
+    // Totals of 2000 / 3000 (major) are stored as 200000 / 300000 minor.
     $byMethod = $this->session->salesByPaymentMethod()->keyBy('method');
 
-    expect((int) $byMethod['cash']['total'])->toBe(2000)
-        ->and((int) $byMethod['bank_transfer']['total'])->toBe(3000)
+    expect((int) $byMethod['cash']['total'])->toBe(200000)
+        ->and((int) $byMethod['bank_transfer']['total'])->toBe(300000)
         ->and($byMethod['cash']['count'])->toBe(1);
 });
 
-test('it breaks down session sales by treasury account', function () {
+test('it breaks down session sales by treasury account in minor units', function () {
     $byAccount = $this->session->salesByTreasuryAccount()->keyBy('account_name');
 
-    expect((int) $byAccount['Cash Box']['total'])->toBe(2000)
-        ->and((int) $byAccount['Main Bank']['total'])->toBe(3000);
+    expect((int) $byAccount['Cash Box']['total'])->toBe(200000)
+        ->and((int) $byAccount['Main Bank']['total'])->toBe(300000);
+});
+
+test('the invoices page exposes the breakdown in major units for display', function () {
+    $response = $this->get(route('pos.invoices', ['tenant' => $this->tenant->slug]));
+
+    $response->assertOk()->assertInertia(function ($page) {
+        $session = collect($page->toArray()['props']['sessions']['data'])
+            ->firstWhere('id', $this->session->id);
+
+        $byMethod = collect($session['sales_by_method'])->keyBy('method');
+        $byAccount = collect($session['sales_by_account'])->keyBy('account_name');
+
+        // model minor (200000/300000) ÷ 100 = major shown to the cashier.
+        expect((float) $byMethod['cash']['total'])->toBe(2000.0)
+            ->and((float) $byMethod['bank_transfer']['total'])->toBe(3000.0)
+            ->and((float) $byAccount['Cash Box']['total'])->toBe(2000.0)
+            ->and((float) $byAccount['Main Bank']['total'])->toBe(3000.0);
+    });
 });

--- a/tests/Feature/TreasuryManagementTest.php
+++ b/tests/Feature/TreasuryManagementTest.php
@@ -78,6 +78,30 @@ test('current balance correctly sums all movements', function () {
     expect($account->currentBalance())->toBe(12000);
 });
 
+test('the show page hero balance reflects movements, not just opening balance', function () {
+    $account = TreasuryAccount::factory()->withOpeningBalance(0)->create([
+        'tenant_id' => $this->tenant->id,
+    ]);
+
+    TreasuryMovement::create([
+        'treasury_account_id' => $account->id,
+        'created_by' => $this->owner->id,
+        'movable_type' => TreasuryAccount::class,
+        'movable_id' => $account->id,
+        'reason' => TreasuryMovementReason::PaymentReceived,
+        'amount' => 437900000, // 4,379,000.00
+        'balance_after' => 437900000,
+        'occurred_at' => now(),
+    ]);
+
+    $this->actingAs($this->owner)
+        ->get(route('treasury.show', ['tenant' => $this->tenant->slug, 'treasury' => $account]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('account.current_balance', 4379000)
+        );
+});
+
 // ─────────────────────────────────────────────
 // RecordTreasuryMovementAction
 // ─────────────────────────────────────────────
@@ -305,6 +329,10 @@ test('closing a POS session with variance records an adjustment', function () {
     $adjustment = TreasuryMovement::where('reason', TreasuryMovementReason::ManualAdjustment)->first();
     expect($adjustment)->not->toBeNull();
     expect($adjustment->amount)->toBe(-500);
+
+    // Note reports formatted major amounts (100.00 / 95.00), not raw minor units.
+    expect($adjustment->notes)->toContain('100.00')
+        ->and($adjustment->notes)->toContain('95.00');
 });
 
 test('closing a POS session with matching float records no adjustment', function () {


### PR DESCRIPTION
Follow-up to #86. Fixes a treasury balance display bug spotted on the account page, plus two money-unit/formatting inconsistencies in the POS flow.

## What was wrong
Screenshot showed a cash account whose **current balance read 0** while its ledger clearly summed to millions.

### 1. Treasury show page: hero balance ignored all movements
`formatAccount()` computed the balance from `movements_sum_amount`, which is only eager-loaded via `->withSum()` in `index()` — **not** in `show()`. So on the account page the balance silently collapsed to `opening_balance` (0). Now uses `TreasuryAccount::currentBalance()`, which falls back to a live `SUM` when the attribute isn't preloaded.

### 2. POS session breakdown: amounts were 100× too small
The breakdown methods added in #86 aliased their `SUM()` as `total`/`amount` — names that collide with `MoneyCast` attributes on the hydrated model, so Eloquent read the sum back in **major** units. The controller then divided by 100 **again**, showing 1/100 of the real figure. Fixed by aliasing to `total_minor` so the raw minor integer passes through, matching `cashSalesTotal()`'s convention (controller still divides once).

### 3. POS reconciliation note: raw minor units + English
The close-session adjustment note printed `Expected: 732900000, Counted: 437900000` in English. Now formatted as major amounts (`7,329,000.00`) and localized (Arabic added).

## Verification of money consistency
Confirmed against real data that the POS backend is otherwise consistent with the rest of the system — a 150.00 sale is stored as `15000` minor across invoice, payment, and treasury movement, and reads back as 150.00 via `MoneyCast` (same convention as non-POS sales). No inflation bug exists; the earlier note in #86 was a misdiagnosis.

## Tests
- Treasury show-page hero balance reflects movements.
- Session breakdown: minor units in the model, major units on the page (end-to-end, guards the double-`/100`).
- Reconciliation note reports formatted major amounts.
- Full treasury + POS + expense suites green.
