### PR TITLE
fix(devices): surface the pairing code after enroll/replace

### DIFF
--- a/app/Http/Controllers/Sync/DevicesController.php
+++ b/app/Http/Controllers/Sync/DevicesController.php
@@ -63,7 +63,9 @@ class DevicesController extends Controller
 
         $enrollment = $action->handle($storage, $request->string('name')->value());
 
-        return back()->with([
+        // Under the single `flash` session key: that is the only shape
+        // HandleInertiaRequests shares with the page (flash.pairing_code).
+        return back()->with('flash', [
             'pairing_code' => $enrollment['pairing_code'],
             'device' => $enrollment['device']->public_id,
             'message' => __('Device enrolled. Enter the pairing code on the device within :minutes minutes.', [
@@ -89,7 +91,7 @@ class DevicesController extends Controller
 
         $result = $action->handle($device, $request->string('name')->value() ?: null);
 
-        return back()->with([
+        return back()->with('flash', [
             'pairing_code' => $result['pairing_code'],
             'device' => $result['device']->public_id,
             'message' => __('Replacement enrolled on the same register. Enter the pairing code within :minutes minutes.', [

--- a/tests/Feature/Sync/DeviceEnrollmentTest.php
+++ b/tests/Feature/Sync/DeviceEnrollmentTest.php
@@ -6,8 +6,10 @@ use App\Enums\StorageType;
 use App\Enums\TreasuryAccountType;
 use App\Models\Device;
 use App\Models\Register;
+use App\Models\Role;
 use App\Models\Storage;
 use App\Models\TreasuryAccount;
+use App\Models\User;
 
 function salePoint(): Storage
 {
@@ -68,18 +70,33 @@ it('exposes enrollment over the web to users with devices.manage', function () {
     ]);
 
     $response->assertRedirect();
-    $response->assertSessionHas('pairing_code');
+    // The page reads flash.pairing_code — assert the shape the UI consumes,
+    // not just any session key.
+    $response->assertSessionHas('flash.pairing_code');
+    $response->assertSessionHas('flash.message');
 
     expect(Device::count())->toBe(1);
 });
 
+it('flashes a fresh pairing code when replacing a device', function () {
+    $this->signIn();
+    $storage = salePoint();
+    $enrollment = app(EnrollDeviceAction::class)->handle($storage, 'Front counter iPad');
+
+    $response = $this->post(route('devices.replace', $enrollment['device']));
+
+    $response->assertRedirect();
+    $response->assertSessionHas('flash.pairing_code');
+    $response->assertSessionHas('flash.message');
+});
+
 it('rejects enrollment for users without devices.manage', function () {
-    $user = \App\Models\User::factory()->create();
+    $user = User::factory()->create();
     $this->actingAs($user);
 
     // demote to cashier (no devices.manage)
     $tenant = app('currentTenant');
-    $cashier = \App\Models\Role::withoutGlobalScopes()
+    $cashier = Role::withoutGlobalScopes()
         ->where('tenant_id', $tenant->id)->where('slug', 'cashier')->first();
     $tenant->users()->updateExistingPivot($user->id, ['role' => 'cashier', 'role_id' => $cashier->id]);
 


### PR DESCRIPTION
## Summary

Adding (or replacing) a device on the tenant Devices page succeeded but showed **no pairing code and no feedback**.

Root cause: `DevicesController@store`/`@replace` flashed `pairing_code`/`message` as top-level session keys, while `HandleInertiaRequests` only shares the single `flash` session key (or the `success`/`error` fallback) — and `Devices/Index.vue` reads `flash.pairing_code`. The value never reached the page. The existing test asserted `assertSessionHas('pairing_code')` — the bare session key rather than the shape the UI consumes — which is why it passed while the UI showed nothing.

## Fix

- Flash the enrollment payload under the `flash` session key (the established pattern used by the export controllers), for both **enroll** and **replace**.
- Tighten the enrollment test to assert `flash.pairing_code` + `flash.message`, and add a missing route test for the replace flow.

## Test plan

Sync suite: 103 passed (includes the new replace-flow test).