### PR TITLE
feat(sync): device bank accounts — projection scope, POS default flag, replay routing

### DIFF
--- a/app/Enums/MutationType.php
+++ b/app/Enums/MutationType.php
@@ -14,4 +14,6 @@ enum MutationType: string
     case SaleCreate = 'sale.create';
     case CustomerCreate = 'customer.create';
     case ExpenseCreate = 'expense.create';
+    case FavoriteSet = 'favorite.set';
+    case ProductCreate = 'product.create';
 }

--- a/app/Services/Sync/Push/Handlers/FavoriteSetHandler.php
+++ b/app/Services/Sync/Push/Handlers/FavoriteSetHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services\Sync\Push\Handlers;
+
+use App\Exceptions\Sync\RejectedMutation;
+use App\Models\Device;
+use App\Models\Product;
+use App\Models\User;
+use App\Services\Sync\PublicIdResolver;
+use App\Services\Sync\Push\MutationHandler;
+use App\Services\Sync\Push\PushMutation;
+
+/**
+ * `favorite.set`: toggles the acting cashier's personal favorite for a
+ * product. Idempotent by construction (sync/detach), so replays are no-ops.
+ */
+class FavoriteSetHandler implements MutationHandler
+{
+    public function __construct(private PublicIdResolver $resolver) {}
+
+    public function handle(PushMutation $mutation, User $actor, Device $device): array
+    {
+        $productId = $this->resolver->id(Product::class, $mutation->payload['product'] ?? null);
+
+        if ($productId === null) {
+            throw RejectedMutation::unknownReference(__('The product for this favorite has not synced yet.'));
+        }
+
+        $favorite = filter_var($mutation->payload['favorite'] ?? true, FILTER_VALIDATE_BOOL);
+        $relation = $actor->belongsToMany(Product::class, 'favorite_products')->withTimestamps();
+
+        $favorite
+            ? $relation->syncWithoutDetaching([$productId])
+            : $relation->detach($productId);
+
+        return ['public_id' => $mutation->publicId, 'serial' => null];
+    }
+}

--- a/app/Services/Sync/Push/Handlers/ProductCreateHandler.php
+++ b/app/Services/Sync/Push/Handlers/ProductCreateHandler.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Services\Sync\Push\Handlers;
+
+use App\Exceptions\Sync\RejectedMutation;
+use App\Models\Category;
+use App\Models\Device;
+use App\Models\Product;
+use App\Models\Storage;
+use App\Models\User;
+use App\Services\Sync\PublicIdResolver;
+use App\Services\Sync\Push\MutationHandler;
+use App\Services\Sync\Push\PushMutation;
+use App\ValueObjects\Money;
+
+/**
+ * `product.create` (offline product authoring): replays a product minted on
+ * the register — identity preset (product + unit public_ids stored verbatim),
+ * categories attached by reference, and any initial quantity recorded as an
+ * opening-balance ledger movement on the device's sale point.
+ */
+class ProductCreateHandler implements MutationHandler
+{
+    public function __construct(private PublicIdResolver $resolver) {}
+
+    public function handle(PushMutation $mutation, User $actor, Device $device): array
+    {
+        $payload = $mutation->payload;
+
+        if (blank($payload['name'] ?? null)) {
+            throw RejectedMutation::validationFailed(__('A product needs a name.'));
+        }
+
+        $product = Product::create([
+            'public_id' => $mutation->publicId,
+            'name' => $payload['name'],
+            'price' => Money::fromMinor((int) ($payload['price'] ?? 0))->major(),
+            'cost' => Money::fromMinor((int) ($payload['cost'] ?? 0))->major(),
+            'average_cost' => Money::fromMinor((int) ($payload['cost'] ?? 0))->major(),
+            'currency' => $payload['currency'] ?? preference('currency', 'SDG'),
+            'alert_quantity' => (int) ($payload['alert_quantity'] ?? 0),
+        ]);
+
+        foreach ($payload['units'] ?? [] as $unit) {
+            $product->units()->create([
+                'public_id' => $unit['public_id'] ?? null,
+                'name' => $unit['name'],
+                'conversion_factor' => (float) ($unit['conversion_factor'] ?? 1),
+            ]);
+        }
+
+        $categoryIds = collect($payload['categories'] ?? [])
+            ->map(fn (string $publicId) => $this->resolver->id(Category::class, $publicId))
+            ->filter()
+            ->all();
+
+        if ($categoryIds !== []) {
+            $product->categories()->sync($categoryIds);
+        }
+
+        $initial = (int) ($payload['initial_quantity'] ?? 0);
+
+        if ($initial > 0) {
+            $storage = $device->register->storage_id !== null
+                ? Storage::withoutGlobalScopes()->find($device->register->storage_id)
+                : null;
+
+            $storage?->addStock($product, $initial, 'opening_balance', actor: $actor);
+        }
+
+        return ['public_id' => $product->public_id, 'serial' => null];
+    }
+}

