### PR TITLE
fix(sync): absolute floor before backlog-based re-snapshot

### DIFF
--- a/app/Http/Controllers/Sync/PullController.php
+++ b/app/Http/Controllers/Sync/PullController.php
@@ -116,6 +116,8 @@ class PullController extends Controller
      * The number of change-log entries above the cursor versus the tenant's live
      * syncable row count (distinct non-tombstone (table, public_id) pairs).
      */
+    private const RESNAPSHOT_BACKLOG_FLOOR = 500;
+
     private function backlogExceedsLiveRows(Device $device, int $cursor): bool
     {
         $backlog = DB::table('change_log')
@@ -131,7 +133,12 @@ class PullController extends Controller
 
         $liveRows = DB::query()->fromSub($liveRowsSubquery, 'live')->count();
 
-        return $liveRows > 0 && $backlog > $liveRows;
+        // Absolute floor: on a YOUNG change log (offline enabled recently,
+        // few distinct rows) a handful of cloud writes made backlog > liveRows
+        // and bounced a same-day device into a full re-bootstrap — field-caught
+        // as the register dropping to the wizard mid-shift. A small backlog is
+        // always cheaper as an incremental pull, whatever the ratio says.
+        return $backlog > max(self::RESNAPSHOT_BACKLOG_FLOOR, $liveRows);
     }
 
     /**

--- a/tests/Feature/Sync/PullTest.php
+++ b/tests/Feature/Sync/PullTest.php
@@ -11,6 +11,7 @@ use App\Models\Storage;
 use App\Models\SyncSnapshot;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage as Disk;
+use Illuminate\Support\Str;
 
 /**
  * @return array{device: Device, token: string, storage: Storage}
@@ -204,4 +205,46 @@ it('runs behind the named sync rate limiter', function () {
     );
 
     expect($throttled)->toBeTrue();
+});
+
+it('serves a small backlog incrementally even when it exceeds live rows', function () {
+    $environment = pullEnvironment();
+    $device = $environment['device'];
+    $tenantId = $device->tenant_id;
+
+    // Young log: one live row, then a burst of updates — backlog > liveRows but
+    // far below the absolute floor. Field-caught: this bounced a same-day
+    // device into a full re-bootstrap mid-shift.
+    $product = Product::create(['name' => 'A', 'cost' => 1, 'price' => 2, 'currency' => 'SDG']);
+    $cursor = 1;
+    foreach (range(1, 10) as $i) {
+        $product->update(['price' => 2 + $i]);
+    }
+
+    $this->getJson("/api/sync/v1/pull?cursor={$cursor}", ['Authorization' => "Bearer {$environment['token']}"])
+        ->assertOk();
+});
+
+it('still re-snapshots past the absolute backlog floor', function () {
+    $environment = pullEnvironment();
+    $device = $environment['device'];
+    $tenantId = $device->tenant_id;
+
+    Product::create(['name' => 'A', 'cost' => 1, 'price' => 2, 'currency' => 'SDG']);
+
+    $base = (int) DB::table('change_log')->where('tenant_id', $tenantId)->max('seq');
+    $churned = strtolower((string) Str::ulid());
+    $rows = collect(range(1, 501))->map(fn ($i) => [
+        'tenant_id' => $tenantId,
+        'seq' => $base + $i,
+        'table_name' => 'products',
+        'public_id' => $churned, // one hot row churning — backlog grows, live rows don't
+        'operation' => 'update',
+        'changed_at' => now(),
+    ])->all();
+    DB::table('change_log')->insert($rows);
+
+    $this->getJson('/api/sync/v1/pull?cursor=1', ['Authorization' => "Bearer {$environment['token']}"])
+        ->assertStatus(409)
+        ->assertJsonPath('error', 'cursor_expired');
 });

--- a/tests/Feature/Sync/RobustnessTest.php
+++ b/tests/Feature/Sync/RobustnessTest.php
@@ -48,11 +48,13 @@ it('returns 409 cursor_expired when the backlog exceeds the live-row count', fun
     $tenantId = $env['device']->tenant_id;
     $publicId = strtolower((string) Str::ulid());
 
-    // One live row, but many superseded log entries → replaying the backlog is
-    // dearer than a fresh snapshot. Insert above the seqs enrollment already used.
+    // One live row, but a backlog past BOTH the live-row ratio and the absolute
+    // floor (500) → replaying the backlog is dearer than a fresh snapshot.
+    // Small backlogs stay incremental (see PullTest) — field-caught: the
+    // ratio alone bounced a same-day device into re-bootstrap mid-shift.
     $base = (int) DB::table('change_log')->where('tenant_id', $tenantId)->max('seq') + 1;
     logEntry($tenantId, $base, $publicId, 'create', now()->toDateTimeString());
-    foreach (range(1, 30) as $i) {
+    foreach (range(1, 501) as $i) {
         logEntry($tenantId, $base + $i, $publicId, 'update', now()->toDateTimeString());
     }
 


### PR DESCRIPTION
## Summary

Field-caught right after the numeric fix: completing a sale then tapping 'new sale' dropped the register onto the provisioning wizard with the sync spinner. The device had received **409 cursor_expired** and rewound to re-bootstrap — by design for genuinely stale cursors, but the trigger was the backlog heuristic (`backlog > liveRows`) misfiring on a **young change log**: offline was enabled the same day, so the tenant had ~20 distinct rows and a handful of cloud writes exceeded it.

## Fix

Require `backlog > max(500, liveRows)` — a small backlog is always cheaper as an incremental pull, whatever the ratio says. Tests: a 10-write burst over 1 live row now pulls incrementally (the field case); 500+ churn on one hot row still re-snapshots.

## Related device-side fix (already shipped to the tablet)

The interrupted re-bootstrap also exposed that locally-minted stock rows collide with cloud-minted ones on re-snapshot (`UNIQUE(storage_id, product_id)`) — fixed in namain-pos by extending natural-key adoption to `stocks`.