### PR TITLE
fix(sync): backfill offline permissions onto existing system roles

### DIFF
--- a/database/migrations/2026_07_22_120000_seed_offline_permissions_and_grant_to_system_roles.php
+++ b/database/migrations/2026_07_22_120000_seed_offline_permissions_and_grant_to_system_roles.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Permission;
+use App\Models\Role;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * The offline stack introduced reconciliation.* and devices.* permissions.
+     * PermissionSeeder only runs on fresh installs (via the 2026_04_25 role
+     * backfill), so existing deployments never receive them and the tenant
+     * Devices/Reconciliation navigation stays hidden for everyone. Seed the
+     * catalog up to date and grant the new slugs to the system roles that
+     * DefaultRolesService gives them to (owner and manager). Custom roles are
+     * untouched — tenants grant those through the roles UI.
+     */
+    private const NEW_SLUGS = [
+        'reconciliation.view',
+        'reconciliation.resolve',
+        'devices.view',
+        'devices.manage',
+    ];
+
+    public function up(): void
+    {
+        (new PermissionSeeder)->run();
+
+        $permissionIds = Permission::whereIn('slug', self::NEW_SLUGS)->pluck('id')->all();
+
+        Role::withoutGlobalScopes()
+            ->whereIn('slug', ['owner', 'manager'])
+            ->where('is_system', true)
+            ->each(fn (Role $role) => $role->permissions()->syncWithoutDetaching($permissionIds));
+    }
+
+    public function down(): void {}
+};

--- a/tests/Feature/Sync/OfflinePermissionsBackfillTest.php
+++ b/tests/Feature/Sync/OfflinePermissionsBackfillTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Models\Permission;
+use App\Models\Role;
+
+/**
+ * The 2026_07_22_120000 migration retrofits the offline permissions onto
+ * deployments whose roles were seeded before the offline stack existed. The
+ * suite's fresh database already has them, so each test first strips the new
+ * slugs to reproduce the pre-migration production state.
+ */
+$offlineSlugs = ['reconciliation.view', 'reconciliation.resolve', 'devices.view', 'devices.manage'];
+
+function runOfflinePermissionsBackfill(): void
+{
+    $migration = require database_path('migrations/2026_07_22_120000_seed_offline_permissions_and_grant_to_system_roles.php');
+    $migration->up();
+}
+
+function stripOfflinePermissions(array $slugs): void
+{
+    $ids = Permission::whereIn('slug', $slugs)->pluck('id');
+
+    Role::withoutGlobalScopes()->each(fn (Role $role) => $role->permissions()->detach($ids));
+    Permission::whereIn('slug', $slugs)->delete();
+}
+
+it('seeds the offline permissions and grants them to owner and manager system roles', function () use ($offlineSlugs) {
+    seedTenantRoles(app('currentTenant'));
+    stripOfflinePermissions($offlineSlugs);
+
+    expect(Permission::whereIn('slug', $offlineSlugs)->count())->toBe(0);
+
+    runOfflinePermissionsBackfill();
+
+    expect(Permission::whereIn('slug', $offlineSlugs)->count())->toBe(4);
+
+    foreach (['owner', 'manager'] as $slug) {
+        $role = Role::withoutGlobalScopes()->where('slug', $slug)->where('is_system', true)->first();
+        expect($role->permissions->pluck('slug')->intersect($offlineSlugs)->count())
+            ->toBe(4, "system role {$slug} should hold all offline permissions");
+    }
+});
+
+it('does not grant the offline permissions to cashier, staff or custom roles', function () use ($offlineSlugs) {
+    seedTenantRoles(app('currentTenant'));
+    $custom = Role::create(['tenant_id' => app('currentTenant')->id, 'name' => 'Auditor', 'slug' => 'auditor', 'is_system' => false]);
+    stripOfflinePermissions($offlineSlugs);
+
+    runOfflinePermissionsBackfill();
+
+    foreach (['cashier', 'staff'] as $slug) {
+        $role = Role::withoutGlobalScopes()->where('slug', $slug)->where('is_system', true)->first();
+        expect($role->permissions->pluck('slug')->intersect($offlineSlugs))->toBeEmpty();
+    }
+
+    expect($custom->fresh()->permissions->pluck('slug')->intersect($offlineSlugs))->toBeEmpty();
+});
+
+it('keeps existing role permissions intact and stays idempotent', function () use ($offlineSlugs) {
+    seedTenantRoles(app('currentTenant'));
+    stripOfflinePermissions($offlineSlugs);
+
+    $owner = Role::withoutGlobalScopes()->where('slug', 'owner')->where('is_system', true)->first();
+    $before = $owner->permissions->pluck('slug')->sort()->values();
+
+    runOfflinePermissionsBackfill();
+    runOfflinePermissionsBackfill();
+
+    $after = $owner->fresh()->permissions->pluck('slug')->sort()->values();
+
+    expect($after->intersect($before)->count())->toBe($before->count());
+    expect($after->duplicates())->toBeEmpty();
+});


### PR DESCRIPTION
## Summary

After #88 deployed, the tenant **Devices** and **Reconciliation** navigation stayed hidden on live (e.g. `wad-elnama.elnama.net/dashboard`) while the super-admin pages showed fine.

Root cause: the sidebar links are gated by `can('devices.view')` / `can('reconciliation.view')`, and the four new permissions (`reconciliation.view|resolve`, `devices.view|manage`) exist only in `PermissionSeeder` — which runs on fresh installs only. Deployed tenants' roles were seeded long before the offline stack, so nobody holds the new slugs (the frontend `can()` has no owner bypass). Fresh test databases do get them, which is why the whole suite passed while production didn't.

## Fix

A backfill migration (following the `resync_cashier_role_permissions` precedent):
1. Re-runs `PermissionSeeder` (idempotent `updateOrCreate`) to bring the permission catalog up to date.
2. Grants the four new slugs to the **owner** and **manager** system roles of every tenant — the same roles `DefaultRolesService` gives them to. Cashier, staff and custom roles are untouched; tenants can grant those through the roles UI.

## Test plan

3 new tests simulate the pre-migration production state (strip the slugs, run the migration): owner/manager receive all four, cashier/staff/custom roles receive none, and the migration is idempotent and preserves existing grants. Sync + reconciliation suites: 132 passed.