### PR TITLE
fix(sync): oversell settlements respect the inventory strategy

### DIFF
--- a/app/Actions/Pos/ReplayPosSaleAction.php
+++ b/app/Actions/Pos/ReplayPosSaleAction.php
@@ -12,6 +12,7 @@ use App\Models\Invoice;
 use App\Models\OversellReconciliation;
 use App\Models\PosSession;
 use App\Models\User;
+use App\Services\Inventory\InventoryStrategy;
 use App\ValueObjects\CheckoutContext;
 use App\ValueObjects\Money;
 use App\ValueObjects\SaleReplayResult;
@@ -74,6 +75,16 @@ class ReplayPosSaleAction
                 continue;
             }
 
+            $flags[] = ['product' => $lines->first()->product->public_id, 'oversold_qty' => $oversold];
+
+            // An overselling tenant ACCEPTS negative balances as a mode of
+            // operation — the device still gets the flag (its UI shows the
+            // oversold line) but no settlement is raised (field-reported:
+            // overselling tenants were asked to "settle" routine sales).
+            if (app(InventoryStrategy::class)->allowsOverselling()) {
+                continue;
+            }
+
             $oversellRow = OversellReconciliation::create([
                 'tenant_id' => $invoice->tenant_id,
                 'device_id' => $device->id,
@@ -94,7 +105,6 @@ class ReplayPosSaleAction
                 occurredAt: $oversellRow->occurred_at,
             );
 
-            $flags[] = ['product' => $lines->first()->product->public_id, 'oversold_qty' => $oversold];
         }
 
         return $flags;

--- a/tests/Feature/Sync/SaleReplayTest.php
+++ b/tests/Feature/Sync/SaleReplayTest.php
@@ -10,7 +10,9 @@ use App\Models\Device;
 use App\Models\Invoice;
 use App\Models\OversellReconciliation;
 use App\Models\PosSession;
+use App\Models\Preference;
 use App\Models\Product;
+use App\Models\ReconciliationItem;
 use App\Models\Register;
 use App\Models\Storage;
 use App\Models\User;
@@ -210,4 +212,24 @@ it('rejects a sale whose session has not synced as retriable', function () {
         ->assertJsonPath('results.0.reason', 'unknown_reference');
 
     expect(Invoice::count())->toBe(0);
+});
+
+it('flags an oversell without raising a settlement for an overselling tenant', function () {
+    Preference::create(['key' => 'inventory_strategy', 'value' => 'free_form']);
+    Preference::create(['key' => 'allow_overselling', 'value' => '1']);
+
+    $env = saleEnvironment(stock: 2);
+    $device = deviceOn($env['storage'], 'Register A');
+
+    // Sells 3 of an on-hand 2 — oversold by 1, accepted mode for this tenant.
+    $response = pushSale($device['token'], saleMutation($env['actor'], 'INV-SA-26-RA-1', $env['session'], $env['product']));
+
+    $response->assertOk()->assertJsonPath('results.0.outcome', 'applied');
+
+    // The device still learns about the short line…
+    expect($response->json('results.0.flags.oversell.0.oversold_qty'))->toBe(1);
+
+    // …but nothing lands in the settlement inbox.
+    expect(OversellReconciliation::count())->toBe(0);
+    expect(ReconciliationItem::count())->toBe(0);
 });


### PR DESCRIPTION
## Summary

Pilot-reported: the tenant allows overselling (free-form strategy + allow_overselling), yet every routine short sale replayed from the register raised an oversell settlement in the reconciliation inbox.

## Fix

`ReplayPosSaleAction::recordOversell` consults `InventoryStrategy::allowsOverselling()`: the push result still carries the oversell flag (device UX unchanged), but `OversellReconciliation` rows and inbox items are raised only for strict tenants — for overselling tenants a negative balance is an accepted mode, not an exception to settle.

## Test plan

New SaleReplayTest case: free-form + overselling tenant → applied, flag present, zero settlement rows/items. Strict-tenant oversell tests unchanged. Sync + reconciliation suites green (135 passed).