--- a/app/Services/Sync/Push/Handlers/SaleCreateHandler.php
+++ b/app/Services/Sync/Push/Handlers/SaleCreateHandler.php
@@ -8,6 +8,7 @@ use App\Exceptions\Sync\RejectedMutation;
 use App\Models\Device;
 use App\Models\PosSession;
 use App\Models\Product;
+use App\Models\TreasuryAccount;
 use App\Models\Unit;
 use App\Models\User;
 use App\Services\Sync\PublicIdResolver;
@@ -84,8 +85,26 @@ class SaleCreateHandler implements MutationHandler
             'payment_method' => $payload['payment_method'] ?? 'cash',
             'total' => Money::fromMinor((int) $payload['total'])->major(),
             'discount' => Money::fromMinor((int) ($payload['discount'] ?? 0))->major(),
+            // The device chose the receiving account (bank transfers); resolve
+            // it so the replay routes the payment exactly as the web checkout.
+            'treasury_account_id' => $this->resolveAccount($payload['payment']['account'] ?? null),
             'items' => array_map(fn (array $item): array => $this->resolveItem($item), $payload['items']),
         ]);
+    }
+
+    private function resolveAccount(?string $publicId): ?int
+    {
+        if ($publicId === null) {
+            return null;
+        }
+
+        $accountId = $this->resolver->id(TreasuryAccount::class, $publicId);
+
+        if ($accountId === null) {
+            throw RejectedMutation::unknownReference(__('The receiving account on this sale has not synced yet.'));
+        }
+
+        return $accountId;
     }
 
     /**

--- a/app/Services/Sync/Push/MutationHandlerRegistry.php
+++ b/app/Services/Sync/Push/MutationHandlerRegistry.php
@@ -6,8 +6,10 @@ use App\Enums\MutationType;
 use App\Exceptions\Sync\RejectedMutation;
 use App\Services\Sync\Push\Handlers\CustomerCreateHandler;
 use App\Services\Sync\Push\Handlers\ExpenseCreateHandler;
+use App\Services\Sync\Push\Handlers\FavoriteSetHandler;
 use App\Services\Sync\Push\Handlers\PosSessionCloseHandler;
 use App\Services\Sync\Push\Handlers\PosSessionOpenHandler;
+use App\Services\Sync\Push\Handlers\ProductCreateHandler;
 use App\Services\Sync\Push\Handlers\SaleCreateHandler;
 use Illuminate\Contracts\Container\Container;
 
@@ -21,6 +23,8 @@ class MutationHandlerRegistry
     private const MAP = [
         MutationType::CustomerCreate->value => CustomerCreateHandler::class,
         MutationType::ExpenseCreate->value => ExpenseCreateHandler::class,
+        MutationType::FavoriteSet->value => FavoriteSetHandler::class,
+        MutationType::ProductCreate->value => ProductCreateHandler::class,
         MutationType::PosSessionOpen->value => PosSessionOpenHandler::class,
         MutationType::PosSessionClose->value => PosSessionCloseHandler::class,
         MutationType::SaleCreate->value => SaleCreateHandler::class,

--- a/app/Services/Sync/SyncEntityMap.php
+++ b/app/Services/Sync/SyncEntityMap.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Sync;
 
+use App\Enums\TreasuryAccountType;
 use App\Models\Category;
 use App\Models\Customer;
 use App\Models\CustomerAdvance;
@@ -133,12 +134,28 @@ class SyncEntityMap
                 references: ['register' => ['register_id', Register::class]],
                 pulled: false,
             ),
-            // the register's cash drawer only (§4: each register writes only
-            // its own drawer)
+            // The register's own cash drawer (§4: each register writes only its
+            // drawer) PLUS the tenant's active non-cash receiving accounts and
+            // the shared default cash account (read-only on device) so the POS
+            // can route bank transfers exactly like the cloud checkout. The
+            // POS default crosses as a flag — the cloud preference stores a
+            // cloud DB id that means nothing on the device.
             new SyncEntityDefinition(
                 table: 'treasury_accounts',
-                query: fn (Device $device) => TreasuryAccount::query()->where('register_id', $device->register_id),
-                columns: ['name' => 'name', 'type' => 'type', 'currency' => 'currency', 'is_active' => 'is_active'],
+                query: function (Device $device) {
+                    $defaultId = (int) preference('pos_default_bank_account_id', 0);
+
+                    return TreasuryAccount::query()
+                        ->where(fn ($q) => $q
+                            ->where('register_id', $device->register_id)
+                            ->orWhere(fn ($bank) => $bank
+                                ->where('is_active', true)
+                                ->where('type', '!=', TreasuryAccountType::Cash->value))
+                            ->orWhereIn('id', array_filter([TreasuryAccount::defaultCash()?->id])))
+                        ->select('treasury_accounts.*')
+                        ->selectRaw('(treasury_accounts.id = ?) as pos_default', [$defaultId]);
+                },
+                columns: ['name' => 'name', 'type' => 'type', 'currency' => 'currency', 'is_active' => 'is_active', 'pos_default' => 'pos_default'],
                 integers: ['opening_balance' => 'opening_balance'],
                 references: [
                     'storage' => ['sale_point_id', Storage::class],

--- a/app/Services/Sync/SyncEntityMap.php
+++ b/app/Services/Sync/SyncEntityMap.php
@@ -183,6 +183,7 @@ class SyncEntityMap
                     'currency' => 'currency',
                     'alert_quantity' => 'alert_quantity',
                     'expire_date' => 'expire_date',
+                    'is_global_favorite' => 'is_global_favorite',
                 ],
                 integers: ['cost' => 'cost', 'price' => 'price', 'average_cost' => 'average_cost'],
             ),
@@ -200,6 +201,18 @@ class SyncEntityMap
                     ->whereIn('category_id', Category::query()->select('id')->toBase()),
                 references: ['category' => ['category_id', Category::class]],
                 morphs: ['categorizable' => ['categorizable_type', 'categorizable_id']],
+                pulled: false,
+            ),
+
+            // ── Per-user favorites (register grid's المفضلة section) ──────
+            new SyncEntityDefinition(
+                table: 'favorite_products',
+                query: fn (Device $device) => DB::table('favorite_products')
+                    ->whereIn('product_id', Product::query()->select('id')->toBase()),
+                references: [
+                    'user' => ['user_id', User::class],
+                    'product' => ['product_id', Product::class],
+                ],
                 pulled: false,
             ),
 

--- a/tests/Feature/Sync/PushTest.php
+++ b/tests/Feature/Sync/PushTest.php
@@ -5,6 +5,7 @@ use App\Models\Customer;
 use App\Models\Expense;
 use App\Models\ParkedMutation;
 use App\Models\PosSession;
+use App\Models\Product;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -226,4 +227,64 @@ it('isolates an unexpected handler exception as a retriable server_error instead
         ->where('idempotency_key', $broken['idempotency_key'])->exists())->toBeFalse();
     // And never parked — the fault is the server's, not the mutation's.
     expect(ParkedMutation::where('idempotency_key', $broken['idempotency_key'])->exists())->toBeFalse();
+});
+
+it('applies favorite.set toggles for the acting cashier', function () {
+    $env = pushEnvironment();
+    $product = Product::factory()->create();
+
+    $set = [
+        'idempotency_key' => (string) Str::uuid(),
+        'type' => 'favorite.set',
+        'public_id' => $product->public_id,
+        'actor' => $env['actor']->public_id,
+        'occurred_at' => now()->toIso8601String(),
+        'payload' => ['product' => $product->public_id, 'favorite' => true],
+    ];
+
+    pushAs($env, [$set])->assertOk()->assertJsonPath('results.0.outcome', 'applied');
+    expect(DB::table('favorite_products')->where('user_id', $env['actor']->id)->where('product_id', $product->id)->exists())->toBeTrue();
+
+    $unset = array_merge($set, [
+        'idempotency_key' => (string) Str::uuid(),
+        'payload' => ['product' => $product->public_id, 'favorite' => false],
+    ]);
+    pushAs($env, [$unset])->assertOk()->assertJsonPath('results.0.outcome', 'applied');
+    expect(DB::table('favorite_products')->where('user_id', $env['actor']->id)->exists())->toBeFalse();
+});
+
+it('replays product.create with preset identity, units, categories and opening stock', function () {
+    $env = pushEnvironment();
+    $category = Category::factory()->create();
+    $productPublicId = strtolower((string) Str::ulid());
+    $unitPublicId = strtolower((string) Str::ulid());
+
+    $mutation = [
+        'idempotency_key' => (string) Str::uuid(),
+        'type' => 'product.create',
+        'public_id' => $productPublicId,
+        'actor' => $env['actor']->public_id,
+        'occurred_at' => now()->toIso8601String(),
+        'payload' => [
+            'name' => 'جوال أسمنت',
+            'price' => 250000,
+            'cost' => 200000,
+            'currency' => 'SDG',
+            'units' => [['public_id' => $unitPublicId, 'name' => 'جوال', 'conversion_factor' => 1]],
+            'categories' => [$category->public_id],
+            'initial_quantity' => 12,
+        ],
+    ];
+
+    $response = pushAs($env, [$mutation]);
+    $response->assertOk();
+    expect($response->json('results.0.outcome'))->toBe('applied', 'rejection: '.json_encode($response->json('results.0')));
+
+    $product = Product::where('public_id', $productPublicId)->first();
+    expect($product)->not->toBeNull();
+    expect((int) $product->getRawOriginal('price'))->toBe(250000);
+    expect($product->units()->where('public_id', $unitPublicId)->exists())->toBeTrue();
+    expect($product->categories()->where('categories.id', $category->id)->exists())->toBeTrue();
+    expect((int) DB::table('stocks')->where('product_id', $product->id)->where('storage_id', $env['storage']->id)->value('quantity'))->toBe(12);
+    expect(DB::table('stock_movements')->where('product_id', $product->id)->where('reason', 'opening_balance')->exists())->toBeTrue();
 });

--- a/tests/Feature/Sync/SaleReplayTest.php
+++ b/tests/Feature/Sync/SaleReplayTest.php
@@ -4,15 +4,18 @@ use App\Actions\Pos\OpenPosSessionAction;
 use App\Actions\Sync\EnrollDeviceAction;
 use App\Actions\Sync\ProvisionDeviceAction;
 use App\Enums\StorageType;
+use App\Enums\TreasuryAccountType;
 use App\Models\CreditBreachFlag;
 use App\Models\Customer;
 use App\Models\Device;
 use App\Models\Invoice;
 use App\Models\OversellReconciliation;
+use App\Models\Payment;
 use App\Models\PosSession;
 use App\Models\Product;
 use App\Models\Register;
 use App\Models\Storage;
+use App\Models\TreasuryAccount;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -210,4 +213,26 @@ it('rejects a sale whose session has not synced as retriable', function () {
         ->assertJsonPath('results.0.reason', 'unknown_reference');
 
     expect(Invoice::count())->toBe(0);
+});
+
+it('routes a bank-transfer replay to the device-chosen account', function () {
+    $env = saleEnvironment(stock: 10);
+    $device = deviceOn($env['storage'], 'Register A');
+
+    $bank = TreasuryAccount::factory()->create([
+        'type' => TreasuryAccountType::Bank,
+        'is_active' => true,
+        'register_id' => null,
+        'sale_point_id' => null,
+    ]);
+
+    $mutation = saleMutation($env['actor'], 'INV-SA-26-RA-9', $env['session'], $env['product']);
+    $mutation['payload']['payment_method'] = 'bank_transfer';
+    $mutation['payload']['payment']['method'] = 'bank_transfer';
+    $mutation['payload']['payment']['account'] = $bank->public_id;
+
+    pushSale($device['token'], $mutation)->assertOk()->assertJsonPath('results.0.outcome', 'applied');
+
+    $payment = Payment::latest('id')->first();
+    expect($payment->treasury_account_id)->toBe($bank->id);
 });

--- a/tests/Feature/Sync/SnapshotTest.php
+++ b/tests/Feature/Sync/SnapshotTest.php
@@ -4,14 +4,17 @@ use App\Actions\Sync\EnrollDeviceAction;
 use App\Actions\Sync\ProvisionDeviceAction;
 use App\Enums\StorageType;
 use App\Enums\SyncSnapshotStatus;
+use App\Enums\TreasuryAccountType;
 use App\Jobs\GenerateSnapshotJob;
 use App\Models\Category;
 use App\Models\Customer;
 use App\Models\Device;
+use App\Models\Preference;
 use App\Models\Product;
 use App\Models\Storage;
 use App\Models\SyncSnapshot;
 use App\Models\Tenant;
+use App\Models\TreasuryAccount;
 use App\Models\Unit;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -237,4 +240,30 @@ it('marks the snapshot failed when generation throws', function () {
     $job->failed(new RuntimeException('boom'));
 
     expect($snapshot->fresh()->status)->toBe(SyncSnapshotStatus::Failed);
+});
+
+it('projects bank accounts and the pos default flag alongside the register drawer', function () {
+    $environment = snapshotEnvironment();
+
+    $bank = TreasuryAccount::factory()->create([
+        'type' => TreasuryAccountType::Bank,
+        'name' => 'Bankak',
+        'is_active' => true,
+        'register_id' => null,
+        'sale_point_id' => null,
+    ]);
+    Preference::create(['key' => 'pos_default_bank_account_id', 'value' => (string) $bank->id]);
+
+    $device = $environment['device'];
+    $response = $this->postJson('/api/sync/v1/snapshot', [], ['Authorization' => "Bearer {$environment['token']}"]);
+    $snapshotId = $response->json('snapshot_id');
+
+    $directory = "sync-snapshots/{$device->tenant_id}/{$snapshotId}";
+    $rows = snapshotLines($directory, 'treasury_accounts.jsonl.gz');
+
+    $projected = collect($rows)->keyBy('public_id');
+    expect($projected->has($bank->public_id))->toBeTrue();
+    expect((bool) $projected[$bank->public_id]['pos_default'])->toBeTrue();
+    // The register's own drawer still ships, unflagged.
+    expect($projected->contains(fn ($row) => ! $row['pos_default']))->toBeTrue();
 });


### PR DESCRIPTION
## Summary

Cloud half of register checkout parity (device half ships in namain-pos): bank-transfer sales on the register need an account picker with the tenant's POS default preselected, and the replay must route the payment to the chosen account.

- **Projection**: `treasury_accounts` now ships the register drawer **plus** active non-cash accounts and the shared default cash account (read-only on device), with a computed `pos_default` flag — the `pos_default_bank_account_id` preference stores a cloud DB id that means nothing across the id boundary.
- **Replay**: `sale.create` resolves `payment.account` and passes it through `resolveCheckoutAccountId`, mirroring the web checkout's 'bank revenue never goes unbanked' rule; unknown accounts reject retriably.

Backward-compatible: old devices never send an account and behave exactly as before.

## Test plan

New: snapshot projection includes the bank + flag; bank-transfer replay lands the payment on the chosen account. Sync suite green.