### PR TITLE
fix(sync): normalize wire quantities before the integer column

### DIFF
--- a/app/Services/Sync/Push/Handlers/SaleCreateHandler.php
+++ b/app/Services/Sync/Push/Handlers/SaleCreateHandler.php
@@ -130,7 +130,11 @@ class SaleCreateHandler implements MutationHandler
         return [
             'product_id' => $productId,
             'unit_id' => $unitId,
-            'quantity' => $item['quantity'],
+            // The wire carries decimal-formatted strings ("2.0000"); the local
+            // column is integer. SQLite coerces silently but MySQL strict mode
+            // rejects the raw string — field-caught as the production 500 that
+            // froze the pilot device's queue. Normalize at the boundary.
+            'quantity' => (int) round((float) $item['quantity']),
             'price' => Money::fromMinor((int) $item['price'])->major(),
         ];
     }

--- a/tests/Feature/Sync/SaleReplayTest.php
+++ b/tests/Feature/Sync/SaleReplayTest.php
@@ -37,7 +37,10 @@ function deviceOn(Storage $storage, string $name): array
 
 function saleMutation(User $actor, string $serial, PosSession $session, Product $product, array $overrides = []): array
 {
-    $quantity = $overrides['quantity'] ?? 3;
+    // Device reality: quantities cross the wire as decimal-formatted STRINGS
+    // ("3.0000") — the replay must normalize them for the integer column
+    // (MySQL strict mode rejects the raw string; field-caught as a prod 500).
+    $quantity = $overrides['quantity'] ?? '3.0000';
     $priceMinor = 1000;
 
     $payload = array_merge([
@@ -47,7 +50,7 @@ function saleMutation(User $actor, string $serial, PosSession $session, Product 
         'customer_type' => 'customer',
         'payment_method' => $overrides['payment_method'] ?? 'cash',
         'serial_number' => $serial,
-        'total' => $quantity * $priceMinor,
+        'total' => (int) ((float) $quantity * $priceMinor),
         'discount' => 0,
         'items' => [
             [


### PR DESCRIPTION
## Summary

The likely root cause behind the pilot tablet's stuck `sale.create` (the fault #91 made visible): device line quantities cross the wire as decimal-formatted strings (`"2.0000"`), and `SaleCreateHandler::resolveItem` passed them raw into `transactions.quantity` — an **integer** column. SQLite (test driver) coerces silently, so the suite was green; MySQL strict mode (production) rejects the insert, which used to 500 the whole envelope and now surfaces as retriable `server_error` rejections.

## Fix

Cast at the replay boundary (`(int) round((float) $qty)`), and make `SaleReplayTest`'s payloads mirror the real wire format (string quantities) so the suite exercises what devices actually send.

## Verification

After deploy, the pilot tablet retries every 5 s — `INV-SA-26-R1-00001` should apply within seconds. If production logs still show a reported exception from the push path (visible since #91), that's a further fault to chase — paste it and I'll follow up.