### PR TITLE
fix(sync): isolate unexpected push-handler exceptions as retriable server_error

### DIFF
--- a/app/Enums/RejectionReason.php
+++ b/app/Enums/RejectionReason.php
@@ -15,10 +15,11 @@ enum RejectionReason: string
     case SessionClosed = 'session_closed';
     case UpgradeRequired = 'upgrade_required';
     case TenantMismatch = 'tenant_mismatch';
+    case ServerError = 'server_error';
 
     public function isRetriable(): bool
     {
-        return $this === self::UnknownReference;
+        return $this === self::UnknownReference || $this === self::ServerError;
     }
 
     /**
@@ -35,6 +36,7 @@ enum RejectionReason: string
             self::SessionClosed => __('The POS session is already closed.'),
             self::UpgradeRequired => __('This app version is no longer supported.'),
             self::TenantMismatch => __('The mutation actor does not belong to this organization.'),
+            self::ServerError => __('The server could not apply this change; it will be retried automatically.'),
         };
     }
 }

--- a/app/Exceptions/Sync/RejectedMutation.php
+++ b/app/Exceptions/Sync/RejectedMutation.php
@@ -39,4 +39,9 @@ class RejectedMutation extends RuntimeException
     {
         return new self(RejectionReason::ValidationFailed, $message);
     }
+
+    public static function serverError(?string $message = null): self
+    {
+        return new self(RejectionReason::ServerError, $message);
+    }
 }

--- a/app/Services/Sync/Push/PushProcessor.php
+++ b/app/Services/Sync/Push/PushProcessor.php
@@ -18,6 +18,7 @@ use Closure;
 use DomainException;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 /**
  * The push engine (Design 02 §5.2): applies an ordered mutation batch, each
@@ -77,6 +78,15 @@ class PushProcessor
             $this->parkIfTerminal($mutation, $device, $rejection);
 
             return $this->rejected($mutation, $rejection);
+        } catch (Throwable $e) {
+            // Anything unexpected (a QueryException on production data, a
+            // TypeError) is OUR fault, not the mutation's: report it, reject
+            // THIS mutation retriably, keep the envelope alive. Field-caught: a
+            // single 500 here froze a device's whole queue — no sale could sync
+            // until an unrelated bug was fixed.
+            report($e);
+
+            return $this->rejected($mutation, RejectedMutation::serverError());
         }
     }
 

--- a/tests/Feature/Sync/PushTest.php
+++ b/tests/Feature/Sync/PushTest.php
@@ -3,6 +3,7 @@
 use App\Models\Category;
 use App\Models\Customer;
 use App\Models\Expense;
+use App\Models\ParkedMutation;
 use App\Models\PosSession;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -189,4 +190,40 @@ it('requires the sync:push ability', function () {
         'protocol' => 1,
         'mutations' => [customerMutation($env, strtolower((string) Str::ulid()))],
     ], ['Authorization' => "Bearer {$limited}"])->assertForbidden();
+});
+
+it('isolates an unexpected handler exception as a retriable server_error instead of a 500', function () {
+    $env = pushEnvironment();
+
+    $session = PosSession::create([
+        'tenant_id' => app('currentTenant')->id,
+        'storage_id' => $env['storage']->id,
+        'opened_by' => $env['actor']->id,
+    ]);
+
+    // items: null makes SaleCreateHandler crash with a TypeError — standing in
+    // for any unexpected production fault inside one handler.
+    $broken = [
+        'idempotency_key' => (string) Str::uuid(),
+        'type' => 'sale.create',
+        'public_id' => strtolower((string) Str::ulid()),
+        'actor' => $env['actor']->public_id,
+        'occurred_at' => now()->toIso8601String(),
+        'payload' => ['session' => $session->public_id, 'items' => null, 'total' => 100],
+    ];
+
+    $fine = customerMutation($env, strtolower((string) Str::ulid()), ['name' => 'Isolated Neighbour']);
+
+    $response = pushAs($env, [$broken, $fine]);
+
+    $response->assertOk();
+    $response->assertJsonPath('results.0.outcome', 'rejected');
+    $response->assertJsonPath('results.0.reason', 'server_error');
+    $response->assertJsonPath('results.1.outcome', 'applied');
+
+    // Retriable: no idempotency row, so the device may re-push after the fix.
+    expect(DB::table('sync_idempotency')
+        ->where('idempotency_key', $broken['idempotency_key'])->exists())->toBeFalse();
+    // And never parked — the fault is the server's, not the mutation's.
+    expect(ParkedMutation::where('idempotency_key', $broken['idempotency_key'])->exists())->toBeFalse();
 });


### PR DESCRIPTION
## Summary

Field-caught on the pilot tablet: **POST /api/sync/v1/push returns HTTP 500** for the device's batch, so the device's entire outbox freezes — the audit sale (`INV-SA-26-R1-00001`) sat unpushed indefinitely with `push failed: HTTP 500`. One unexpected exception in one mutation handler kills sync for every mutation behind it.

## Fix

`PushProcessor::processOne` now catches `Throwable`:
- `report()` the real exception (so the actual production fault finally lands in the log — it is currently invisible),
- reject **that mutation** with the new **retriable** `server_error` reason,
- keep processing the rest of the envelope (each mutation is already its own transaction).

The device retries with backoff instead of parking — the fault is the server's, not the mutation's. Mirrored in `namain/sync-protocol`: new `ServerError` retriable reason + `tryFrom` parsing so an older client never crashes on a reason minted by a newer server.

## After deploy

The pilot tablet's stuck `sale.create` will be attempted again and either apply or surface the true underlying exception in `laravel.log` via `report()` — which is the next thing to fix.

## Test plan

New PushTest case: batch of [crashing sale.create, valid customer.create] → 200, first rejected `server_error` retriable (no idempotency row, never parked), second applied. Sync + reconciliation suites green.